### PR TITLE
Fix install of clang and running of lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ tools/gcc-arm-none-eabi-*
 **/env.sh
 archive/
 .idea/
+**/*/.vscode
+.vscode

--- a/makefile
+++ b/makefile
@@ -38,7 +38,7 @@ endif
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-CLANG_TIDY   = clang-tidy
+CLANG_TIDY   = clang-tidy-6.0
 endif
 ifeq ($(UNAME_S),Darwin)
 CLANG_TIDY   = /usr/local/opt/llvm/bin/clang-tidy
@@ -416,7 +416,7 @@ $(TEST_EXEC): $(TEST_FRAMEWORK) $(OBJECT_FILES)
 	@echo ' '
 
 lint:
-	@python $(TOOLS)/cpplint/cpplint.py $(LINT_FILES)
+	@python2 $(TOOLS)/cpplint/cpplint.py $(LINT_FILES)
 
 tidy:
 	@$(CLANG_TIDY) -extra-arg=-std=c++17 $(LINT_FILES) -- -std=c++17 $(INCLUDES)

--- a/setup
+++ b/setup
@@ -70,8 +70,25 @@ case "$OS" in
         echo " ───────────────────────────────────────────────────┐"
         echo "                Updating Apt listings                "
         echo "└─────────────────────────────────────────────────── "
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo apt-add-repository -y "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
+        sudo apt-add-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main"
+        sudo apt-add-repository -y "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main"
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        sudo apt update -qq
+        sudo apt update
+        echo " ───────────────────────────────────────────────────┐"
+        echo "               Installing Clang 6.0                  "
+        echo "└─────────────────────────────────────────────────── "
+        apt search clang
+        sudo apt install clang-6.0 lldb-6.0 lld-6.0
+        echo " ───────────────────────────────────────────────────┐"
+        echo "            Installing Clang Format 6.0              "
+        echo "└─────────────────────────────────────────────────── "
+        sudo apt -y install clang-format-6.0
+        echo " ───────────────────────────────────────────────────┐"
+        echo "              Installing Clang Tidy 6.0              "
+        echo "└─────────────────────────────────────────────────── "
+        sudo apt -y install clang-tidy-6.0
         echo " ───────────────────────────────────────────────────┐"
         echo "                Installing OpenOCD                   "
         echo "└─────────────────────────────────────────────────── "
@@ -93,18 +110,6 @@ case "$OS" in
         echo "         Installing Testing Tools (Valgrind)         "
         echo "└─────────────────────────────────────────────────── "
         sudo apt -y install valgrind
-        echo " ───────────────────────────────────────────────────┐"
-        echo "                 Installing Clang                    "
-        echo "└─────────────────────────────────────────────────── "
-        sudo apt -y install clang
-        echo " ───────────────────────────────────────────────────┐"
-        echo "              Installing Clang Format                "
-        echo "└─────────────────────────────────────────────────── "
-        sudo apt -y install clang-format
-        echo " ───────────────────────────────────────────────────┐"
-        echo "               Installing Clang Tidy                 "
-        echo "└─────────────────────────────────────────────────── "
-        sudo apt -y install clang-tidy
         echo " ───────────────────────────────────────────────────┐"
         echo "                Installing OpenOCD                   "
         echo "└─────────────────────────────────────────────────── "


### PR DESCRIPTION
Setup will not install clang-6.0, clang-format-6.0, and clang-tidy-6.0.

Makefile will now use 6.0 version of clang tools.
Makefile will now use python2 explicitly.