### PR TITLE
PinConfigure support for all IOCON register types

### DIFF
--- a/firmware/library/L1_Drivers/pin_configure.cpp
+++ b/firmware/library/L1_Drivers/pin_configure.cpp
@@ -1,5 +1,6 @@
 #include "L0_LowLevel/LPC40xx.h"
 #include "L1_Drivers/pin_configure.hpp"
 
+// Initialize PinConfigure::pin_map to LPC40xx memory mapped LPC_IOCON register
 PinConfigure::PinMap_t * PinConfigure::pin_map =
     reinterpret_cast<PinMap_t *>(LPC_IOCON);

--- a/firmware/library/L1_Drivers/pin_configure.hpp
+++ b/firmware/library/L1_Drivers/pin_configure.hpp
@@ -22,12 +22,18 @@ class PinConfigureInterface
         kPullUp,
         kRepeater
     };
-    virtual void SetPinFunction(uint8_t function)         = 0;
-    virtual void SetPinMode(PinMode mode)                 = 0;
-    virtual void EnableHysteresis(bool enable_hysteresis) = 0;
-    virtual void SetAsActiveLow(bool set_as_active_low)   = 0;
-    virtual void EnableFastMode(bool enable_fast_mode)    = 0;
-    virtual void SetAsOpenDrain(bool set_as_open_drain)   = 0;
+    virtual void SetPinFunction(uint8_t function)                        = 0;
+    virtual void SetPinMode(PinConfigureInterface::PinMode mode)         = 0;
+    virtual void EnableHysteresis(bool enable_hysteresis)                = 0;
+    virtual void SetAsActiveLow(bool set_as_active_low)                  = 0;
+    virtual void SetAsAnalogMode(bool set_as_analog)                     = 0;
+    virtual void EnableDigitalFilter(bool enable_digital_filter)         = 0;
+    virtual void EnableFastMode(bool enable_fast_mode)                   = 0;
+    virtual void EnableI2cHighSpeedMode(bool enable_i2c_high_speed_mode) = 0;
+    virtual void EnableI2cHighCurrentDrive(
+        bool enable_i2c_high_current_drive)             = 0;
+    virtual void SetAsOpenDrain(bool set_as_open_drain) = 0;
+    virtual void EnableDac(bool enable_dac)             = 0;
 };
 
 class PinConfigure : public PinConfigureInterface
@@ -36,12 +42,17 @@ class PinConfigure : public PinConfigureInterface
     // Source: "UM10562 LPC408x/407x User manual" table 83 page 132
     enum PinBitMap : uint8_t
     {
-        kFunction    = 0,
-        kMode        = 3,
-        kHysteresis  = 5,
-        kInputInvert = 6,
-        kSlew        = 9,
-        kOpenDrain   = 10
+        kFunction            = 0,
+        kMode                = 3,
+        kHysteresis          = 5,
+        kInputInvert         = 6,
+        kAnalogDigitalMode   = 7,
+        kDigitalFilter       = 8,
+        kI2cHighSpeed        = 8,
+        kSlew                = 9,
+        kI2cHighCurrentDrive = 9,
+        kOpenDrain           = 10,
+        kDacEnable           = 16
     };
     SJ2_PACKED(struct) PinMap_t
     {
@@ -59,11 +70,13 @@ class PinConfigure : public PinConfigureInterface
         static_assert(port <= 5, "Port must be between 0 and 5");
         static_assert(pin <= 31, "Pin must be between 0 and 31");
         static_assert(port == 5 && pin <= 4,
-            "For port 5, the pin number must be equal to or below 4");
+                      "For port 5, the pin number must be equal to or below 4");
         return PinConfigure(port, pin);
     }
     constexpr PinConfigure(const uint8_t _port, const uint8_t _pin)
-        : port(_port), pin(_pin) { }
+        : port(_port), pin(_pin)
+    {
+    }
     void SetPinFunction(uint8_t function) final override
     {
         pin_map->_register[port][pin] =
@@ -87,11 +100,40 @@ class PinConfigure : public PinConfigureInterface
             BitPlace(pin_map->_register[port][pin], PinBitMap::kInputInvert,
                      set_as_active_low, 1);
     }
