### PR TITLE
Adding backtrace support

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,5 +1,5 @@
 set noparent
-filter=-whitespace/braces,-legal/copyright,+readability/check,-readability/nolint,-whitespace/newline,+build/include_what_you_use
+filter=-whitespace/braces,-legal/copyright,+readability/check,-readability/nolint,-whitespace/newline,+build/include_what_you_use,-readability/braces
 linelength=80
 root=firmware
 

--- a/firmware/examples/Backtrace/source/main.cpp
+++ b/firmware/examples/Backtrace/source/main.cpp
@@ -1,0 +1,46 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+#include "config.hpp"
+#include "L2_Utilities/macros.hpp"
+
+int Baz(void)
+{
+    DEBUG_PRINT(
+        "Calling backtrace application directly within Baz() function...");
+    SJ2_DUMP_BACKTRACE();
+    return 2;
+}
+
+int Bar(void)
+{
+    return Baz();
+}
+
+int Foo(void)
+{
+    return Bar();
+}
+
+int main(void)
+{
+    // This application assumes that all pins are set to function 0 (GPIO)
+    DEBUG_PRINT("Backtrace Application Starting...");
+    Foo();
+    SJ2_ASSERT_WARNING(2 < 5,
+                       "This assert warning message shouldn't show up "
+                       "since the condition evaluates to true. If it wasn't "
+                       "true, then this message would be printed to STDOUT. ");
+    SJ2_ASSERT_WARNING(1 == 0,
+                       "This assert warning message SHOULD show up, since the "
+                       "condition is, does 1 == 0, which is false. Since this "
+                       "is just a warning, the program will be stoped.");
+    SJ2_ASSERT_FATAL(
+        false,
+        "SJ2_ASSERT_FATAL will cause the system to abort operations. This "
+        "should be used in cases where a users action or an improper setup "
+        "could lead to hardware damage or sever maloperation.");
+    return 0;
+}

--- a/firmware/library/L2_Utilities/backtrace.cpp
+++ b/firmware/library/L2_Utilities/backtrace.cpp
@@ -1,0 +1,21 @@
+#include <unwind.h>
+#include <cstdio>
+
+// This log function can be swapped out during runtime, but was mostly meant for
+// unit testing.
+int (*log_function)(const char *, ...) = printf;
+
+_Unwind_Reason_Code Trace(_Unwind_Context *context, void *depth)
+{
+    int *depth_value = reinterpret_cast<int*>(depth);
+    log_function("    #%d: program counter at %p\n", *depth_value,
+      reinterpret_cast<void *>(_Unwind_GetIP(context)-4));
+    (*depth_value)++;
+    return _URC_NO_REASON;
+}
+
+void PrintTrace()
+{
+  int depth = 0;
+  _Unwind_Backtrace(&Trace, &depth);
+}

--- a/firmware/library/L2_Utilities/backtrace.hpp
+++ b/firmware/library/L2_Utilities/backtrace.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <unwind.h>
+
+extern int (*log_function)(const char *, ...);
+
+_Unwind_Reason_Code Trace(_Unwind_Context *context, void *depth);
+void PrintTrace();

--- a/firmware/library/L2_Utilities/backtrace_test.cpp
+++ b/firmware/library/L2_Utilities/backtrace_test.cpp
@@ -1,0 +1,17 @@
+#include <unwind.h>
+#include <cstdio>
+#include "L2_Utilities/backtrace.hpp"
+#include "L5_Testing/testing_frameworks.hpp"
+
+FAKE_VALUE_FUNC_VARARG(int, test_logger, const char*, ...);
+
+TEST_CASE("Testing Backtrace", "[backtrace]")
+{
+    log_function = test_logger;
+
+    SECTION("Test that test_logger was called")
+    {
+        PrintTrace();
+        CHECK(0 < test_logger_fake.call_count);
+    }
+}

--- a/firmware/library/L2_Utilities/macros.hpp
+++ b/firmware/library/L2_Utilities/macros.hpp
@@ -1,6 +1,10 @@
 // This file is meant for general purpose macros that can be used across the
 // SJSU-Dev2 environment.
 #pragma once
+#include "config.hpp"
+#include "L2_Utilities/ansi_terminal_codes.hpp"
+#include "L2_Utilities/backtrace.hpp"
+#include "L2_Utilities/debug_print.hpp"
 // SJ2_SECTION will place a variable or function within a given section of the
 // executable. It uses both attribute "section" and "used". Section attribute
 // places variable/function into that section and "used" labels the symbol as
@@ -27,3 +31,46 @@
 // Similar to the weak attribute, but also gives each function the
 // implementation of the function f.
 #define SJ2_ALIAS(f) __attribute__((weak, alias(#f)))  // NOLINT
