### PR TITLE
Adding newline character to DEBUG_PRINT

### DIFF
--- a/firmware/HelloWorld/source/main.cpp
+++ b/firmware/HelloWorld/source/main.cpp
@@ -15,17 +15,17 @@ int main(void)
     fputs(SJ2_BACKGROUND_GREEN
          "================================== SJTwo Booted! "
          "==================================\n" SJ2_COLOR_RESET, stdout);
-    DEBUG_PRINT("Initializing LEDs...\n");
+    DEBUG_PRINT("Initializing LEDs...");
     LPC_IOCON->P1_1 &= ~(0b111);
     LPC_IOCON->P1_8 &= ~(0b111);
     LPC_GPIO1->DIR |= (1 << 1);
     LPC_GPIO1->PIN &= ~(1 << 1);
     LPC_GPIO1->DIR |= (1 << 8);
     LPC_GPIO1->PIN |= (1 << 8);
-    DEBUG_PRINT("LEDs Initialized...\n");
+    DEBUG_PRINT("LEDs Initialized...");
     fputs("Enter wait cycles for led animation: ", stdout);
     scanf("%lu", &cycles);
-    DEBUG_PRINT("Toggling LEDs...\n");
+    DEBUG_PRINT("Toggling LEDs...");
 
     while (1)
     {

--- a/firmware/examples/PinConfigure/source/main.cpp
+++ b/firmware/examples/PinConfigure/source/main.cpp
@@ -7,48 +7,40 @@
 #include "L1_Drivers/pin_configure.hpp"
 #include "config.hpp"
 
-// template <unsigned port, unsigned pin>
-// constexpr PinConfigure CreatePinConfigure()
-// {
-//     static_assert(port <= 5, "Port must be between 0 and 5");
-//     static_assert(pin <= 31, "Pin must be between 0 and 31");
-//     return PinConfigure(port, pin);
-// }
-
 int main(void)
 {
     // This application assumes that all pins are set to function 0 (GPIO)
-    DEBUG_PRINT("Pin Configure Application Starting...\n");
+    DEBUG_PRINT("Pin Configure Application Starting...");
     // Using constructor directly to constuct PinConfigure object
     // This is discouraged, since this constructor does not perform any compile
     // time checks on the port or pin value
     PinConfigure p0_0(0, 7);
     p0_0.SetPinMode(PinConfigureInterface::PinMode::kInactive);
-    DEBUG_PRINT("Disabling both pull up and down resistors for P0.0...\n");
+    DEBUG_PRINT("Disabling both pull up and down resistors for P0.0...");
     // Prefered option of constructing PinConfigure, since this factory call is
     // done in compile time and will perform compile time validation on the port
     // and pin template parameters.
     PinConfigure p1_24 = PinConfigure::CreatePinConfigure<1, 24>();
     p1_24.SetPinMode(PinConfigureInterface::PinMode::kPullDown);
-    DEBUG_PRINT("Enabling P1.24 pull down resistor...\n");
+    DEBUG_PRINT("Enabling P1.24 pull down resistor...");
 
     PinConfigure p2_0 = PinConfigure::CreatePinConfigure<2, 0>();
     p2_0.SetPinMode(PinConfigureInterface::PinMode::kPullUp);
-    DEBUG_PRINT("Enabling P2.0 pull up resistor...\n");
+    DEBUG_PRINT("Enabling P2.0 pull up resistor...");
 
     PinConfigure p4_28 = PinConfigure::CreatePinConfigure<4, 29>();
     p4_28.SetPinMode(PinConfigureInterface::PinMode::kRepeater);
-    DEBUG_PRINT("Setting P4.29 to repeater mode...\n");
+    DEBUG_PRINT("Setting P4.29 to repeater mode...");
 
     DEBUG_PRINT(
         "Use some jumpers and a multimeter to test each pin to see if the "
-        "internal pull up and pull down resistors are working.\n");
+        "internal pull up and pull down resistors are working.");
     DEBUG_PRINT(
         "Use a jumper and resistor to pull P4.28 high or low. If you check the "
         "pin with a multimeter you will see that the pin retains the previous "
-        "input value.\n");
+        "input value.");
 
-    DEBUG_PRINT("Halting any action.\n");
+    DEBUG_PRINT("Halting any action.");
     while (1) { continue; }
     return 0;
 }

--- a/firmware/examples/SystemTimer/source/low_level_init.cpp
+++ b/firmware/examples/SystemTimer/source/low_level_init.cpp
@@ -34,10 +34,10 @@ void LowLevelInit()
     bool timer_started_successfully = system_timer.StartTimer();
     if (timer_started_successfully)
     {
-        DEBUG_PRINT("Demo System Timer has begun.\n");
+        DEBUG_PRINT("Demo System Timer has begun.");
     }
     else
     {
-        DEBUG_PRINT("Demo System Timer has FAILED!!\n");
+        DEBUG_PRINT("Demo System Timer has FAILED!!");
     }
 }

--- a/firmware/examples/SystemTimer/source/main.cpp
+++ b/firmware/examples/SystemTimer/source/main.cpp
@@ -2,18 +2,18 @@
 
 int main(void)
 {
-    DEBUG_PRINT("System Timer Application Starting...\n");
+    DEBUG_PRINT("System Timer Application Starting...");
 
     DEBUG_PRINT(
         "If you look at the source code of this demo, you can see that the "
         "main only prints these messages and then waits in a while loop. Main "
-        "isn't doing anything and yet the 3rd LED is blinking?\n");
+        "isn't doing anything and yet the 3rd LED is blinking?");
     DEBUG_PRINT(
         "If you checkout the low_level_init.cpp file you will see that the "
         "LowLevelInit() function has been overriden and SystemTimer has been "
-        "programmed to toggle the LED at a frequency of 10Hz.\n");
+        "programmed to toggle the LED at a frequency of 10Hz.");
 
-    DEBUG_PRINT("Halting any action.\n");
+    DEBUG_PRINT("Halting any action.");
     while (1) { continue; }
     return 0;
 }

--- a/firmware/library/L2_Utilities/debug_print.hpp
+++ b/firmware/library/L2_Utilities/debug_print.hpp
@@ -3,7 +3,7 @@
 #include <cstdio>
 #include "L2_Utilities/ansi_terminal_codes.hpp"
 // Printf style logging with filename, function name, and line number
-#define DEBUG_PRINT(format, ...)                                \
-    printf(SJ2_HI_BLUE "%s:" SJ2_HI_GREEN "%s:" SJ2_HI_YELLOW   \
-                       "%d> " SJ2_WHITE format SJ2_COLOR_RESET, \
+#define DEBUG_PRINT(format, ...)                                     \
+    printf(SJ2_HI_BLUE "%s:" SJ2_HI_GREEN "%s:" SJ2_HI_YELLOW        \
+                       "%d> " SJ2_WHITE format SJ2_COLOR_RESET "\n", \
            __FILE__, __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);


### PR DESCRIPTION
In order to make the DEBUG_PRINT look cleaner, a newline character is
added to each DEBUG_PRINT.

Removed extra newline characters from DEBUG_PRINT messages.

Cleaning up some commented out code in PinConfigure.