+    // Set bit to 0 to enable analog mode
+    void SetAsAnalogMode(bool set_as_analog = true) final override
+    {
+        pin_map->_register[port][pin] =
+            BitPlace(pin_map->_register[port][pin],
+                     PinBitMap::kAnalogDigitalMode, !set_as_analog, 1);
+    }
+    // Enable by setting bit to 0 to enable digital filter.
+    void EnableDigitalFilter(bool enable_digital_filter = true) final override
+    {
+        pin_map->_register[port][pin] =
+            BitPlace(pin_map->_register[port][pin], PinBitMap::kDigitalFilter,
+                     !enable_digital_filter, 1);
+    }
     void EnableFastMode(bool enable_fast_mode = true) final override
     {
         pin_map->_register[port][pin] =
             BitPlace(pin_map->_register[port][pin], PinBitMap::kSlew,
                      enable_fast_mode, 1);
+    }
+    // Enable by setting bit to 0 for i2c high speed mode
+    void EnableI2cHighSpeedMode(
+        bool enable_i2c_high_speed_mode = true) final override
+    {
+        pin_map->_register[port][pin] =
+            BitPlace(pin_map->_register[port][pin], PinBitMap::kI2cHighSpeed,
+                     !enable_i2c_high_speed_mode, 1);
+    }
+    void EnableI2cHighCurrentDrive(
+        bool enable_i2c_high_current_drive = true) final override
+    {
+        pin_map->_register[port][pin] = BitPlace(
+            pin_map->_register[port][pin], PinBitMap::kI2cHighCurrentDrive,
+            enable_i2c_high_current_drive, 1);
     }
     void SetAsOpenDrain(bool set_as_open_drain = true) final override
     {
@@ -99,17 +141,31 @@ class PinConfigure : public PinConfigureInterface
             BitPlace(pin_map->_register[port][pin], PinBitMap::kOpenDrain,
                      set_as_open_drain, 1);
     }
+    void EnableDac(bool enable_dac = true) final override
+    {
+        pin_map->_register[port][pin] =
+            BitPlace(pin_map->_register[port][pin], PinBitMap::kDacEnable,
+                     enable_dac, 1);
+    }
     inline uint32_t BitPlace(uint32_t target, uint32_t position, uint32_t value,
-                      uint32_t value_width)
+                             uint32_t value_width)
     {
         // Generate mask with all 1s
         uint32_t mask = 0xFFFFFFFF >> (32 - value_width);
         target &= ~(mask << position);
-        target |= value << position;
+        target |= (value & mask) << position;
         return target;
     }
+    uint8_t getPort()
+    {
+        return port;
+    }
+    uint8_t setPin()
+    {
+        return pin;
+    }
 
-   private:
+   protected:
     const uint8_t port;
     const uint8_t pin;
 };

--- a/firmware/library/L1_Drivers/pin_configure_test.cpp
+++ b/firmware/library/L1_Drivers/pin_configure_test.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Testing PinConfigure", "[pin_configure]")
     PinConfigure test_subject00(0, 0);
     PinConfigure test_subject25(2, 5);
 
-    SECTION("Test Pin Function")
+    SECTION("Pin Function")
     {
         // Source: "UM10562 LPC408x/407x User manual" table 84 page 133
         constexpr uint8_t kP0_0_U3_TXD = 0b010;
@@ -30,12 +30,12 @@ TEST_CASE("Testing PinConfigure", "[pin_configure]")
         test_subject25.SetPinFunction(kP2_5_PWM1_6);
         // Check that mapped pin P0.0's first 3 bits are equal to the function
         // U3_TXD
-        CHECK((local_iocon.P0_0 & 0b111) == kP0_0_U3_TXD);
+        CHECK(kP0_0_U3_TXD == (local_iocon.P0_0 & 0b111));
         // Check that mapped pin P2.5's first 3 bits are equal to the function
         // PWM1_6
-        CHECK((local_iocon.P2_5 & 0b111) == kP2_5_PWM1_6);
+        CHECK(kP2_5_PWM1_6 == (local_iocon.P2_5 & 0b111));
     }