+
+#if defined SJ2_INCLUDE_BACKTRACE && SJ2_INCLUDE_BACKTRACE == true
+#define SJ2_DUMP_BACKTRACE() PrintTrace()
+#else
+#define SJ2_DUMP_BACKTRACE() \
+    do                       \
+    {                        \
+    } while (0)
+#endif  // defined SJ2_INCLUDE_BACKTRACE && SJ2_INCLUDE_BACKTRACE == true
+
+#define SJ2_ASSERT_WARNING(condition, warning_message)                \
+    do                                                                \
+    {                                                                 \
+        if (!(condition))                                             \
+        {                                                             \
+            DEBUG_PRINT("\n" SJ2_BACKGROUND_RED                       \
+                        "WARNING: " warning_message SJ2_COLOR_RESET); \
+        }                                                             \
+    } while (0)
+
+#define SJ2_ASSERT_FATAL(condition, fatal_message)                            \
+    do                                                                        \
+    {                                                                         \
+        if (!(condition))                                                     \
+        {                                                                     \
+            DEBUG_PRINT("\n" SJ2_BACKGROUND_RED                               \
+                        "WARNING: " fatal_message SJ2_COLOR_RESET);           \
+            printf("\nPrinting Stack Trace:\n");                              \
+            SJ2_DUMP_BACKTRACE();                                             \
+            printf(                                                           \
+                "\nRun: the following command in your project directory\n   " \
+                " " SJ2_BOLD_WHITE                                            \
+                "arm-none-eabi-addr2line -e build/binaries/firmware.elf "     \
+                "<insert pc>" SJ2_COLOR_RESET                                 \
+                "\n"                                                          \
+                "This will report the file and line number associated "       \
+                "with that program counter values above.");                   \
+            while (true)                                                      \
+            {                                                                 \
+                continue;                                                     \
+            }                                                                 \
+        }                                                                     \
+    } while (0)

--- a/firmware/library/config.hpp
+++ b/firmware/library/config.hpp
@@ -38,13 +38,13 @@ namespace config
 // ansi_terminal_codes.hpp
 #if !defined SJ2_ENABLE_ANSI_CODES
 #define SJ2_ENABLE_ANSI_CODES true
-#endif  // defined SJ2_ENABLE_ANSI_CODES
+#endif  // !defined SJ2_ENABLE_ANSI_CODES
 SJ2_DECLARE_CONSTANT(ENABLE_ANSI_CODES, bool, kEnableAnsiCodes);
 
 // Used to set the system clock speed for the LPC4078
 #if !defined SJ2_SYSTEM_CLOCK_RATE
 #define SJ2_SYSTEM_CLOCK_RATE 12'000'000
-#endif  // defined SJ2_SYSTEM_CLOCK_RATE
+#endif  // !defined SJ2_SYSTEM_CLOCK_RATE
 SJ2_DECLARE_CONSTANT(SYSTEM_CLOCK_RATE, uint32_t, kSystemClockRate);
 static_assert(1 <= kSystemClockRate && kSystemClockRate <= 100'000'000,
               "SJ2_SYSTEM_CLOCK can only be between 1Hz and 100Mhz");
@@ -52,9 +52,17 @@ static_assert(1 <= kSystemClockRate && kSystemClockRate <= 100'000'000,
 // Used to set the FreeRTOS tick frequency defined in Hz
 #if !defined SJ2_RTOS_FREQUENCY
 #define SJ2_RTOS_FREQUENCY 1'000
-#endif  // defined SJ2_RTOS_FREQUENCY
+#endif  // !defined SJ2_RTOS_FREQUENCY
 SJ2_DECLARE_CONSTANT(RTOS_FREQUENCY, uint16_t, kRtosFrequency);
 static_assert(1 <= kRtosFrequency && kRtosFrequency <= 10'000,
               "SJ2_RTOS_FREQUENCY can only be between 1,000Hz and 1Hz");
+
+// Used to dump all the call stack when "PrintBacktrace" is called or an assert
+// using PrintBacktrace is occurs.
+// Disable this to omit getting these logs and reduce the binary size by ~5kB.
+#if !defined SJ2_INCLUDE_BACKTRACE
+#define SJ2_INCLUDE_BACKTRACE true
+#endif  // !defined SJ2_INCLUDE_BACKTRACE
+SJ2_DECLARE_CONSTANT(INCLUDE_BACKTRACE, bool, kIncludeBacktrace);
 
 }  // namespace config

--- a/makefile
+++ b/makefile
@@ -79,7 +79,7 @@ CORTEX_M4F = -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 			 -fabi-version=0
 # CORTEX_M4F  = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
 OPTIMIZE  = -O0 -fmessage-length=0 -ffunction-sections -fdata-sections -fno-exceptions \
-               -fsingle-precision-constant
+               -fsingle-precision-constant -fasynchronous-unwind-tables
 CPPOPTIMIZE = -fno-rtti
 DEBUG     = -g
 WARNINGS_ARE_ERRORS ?=


### PR DESCRIPTION
The desired effect is to allow assert to print the call stack so the user
can determine what sequence of function calls caused the assert to occur.

Removing unnecessary keep-folder.txt files

Does not work with faults and interrupt, may add that functionality at a
later time.