### PR TITLE
Changing from using python2 to python2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ firmware/**/makefile
 tools/Hyperload
 tools/Telemetry
 tools/gcc-arm-none-eabi-*
+tools/clang*
 
 **/*.gch
 **/*.gcno

--- a/firmware/library/L2_Utilities/macros.hpp
+++ b/firmware/library/L2_Utilities/macros.hpp
@@ -9,7 +9,12 @@
 // executable. It uses both attribute "section" and "used". Section attribute
 // places variable/function into that section and "used" labels the symbol as
 // used to ensure that the compiler does remove this symbol at link time.
-#define SJ2_SECTION(section_name) __attribute__((used, section(section_name)))
+#if defined(__APPLE__)
+#define SJ2_SECTION(section_name) \
+    __attribute__((section("__text," section_name), used))
+#else
+#define SJ2_SECTION(section_name) __attribute__((section(section_name), used))
+#endif  // __APPLE__
 // SJ2_USED will use void casting as a means to convince the compiler that the
 // variable has been used in the software, to remove compiler warnings about
 // unused variables.
@@ -30,7 +35,11 @@
 #define SJ2_WEAK __attribute__((weak))
 // Similar to the weak attribute, but also gives each function the
 // implementation of the function f.
+#if defined(__APPLE__)
+#define SJ2_ALIAS(f) __attribute__((weakref(#f)))  // NOLINT
+#else
 #define SJ2_ALIAS(f) __attribute__((weak, alias(#f)))  // NOLINT
+#endif  // __APPLE__
 
 #if defined SJ2_INCLUDE_BACKTRACE && SJ2_INCLUDE_BACKTRACE == true
 #define SJ2_DUMP_BACKTRACE() PrintTrace()

--- a/makefile
+++ b/makefile
@@ -416,7 +416,7 @@ $(TEST_EXEC): $(TEST_FRAMEWORK) $(OBJECT_FILES)
 	@echo ' '
 
 lint:
-	@python2 $(TOOLS)/cpplint/cpplint.py $(LINT_FILES)
+	@python2.7 $(TOOLS)/cpplint/cpplint.py $(LINT_FILES)
 
 tidy:
 	@$(CLANG_TIDY) -extra-arg=-std=c++17 $(LINT_FILES) -- -std=c++17 $(INCLUDES)

--- a/setup
+++ b/setup
@@ -71,14 +71,34 @@ case "$OS" in
         echo "                Updating Apt listings                "
         echo "└─────────────────────────────────────────────────── "
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo apt-add-repository -y "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
-        sudo apt-add-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main"
-        sudo apt-add-repository -y "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main"
-        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        VERSION_ID=$(cat /etc/os-release | grep "VERSION_ID=")
+        echo "UBUNTU $VERSION_ID"
+        if [ "$VERSION_ID" = "VERSION_ID=18.04" ]
+        then
+            echo " ───────────────────────────────────────────────────┐"
+            echo "    Setting up Clang 6.0 tools repo (Ubuntu 18.04)   "
+            echo "└─────────────────────────────────────────────────── "
+            sudo apt-add-repository -y "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-6.0 main"
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        elif [ "$VERSION_ID" = "VERSION_ID=16.04" ]
+        then
+            echo " ───────────────────────────────────────────────────┐"
+            echo "    Setting up Clang 6.0 tools repo (Ubuntu 16.04)   "
+            echo "└─────────────────────────────────────────────────── "
+            sudo apt-add-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main"
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        else
+            echo " ───────────────────────────────────────────────────┐"
+            echo "   Setting up Clang 6.0 tools repo (Ubuntu <=14.04)  "
+            echo "└─────────────────────────────────────────────────── "
+            sudo apt-add-repository -y "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
+            sudo apt-add-repository -y "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main"
+        fi
         sudo apt update
         echo " ───────────────────────────────────────────────────┐"
         echo "               Installing Clang 6.0                  "
         echo "└─────────────────────────────────────────────────── "
+        apt search clang
         sudo apt -y install clang-6.0 lldb-6.0 lld-6.0
         echo " ───────────────────────────────────────────────────┐"
         echo "            Installing Clang Format 6.0              "


### PR DESCRIPTION
Using python2.7 rather than python2 in 'lint' make target.
Python2.7 should be the true path that python2 is aliased with. For
systems that do not have python2.7 aliased with python2, this fix should
fix their issues.