-    SECTION("Test Pin Mode")
+    SECTION("Pin Mode")
     {
         // Source: "UM10562 LPC408x/407x User manual" table 83 page 132
         constexpr uint8_t kModePosition = 3;
@@ -43,36 +43,36 @@ TEST_CASE("Testing PinConfigure", "[pin_configure]")
 
         test_subject00.SetPinMode(PinConfigureInterface::kInactive);
         test_subject25.SetPinMode(PinConfigureInterface::kInactive);
-        CHECK((local_iocon.P0_0 & kMask) == PinConfigureInterface::kInactive
-                                                << kModePosition);
-        CHECK((local_iocon.P2_5 & kMask) == PinConfigureInterface::kInactive
-                                                << kModePosition);
+        CHECK(PinConfigureInterface::kInactive << kModePosition ==
+              (local_iocon.P0_0 & kMask));
+        CHECK(PinConfigureInterface::kInactive << kModePosition ==
+              (local_iocon.P2_5 & kMask));
 
         test_subject00.SetPinMode(PinConfigureInterface::kPullDown);
         test_subject25.SetPinMode(PinConfigureInterface::kPullDown);
 
-        CHECK((local_iocon.P0_0 & kMask) == PinConfigureInterface::kPullDown
-                                                << kModePosition);
-        CHECK((local_iocon.P2_5 & kMask) == PinConfigureInterface::kPullDown
-                                                << kModePosition);
+        CHECK(PinConfigureInterface::kPullDown << kModePosition ==
+              (local_iocon.P0_0 & kMask));
+        CHECK(PinConfigureInterface::kPullDown << kModePosition ==
+              (local_iocon.P2_5 & kMask));
 
         test_subject00.SetPinMode(PinConfigureInterface::kPullUp);
         test_subject25.SetPinMode(PinConfigureInterface::kPullUp);
 
-        CHECK((local_iocon.P0_0 & kMask) == PinConfigureInterface::kPullUp
-                                                << kModePosition);
-        CHECK((local_iocon.P2_5 & kMask) == PinConfigureInterface::kPullUp
-                                                << kModePosition);
+        CHECK(PinConfigureInterface::kPullUp << kModePosition ==
+              (local_iocon.P0_0 & kMask));
+        CHECK(PinConfigureInterface::kPullUp << kModePosition ==
+              (local_iocon.P2_5 & kMask));
 
         test_subject00.SetPinMode(PinConfigureInterface::kRepeater);
         test_subject25.SetPinMode(PinConfigureInterface::kRepeater);
 
-        CHECK((local_iocon.P0_0 & kMask) == PinConfigureInterface::kRepeater
-                                                << kModePosition);
-        CHECK((local_iocon.P2_5 & kMask) == PinConfigureInterface::kRepeater
-                                                << kModePosition);
+        CHECK(PinConfigureInterface::kRepeater << kModePosition ==
+              (local_iocon.P0_0 & kMask));
+        CHECK(PinConfigureInterface::kRepeater << kModePosition ==
+              (local_iocon.P2_5 & kMask));
     }
-    SECTION("Test Hysteresis")
+    SECTION("Set and alear Hysteresis modes")
     {
         // Source: "UM10562 LPC408x/407x User manual" table 83 page 132
         constexpr uint8_t kHysteresisPosition = 5;
@@ -80,16 +80,16 @@ TEST_CASE("Testing PinConfigure", "[pin_configure]")
         test_subject00.EnableHysteresis(true);
         test_subject25.EnableHysteresis(false);
 
-        CHECK((local_iocon.P0_0 & kMask) == kMask);
-        CHECK((local_iocon.P2_5 & kMask) == 0);
+        CHECK(kMask == (local_iocon.P0_0 & kMask));
+        CHECK(0 == (local_iocon.P2_5 & kMask));
 
         test_subject00.EnableHysteresis(false);
         test_subject25.EnableHysteresis(true);
 
-        CHECK((local_iocon.P0_0 & kMask) == 0);
-        CHECK((local_iocon.P2_5 & kMask) == kMask);
+        CHECK(0 == (local_iocon.P0_0 & kMask));
+        CHECK(kMask == (local_iocon.P2_5 & kMask));
     }
-    SECTION("Test Set Active level")
+    SECTION("Set and clear Active level")
     {
         // Source: "UM10562 LPC408x/407x User manual" table 83 page 132
         constexpr uint8_t kInvertPosition = 6;
@@ -97,16 +97,52 @@ TEST_CASE("Testing PinConfigure", "[pin_configure]")
         test_subject00.SetAsActiveLow(true);
         test_subject25.SetAsActiveLow(false);
 
-        CHECK((local_iocon.P0_0 & kMask) == kMask);
-        CHECK((local_iocon.P2_5 & kMask) == 0);
+        CHECK(kMask == (local_iocon.P0_0 & kMask));
+        CHECK(0 == (local_iocon.P2_5 & kMask));
 
         test_subject00.SetAsActiveLow(false);
         test_subject25.SetAsActiveLow(true);
 
-        CHECK((local_iocon.P0_0 & kMask) == 0);
-        CHECK((local_iocon.P2_5 & kMask) == kMask);
+        CHECK(0 == (local_iocon.P0_0 & kMask));
+        CHECK(kMask == (local_iocon.P2_5 & kMask));
     }
-    SECTION("Test Fast Mode Set")
+    SECTION("Set and Clear Analog Mode")
+    {
+        // Source: "UM10562 LPC408x/407x User manual" table 83 page 132
+        constexpr uint8_t kAdMode = 7;
+        constexpr uint32_t kMask  = 0b1 << kAdMode;
+        test_subject00.SetAsAnalogMode(true);
+        test_subject25.SetAsAnalogMode(false);
+
+        // Digital filter is set with zero
+        CHECK(0 == (local_iocon.P0_0 & kMask));
+        CHECK(kMask == (local_iocon.P2_5 & kMask));
+
+        test_subject00.SetAsAnalogMode(false);
+        test_subject25.SetAsAnalogMode(true);
+
+        CHECK(kMask == (local_iocon.P0_0 & kMask));
+        CHECK(0 == (local_iocon.P2_5 & kMask));
+    }
+    SECTION("Enable and Disable Digital Filter")
+    {
+        // Source: "UM10562 LPC408x/407x User manual" table 83 page 132
+        constexpr uint8_t kDigitalFilter = 8;
+        constexpr uint32_t kMask         = 0b1 << kDigitalFilter;
+        test_subject00.EnableDigitalFilter(true);
+        test_subject25.EnableDigitalFilter(false);
+
+        // Digital filter is set with zero
+        CHECK(0 == (local_iocon.P0_0 & kMask));
+        CHECK(kMask == (local_iocon.P2_5 & kMask));
+
+        test_subject00.EnableDigitalFilter(false);
+        test_subject25.EnableDigitalFilter(true);
+
+        CHECK(kMask == (local_iocon.P0_0 & kMask));
+        CHECK(0 == (local_iocon.P2_5 & kMask));
+    }
+    SECTION("Fast Mode Set")
     {
         // Source: "UM10562 LPC408x/407x User manual" table 83 page 132
         constexpr uint8_t kSlewPosition = 9;
@@ -114,16 +150,50 @@ TEST_CASE("Testing PinConfigure", "[pin_configure]")
         test_subject00.EnableFastMode(true);
         test_subject25.EnableFastMode(false);
 
-        CHECK((local_iocon.P0_0 & kMask) == kMask);
-        CHECK((local_iocon.P2_5 & kMask) == 0);
+        CHECK(kMask == (local_iocon.P0_0 & kMask));
+        CHECK(0 == (local_iocon.P2_5 & kMask));
 
         test_subject00.EnableFastMode(false);
         test_subject25.EnableFastMode(true);
 
-        CHECK((local_iocon.P0_0 & kMask) == 0);
-        CHECK((local_iocon.P2_5 & kMask) == kMask);
+        CHECK(0 == (local_iocon.P0_0 & kMask));
+        CHECK(kMask == (local_iocon.P2_5 & kMask));
     }
-    SECTION("Test Open Drain")
+    SECTION("Enable and Disable I2c High Speed Mode")
+    {
+        // Source: "UM10562 LPC408x/407x User manual" table 89 page 141
+        constexpr uint8_t kI2cHighSpeedMode = 8;
+        constexpr uint32_t kMask            = 0b1 << kI2cHighSpeedMode;
+        test_subject00.EnableI2cHighSpeedMode(true);
+        test_subject25.EnableI2cHighSpeedMode(false);
+        // I2C Highspeed is set with zero
+        CHECK(0 == (local_iocon.P0_0 & kMask));
+        CHECK(kMask == (local_iocon.P2_5 & kMask));
+
+        test_subject00.EnableI2cHighSpeedMode(false);
+        test_subject25.EnableI2cHighSpeedMode(true);
+
+        CHECK(kMask == (local_iocon.P0_0 & kMask));
+        CHECK(0 == (local_iocon.P2_5 & kMask));
+    }
+    SECTION("Enable and disable high current drive")
+    {
+        // Source: "UM10562 LPC408x/407x User manual" table 89 page 141
+        constexpr uint8_t kHighCurrentDrive = 9;
+        constexpr uint32_t kMask            = 0b1 << kHighCurrentDrive;
+        test_subject00.EnableI2cHighCurrentDrive(true);
+        test_subject25.EnableI2cHighCurrentDrive(false);
+
+        CHECK(kMask == (local_iocon.P0_0 & kMask));
+        CHECK(0 == (local_iocon.P2_5 & kMask));
+
+        test_subject00.EnableI2cHighCurrentDrive(false);
+        test_subject25.EnableI2cHighCurrentDrive(true);
+
+        CHECK(0 == (local_iocon.P0_0 & kMask));
+        CHECK(kMask == (local_iocon.P2_5 & kMask));
+    }
+    SECTION("Open Drain")
     {
         // Source: "UM10562 LPC408x/407x User manual" table 83 page 132
         constexpr uint8_t kOpenDrainPosition = 10;
@@ -131,13 +201,30 @@ TEST_CASE("Testing PinConfigure", "[pin_configure]")
         test_subject00.SetAsOpenDrain(true);
         test_subject25.SetAsOpenDrain(false);
 
-        CHECK((local_iocon.P0_0 & kMask) == kMask);
-        CHECK((local_iocon.P2_5 & kMask) == 0);
+        CHECK(kMask == (local_iocon.P0_0 & kMask));
+        CHECK(0 == (local_iocon.P2_5 & kMask));
 
         test_subject00.SetAsOpenDrain(false);
         test_subject25.SetAsOpenDrain(true);
 
-        CHECK((local_iocon.P0_0 & kMask) == 0);
-        CHECK((local_iocon.P2_5 & kMask) == kMask);
+        CHECK(0 == (local_iocon.P0_0 & kMask));
+        CHECK(kMask == (local_iocon.P2_5 & kMask));
+    }
+    SECTION("Enable Dac")
+    {
+        // Source: "UM10562 LPC408x/407x User manual" table 85 page 138
+        constexpr uint8_t kDac   = 16;
+        constexpr uint32_t kMask = 0b1 << kDac;
+        test_subject00.EnableDac(true);
+        test_subject25.EnableDac(false);
+
+        CHECK(kMask == (local_iocon.P0_0 & kMask));
+        CHECK(0 == (local_iocon.P2_5 & kMask));
+
+        test_subject00.EnableDac(false);
+        test_subject25.EnableDac(true);
+
+        CHECK(0 == (local_iocon.P0_0 & kMask));
+        CHECK(kMask == (local_iocon.P2_5 & kMask));
     }
 }


### PR DESCRIPTION
The driver now supports type D, A, U, I, and W IOCON registers.