### PR TITLE
Adding TaskScheduler

### DIFF
--- a/firmware/examples/TaskScheduler/source/main.cpp
+++ b/firmware/examples/TaskScheduler/source/main.cpp
@@ -1,0 +1,62 @@
+#include <cstdarg>
+
+#include "L0_LowLevel/uart0.hpp"
+#include "L2_Utilities/debug_print.hpp"
+#include "L4_Application/task.hpp"
+
+class PrinterTask : public rtos::Task<1024>
+{
+ public:
+    PrinterTask(const char * task_name, const char * message)
+        : Task(task_name, rtos::Priority::kMedium),
+          message_(message),
+          run_count_(0){};
+    bool Setup() override
+    {
+        DEBUG_PRINT("Setup() for: %s", kName);
+        return true;
+    };
+    bool PreRun() override
+    {
+        DEBUG_PRINT("PreRun() for: %s", kName);
+        return true;
+    };
+    bool Run() override
+    {
+        run_count_ += 1;
+        DEBUG_PRINT("%s: %ld", message_, run_count_);
+        if (run_count_ == 10)
+        {
+            Delete();
+        }
+        return true;
+    };
+
+ private:
+    const char * message_;
+    uint32_t run_count_;
+};
+
+int main()
+{
+    DEBUG_PRINT("Starting TaskScheduler example...");
+    // TODO(#210): Should remove the use of new and use static allocation for
+    //             constructing tasks when the issue is fixed.
+    PrinterTask * printer_one =
+        new PrinterTask("Printer A", "I am a printer, I am faster");
+    printer_one->SetDelayTime(500);
+    PrinterTask * printer_two =
+        new PrinterTask("Printer B", "I am also a printer");
+    printer_two->SetDelayTime(1000);
+
+    DEBUG_PRINT("Attempting to search for Printer A in the scheduler...");
+    rtos::TaskInterface & task =
+        *(rtos::TaskScheduler::Instance().GetTask("Printer A"));
+    DEBUG_PRINT("Found task: %s", task.GetName());
+
+    rtos::TaskScheduler::Instance().Start();
+    DEBUG_PRINT("This point should not be reached!");
+    delete printer_one;
+    delete printer_two;
+    return 0;
+}

--- a/firmware/library/L0_LowLevel/startup.cpp
+++ b/firmware/library/L0_LowLevel/startup.cpp
@@ -243,10 +243,25 @@ IsrPointer dynamic_isr_vector_table[] = {
     EepromIrqHandler,       // 56, 0xe0 - EEPROM
 };
 
-
 extern "C" void vPortSetupTimerInterrupt(void)  // NOLINT
 {
     // Empty implementation, startup handles this itself.
+}
+
+static StaticTask_t idle_task_tcb;
+static StackType_t idle_task_stack[configMINIMAL_STACK_SIZE];
+// Implementation of vApplicationGetIdleTaskMemory required when
+// configSUPPORT_STATIC_ALLOCATION == 1.
+// The function is called to statically create the idle task when
+// vTaskStartScheduler is invoked.
+extern "C" void vApplicationGetIdleTaskMemory(  // NOLINT
+    StaticTask_t ** ppx_idle_task_tcb_buffer,
+    StackType_t ** ppx_idle_task_stack_buffer,
+    uint32_t * pul_idle_task_stack_size)
+{
+    *ppx_idle_task_tcb_buffer   = &idle_task_tcb;
+    *ppx_idle_task_stack_buffer = idle_task_stack;
+    *pul_idle_task_stack_size   = SJ2_ARRAY_LENGTH(idle_task_stack);
 }
 
 // .data Section Table Information
@@ -341,7 +356,7 @@ void SetupTimerInterrupt()
     system_timer.SetTickFrequency(config::kRtosFrequency);
     bool timer_started_successfully = system_timer.StartTimer();
     SJ2_ASSERT_WARNING(timer_started_successfully,
-                    "System Timer has FAILED to start!");
+                       "System Timer has FAILED to start!");
 }
 
 SJ2_WEAK void LowLevelInit()

--- a/firmware/library/L2_Utilities/rtos.cpp
+++ b/firmware/library/L2_Utilities/rtos.cpp
@@ -1,0 +1,19 @@
+#include "L2_Utilities/rtos.hpp"
+
+#if defined HOST_TEST
+DEFINE_FAKE_VOID_FUNC(vTaskStartScheduler);
+DEFINE_FAKE_VOID_FUNC(vTaskSuspend, TaskHandle_t);
+DEFINE_FAKE_VOID_FUNC(vTaskResume, TaskHandle_t);
+DEFINE_FAKE_VOID_FUNC(vTaskDelete, TaskHandle_t);
+DEFINE_FAKE_VOID_FUNC(vTaskDelayUntil, TickType_t *, TickType_t);
+DEFINE_FAKE_VOID_FUNC(vApplicationGetIdleTaskMemory, StaticTask_t **,
+                      StackType_t **, uint32_t *);
+DEFINE_FAKE_VALUE_FUNC(TickType_t, xTaskGetTickCount);
+DEFINE_FAKE_VALUE_FUNC(TaskHandle_t, xTaskCreateStatic, TaskFunction_t,
+                       const char *, uint32_t, void *, UBaseType_t,
+                       StackType_t *, StaticTask_t *);
+DEFINE_FAKE_VALUE_FUNC(EventGroupHandle_t, xEventGroupCreateStatic,
+                       StaticEventGroup_t *);
+DEFINE_FAKE_VALUE_FUNC(EventBits_t, xEventGroupSync, EventGroupHandle_t,
+                       EventBits_t, EventBits_t, TickType_t);
+#endif  // HOST_TEST

--- a/firmware/library/L2_Utilities/rtos.hpp
+++ b/firmware/library/L2_Utilities/rtos.hpp
@@ -7,6 +7,27 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
+#if defined HOST_TEST
+#include "event_groups.h"
+#include "L5_Testing/testing_frameworks.hpp"
+
+DECLARE_FAKE_VOID_FUNC(vTaskStartScheduler);
+DECLARE_FAKE_VOID_FUNC(vTaskSuspend, TaskHandle_t);
+DECLARE_FAKE_VOID_FUNC(vTaskResume, TaskHandle_t);
+DECLARE_FAKE_VOID_FUNC(vTaskDelete, TaskHandle_t);
+DECLARE_FAKE_VOID_FUNC(vTaskDelayUntil, TickType_t *, TickType_t);
+DECLARE_FAKE_VOID_FUNC(vApplicationGetIdleTaskMemory, StaticTask_t **,
+                       StackType_t **, uint32_t *);
+DECLARE_FAKE_VALUE_FUNC(TickType_t, xTaskGetTickCount);
+DECLARE_FAKE_VALUE_FUNC(TaskHandle_t, xTaskCreateStatic, TaskFunction_t,
+                        const char *, uint32_t, void *, UBaseType_t,
+                        StackType_t *, StaticTask_t *);
+DECLARE_FAKE_VALUE_FUNC(EventGroupHandle_t, xEventGroupCreateStatic,
+                        StaticEventGroup_t *);
+DECLARE_FAKE_VALUE_FUNC(EventBits_t, xEventGroupSync, EventGroupHandle_t,
+                        EventBits_t, EventBits_t, TickType_t);
+#endif  // HOST_TEST
+
 namespace rtos
 {
 enum Priority

--- a/firmware/library/L4_Application/task.hpp
+++ b/firmware/library/L4_Application/task.hpp
@@ -1,0 +1,142 @@
+// This file contains the TaskInterface class.
+// All tasks must inherit TaskInterface and override the Run() function.
+// Usage:
+//      class PrinterTask : public rtos::Task<1024>;
+//      PrinterTask * printer_one =
+//          new PrinterTask("Printer A", "I am a printer, I am faster");
+//      printer_one->SetDelayTime(500);
+//      rtos::TaskScheduler::Instance().Start();
+#pragma once
+
+#include <cstdint>
+
+#include "L2_Utilities/macros.hpp"
+#include "L4_Application/task_scheduler.hpp"
+
+namespace rtos
+{
+class TaskInterface
+{
+ public:
+    virtual bool Setup()                          = 0;
+    virtual bool PreRun()                         = 0;
+    virtual bool Run()                            = 0;
+    virtual void Suspend()                        = 0;
+    virtual void Resume()                         = 0;
+    virtual void Delete()                         = 0;
+    virtual const char * GetName()                = 0;
+    virtual Priority GetPriority()                = 0;
+    virtual size_t GetStackSize()                 = 0;
+    virtual void SetHandle(TaskHandle_t * handle) = 0;
+    virtual TaskHandle_t * GetHandle()            = 0;
+    virtual StaticTask_t * GetTaskBuffer()        = 0;
+    virtual StackType_t * GetStack()              = 0;
+    virtual void SetDelayTime(uint32_t time)      = 0;
+    virtual uint32_t GetDelayTime()               = 0;
+};
+
+template <size_t kStackSize>
+class Task : public TaskInterface
+{
+ public:
+    virtual ~Task(){};
+    // Setup is performed before the task begins to execute.
+    // The function should be overridden with any initialization code that the
+    // task requires.
+    bool Setup() override
+    {
+        return true;
+    };
+    // Called once before Run() is invoked.
+    bool PreRun() override
+    {
+        return true;
+    };
+    // Suspends the task until it is resumed.
+    inline void Suspend() override
+    {
+        vTaskSuspend(handle_);
+    };
+    // Resumes the task if it has been suspened.
+    inline void Resume() override
+    {
+        vTaskResume(handle_);
+    };
+    // Remove the task from the scheduler and delete the task.
+    inline void Delete() override
+    {
+        vTaskSuspend(handle_);
+        rtos::TaskScheduler::Instance().RemoveTask(kName);
+    };
+    inline const char * GetName() override
+    {
+        return kName;
+    };
+    inline Priority GetPriority() override
+    {
+        return kPriority;
+    };
+    // @return Returns the allocated stack size for the task in kilobytes.
+    inline size_t GetStackSize() override
+    {
+        return kStackSize;
+    };
+    inline void SetHandle(TaskHandle_t * handle) override
+    {
+        handle_ = handle;
+    };
+    inline TaskHandle_t * GetHandle() override
+    {
+        return &(handle_);
+    };
+    inline StaticTask_t * GetTaskBuffer() override
+    {
+        return &(task_buffer_);
+    };
+    // @return A pointer reference of the task's statically allocated stack.
+    inline StackType_t * GetStack() override
+    {
+        return stack_;
+    };
+    // Sets the delay time to ensure Run() is called at a desired frequency for
+    // periodic tasks.
+    //
+    // For examples, if time = 1000 and the rtos tick period = 1ms, then Run()
+    // will be called every 1 second.
+    //
+    // @param time Desired delay time in rtos ticks.
+    inline void SetDelayTime(uint32_t time) override
+    {
+        delay_time_ = time;
+    };
+    // @return Returns the delay time in rtos ticks.
+    inline uint32_t GetDelayTime() override
+    {
+        return delay_time_;
+    };
+
+ protected:
+    const char * const kName;
+    const Priority kPriority;
+    // Used to identify the task
+    TaskHandle_t handle_;
+    // Task delay time in rtos ticks.
+    uint32_t delay_time_;
+    // Pointer reference to the statically allocated buffer that will hold the
+    // task TCB.
+    StaticTask_t task_buffer_;
+    // Pointer reference to the allocated stack with the size specified by
+    // stack_size_.
+    StackType_t stack_[kStackSize];
+    // Defualt constructor. When a Task is constructed, it is automatically
+    // added to the TaskScheduler singleton.
+    //
+    // @param name       Name used to easily identify the task.
+    // @param priority   Priority of the task.
+    constexpr Task(const char * name, Priority priority)
+        : kName(name), kPriority(priority), handle_(NULL), delay_time_(0)
+    {
+        rtos::TaskScheduler::Instance().AddTask(this);
+    };
+};
+};  // namespace rtos

--- a/firmware/library/L4_Application/task_scheduler.cpp
+++ b/firmware/library/L4_Application/task_scheduler.cpp
@@ -1,0 +1,101 @@
+#include "L4_Application/task_scheduler.hpp"
+
+#include <cstring>
+
+#include "L4_Application/task.hpp"
+
+void rtos::TaskScheduler::RunTask(void * task_ptr)
+{
+    TaskInterface & task = *(reinterpret_cast<TaskInterface *>(task_ptr));
+
+    const uint8_t kTaskCount = TaskScheduler::Instance().GetTaskCount();
+    const uint8_t kTaskIndex =
+        TaskScheduler::Instance().GetTaskIndex(task.GetName());
+    SJ2_ASSERT_FATAL(kTaskIndex < kTaskCount,
+                     "The task index should not exceed the task count.");
+    // Perform PreRun for the task and then set the event group sync bit to
+    // broadcast this task's PreRun has completed
+    EventGroupHandle_t pre_run_event_group_handle =
+        TaskScheduler::Instance().GetPreRunEventGroupHandle();
+    const EventBits_t kPreRunSyncBits =
+        TaskScheduler::Instance().GetPreRunSyncBits();
+    const uint32_t kSyncBit = (1 << kTaskIndex);
+    SJ2_ASSERT_FATAL(task.PreRun(),
+                     "PreRun() failed for task: %s, terminating scheduler!",
+                     task.GetName());
+    // wait for all other PreRun() of other tasks to finish
+    xEventGroupSync(pre_run_event_group_handle, kSyncBit, kPreRunSyncBits,
+                    portMAX_DELAY);
+    // All PreRun() complete, each Task's Run() can now start executing...
+    TickType_t last_wake_time = xTaskGetTickCount();
+    while (true)
+    {
+        if (!task.Run())
+        {
+            SJ2_ASSERT_WARNING(
+                false,
+                "An error occured, the following task will be suspended: %s",
+                task.GetName());
+            vTaskSuspend(NULL);
+        }
+        // delay task if the task's delay time has been set...
+        uint32_t delay_time = task.GetDelayTime();
+        if (delay_time)
+        {
+            vTaskDelayUntil(&last_wake_time, delay_time);
+        }
+    }
+};
+
+void rtos::TaskScheduler::InitializeAllTasks()
+{
+    for (uint32_t i = 0; i < task_count_; i++)
+    {
+        TaskInterface * task = task_list_[i];
+        *(task->GetHandle()) = xTaskCreateStatic(
+            RunTask,  // function to execute the task
+            task->GetName(),
+            static_cast<uint16_t>(StackSize(task->GetStackSize())),
+            PassParameter(task),  // pointer of task to run
+            task->GetPriority(),
+            task->GetStack(),        // the task's statically allocated memory
+            task->GetTaskBuffer());  // task TCB
+        SJ2_ASSERT_FATAL(task->GetHandle() != nullptr,
+                         "Unable to create task: %s", task->GetName());
+        SJ2_ASSERT_FATAL(task->Setup(),
+                         "Failed to complete Setup() for task: %s",
+                         task->GetName());
+        pre_run_sync_bits_ |= (1 << i);
+    }
+    pre_run_event_group_handle_ =
+        xEventGroupCreateStatic(&pre_run_event_group_buffer_);
+    SJ2_ASSERT_FATAL(pre_run_event_group_handle_ != nullptr,
+                     "Failed to create PreRun Event Group!");
+};
+
+void rtos::TaskScheduler::RemoveTask(const char * task_name)
+{
+    const uint8_t kTaskIndex = GetTaskIndex(task_name);
+    if (kTaskIndex > config::kTaskSchedulerSize)
+    {
+        return;
+    }
+    vTaskDelete(task_list_[kTaskIndex]->GetHandle());
+    task_list_[kTaskIndex] = nullptr;
+    task_count_--;
+};
+
+uint8_t rtos::TaskScheduler::GetTaskIndex(const char * task_name)
+{
+    for (uint8_t i = 0; i < config::kTaskSchedulerSize; i++)
+    {
+        if (task_list_[i] != nullptr)
+        {
+            if (!strcmp(task_list_[i]->GetName(), task_name))
+            {
+                return i;
+            }
+        }
+    }
+    return static_cast<uint8_t>(config::kTaskSchedulerSize + 1);
+};

--- a/firmware/library/L4_Application/task_scheduler.hpp
+++ b/firmware/library/L4_Application/task_scheduler.hpp
@@ -1,0 +1,151 @@
+// This file contains the TaskScheduler class used to scheduler task classes
+// that inherit TaskInterface.
+// Tasks inheriting TaskInterface are automatically added to the scheduler when
+// constructed. Simply start the scheduler after constructing and configuring
+// desired tasks.
+// Usage:
+//      rtos::TaskScheduler::Instance().Start();
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "config.hpp"
+#include "L2_Utilities/macros.hpp"
+#include "L2_Utilities/rtos.hpp"
+// Must include FreeRTOS before event_groups.h
+#include "event_groups.h"
+
+namespace rtos
+{
+class TaskInterface;
+
+class TaskSchedulerInterface
+{
+ public:
+    virtual EventGroupHandle_t GetPreRunEventGroupHandle()  = 0;
+    virtual EventBits_t GetPreRunSyncBits()                 = 0;
+    virtual uint8_t GetTaskCount()                          = 0;
+    virtual void AddTask(TaskInterface * task)              = 0;
+    virtual void RemoveTask(const char * task_name)         = 0;
+    virtual TaskInterface * GetTask(const char * task_name) = 0;
+    virtual uint8_t GetTaskIndex(const char * task_name)    = 0;
+    virtual void Start()                                    = 0;
+    virtual void InitializeAllTasks()                       = 0;
+};
+
+class TaskScheduler final : public TaskSchedulerInterface
+{
+ public:
+    static TaskScheduler & Instance()
+    {
+        static TaskScheduler instance;
+        return instance;
+    };
+    inline EventGroupHandle_t GetPreRunEventGroupHandle() override
+    {
+        return pre_run_event_group_handle_;
+    };
+    inline EventBits_t GetPreRunSyncBits() override
+    {
+        return pre_run_sync_bits_;
+    };
+    // @return Returns the current number of scheduled tasks.
+    inline uint8_t GetTaskCount() override
+    {
+        return task_count_;
+    };
+    // Add a task to the task scheduler. If the scheduler is full, the task will
+    // not be added and a fatal error will be asserted.
+    //
+    // @note When a task inheriting the TaskInterface is constructed, it will
+    // automatically call this function to add itself to the scheduler.
+    //
+    // @param task  Task to add.
+    void AddTask(TaskInterface * task) override
+    {
+        SJ2_ASSERT_FATAL(
+            task_count_ + 1 < config::kTaskSchedulerSize,
+            "The scheduler is currently full, the task will not be "
+            "added. Consider increasing the scheduler size configuration.");
+        for (uint8_t i = 0; i < config::kTaskSchedulerSize; i++)
+        {
+            if (task_list_[i] == nullptr)
+            {
+                task_list_[i] = task;
+                task_count_++;
+                return;
+            }
+        }
+    };
+    // Removes a specified task by its name and updates the task_list_ and
+    // task_count_.
+    // @param task_name  Name of the task to remove.
+    void RemoveTask(const char * task_name) override;
+    // Retreive a task by its task name.
+    //
+    // @param   task_name Name of the task.
+    // @return  Returns nullptr if the task does not exist. Otherwise, returns a
+    //          pointer reference to the retreived task with the matching name.
+    TaskInterface * GetTask(const char * task_name) override
+    {
+        const uint32_t kTaskIndex = GetTaskIndex(task_name);
+        if (kTaskIndex > task_count_)
+        {
+            return nullptr;
+        }
+        return task_list_[kTaskIndex];
+    };
+    // Used to get a task's index to determine the sync bit for the PreRun event
+    // group.
+    //
+    // @param   task_name Name of the task.
+    // @return  Returns the index of the specified task. If the task is not
+    //          scheduled, kTaskSchedulerSize + 1 will be returned.
+    uint8_t GetTaskIndex(const char * task_name) override;
+    // @return Returns a pointer reference to all currently scheduled tasks.
+    inline TaskInterface ** GetAllTasks()
+    {
+        return task_list_;
+    };
+    // Starts the scheduler and attempts to initialize all tasks.
+    // If there are currently no tasks scheduled, a fatal error will be
+    // asserted.
+    void Start() override
+    {
+        SJ2_ASSERT_FATAL(
+            task_count_ != 0,
+            "Attempting to start TaskScheduler but there are no tasks that "
+            "are currently scheduled.");
+        InitializeAllTasks();
+        vTaskStartScheduler();
+        // does not reach this point
+    };
+
+ private:
+    // Array containing all scheduled tasks.
+    TaskInterface * task_list_[config::kTaskSchedulerSize];
+    // Current number of scheduled tasks in task_list_.
+    uint8_t task_count_;
+    // Buffer to hold the static allocation of the PreRun Event Group.
+    StaticEventGroup_t pre_run_event_group_buffer_;
+    // Event Group handle of for notfiying all PreRun are complete.
+    EventGroupHandle_t pre_run_event_group_handle_;
+    // All PreRun sync bits for PreRun Event Group.
+    EventBits_t pre_run_sync_bits_;
+    // Function used during InitalizeAllTasks() for xTaskCreate() for running
+    // scheduled tasks.
+    //
+    // @param task_ptr Pointer reference of the task to run.
+    static void RunTask(void * task_ptr);
+
+    TaskScheduler()
+        : task_count_(0),
+          pre_run_event_group_handle_(NULL),
+          pre_run_sync_bits_(0x0){};
+    // Attempt to initialize each scheduled task with xTaskCreate() and execute
+    // each task's Setup().
+    // A fatal error is asserted if either xTaskCreate() or Setup() fails.
+    void InitializeAllTasks() override;
+};
+};  // namespace rtos

--- a/firmware/library/L4_Application/task_scheduler_test.cpp
+++ b/firmware/library/L4_Application/task_scheduler_test.cpp
@@ -1,0 +1,115 @@
+// Tests for the TaskScheduler singleton class.
+#include "L4_Application/task.hpp"
+#include "L5_Testing/testing_frameworks.hpp"
+
+EventGroupHandle_t test_event_group_handle;
+EventGroupHandle_t xEventGroupCreateStatic_custom_fake(  // NOLINT
+    StaticEventGroup_t *)
+{
+    return test_event_group_handle;
+}
+
+TEST_CASE("Testing TaskScheduler", "[task_scheduler]")
+{
+    using namespace rtos;  // NOLINT
+
+    constexpr uint32_t kTotalTestTaskCount         = 2;
+    const char * task_names[]                      = { "Task One", "Task Two" };
+    TaskHandle_t task_handles[kTotalTestTaskCount] = { NULL };
+
+    Mock<TaskInterface> mock_task_one;
+    When(Method(mock_task_one, GetName)).AlwaysReturn(task_names[0]);
+    When(Method(mock_task_one, Setup)).AlwaysReturn(true);
+    When(Method(mock_task_one, Run)).AlwaysReturn(true);
+    When(Method(mock_task_one, GetHandle)).AlwaysReturn(&task_handles[0]);
+    When(Method(mock_task_one, GetStackSize)).AlwaysReturn(0);
+    When(Method(mock_task_one, GetPriority)).AlwaysReturn(Priority::kLow);
+    When(Method(mock_task_one, GetStack)).AlwaysReturn(0);
+    When(Method(mock_task_one, GetTaskBuffer)).AlwaysReturn(0);
+
+    Mock<TaskInterface> mock_task_two;
+    When(Method(mock_task_two, GetName)).AlwaysReturn(task_names[1]);
+    When(Method(mock_task_two, Setup)).AlwaysReturn(true);
+    When(Method(mock_task_two, Run)).AlwaysReturn(true);
+    When(Method(mock_task_two, GetHandle)).AlwaysReturn(&task_handles[1]);
+    When(Method(mock_task_two, GetStackSize)).AlwaysReturn(0);
+    When(Method(mock_task_two, GetPriority)).AlwaysReturn(Priority::kLow);
+    When(Method(mock_task_two, GetStack)).AlwaysReturn(0);
+    When(Method(mock_task_two, GetTaskBuffer)).AlwaysReturn(0);
+
+    TaskInterface & task_one = mock_task_one.get();
+    TaskInterface & task_two = mock_task_two.get();
+
+    SECTION("AddTask")
+    {
+        TaskScheduler scheduler    = TaskScheduler::Instance();
+        TaskInterface ** task_list = scheduler.GetAllTasks();
+        scheduler.AddTask(&task_one);
+        CHECK(scheduler.GetTaskCount() == 1);
+        CHECK(!strcmp(task_list[0]->GetName(), task_names[0]));
+
+        scheduler.AddTask(&task_two);
+        CHECK(scheduler.GetTaskCount() == 2);
+        CHECK(!strcmp(task_list[1]->GetName(), task_names[1]));
+    }
+    SECTION("GetTask")
+    {
+        TaskScheduler scheduler = TaskScheduler::Instance();
+        scheduler.AddTask(&task_one);
+        TaskInterface * fetched_task = scheduler.GetTask(task_names[0]);
+        CHECK(!strcmp(fetched_task->GetName(), task_names[0]));
+    }
+    SECTION("GetTaskIndex")
+    {
+        TaskScheduler scheduler = TaskScheduler::Instance();
+        scheduler.AddTask(&task_two);
+        scheduler.AddTask(&task_one);
+        CHECK(scheduler.GetTaskIndex(task_two.GetName()) == 0);
+        CHECK(scheduler.GetTaskIndex(task_one.GetName()) == 1);
+    }
+    SECTION("RemoveTask")
+    {
+        TaskScheduler scheduler    = TaskScheduler::Instance();
+        TaskInterface ** task_list = scheduler.GetAllTasks();
+        scheduler.AddTask(&task_one);
+        scheduler.AddTask(&task_two);
+        // should do nothing since this taks is not scheduled
+        scheduler.RemoveTask("Task A");
+        CHECK(vTaskDelete_fake.call_count == 0);
+        // Remove 'Task One' from scheduler
+        // 'Task Two' should now be the first and only task in the scheduler
+        scheduler.RemoveTask(task_names[0]);
+        CHECK(scheduler.GetTaskCount() == 1);
+        CHECK(task_list[0] == nullptr);
+        CHECK(scheduler.GetTask(task_names[0]) == nullptr);
+        // Remove 'Task Two' from scheduler
+        // Scheduler should now be emtpy
+        scheduler.RemoveTask(task_names[1]);
+        CHECK(scheduler.GetTaskCount() == 0);
+        CHECK(scheduler.GetTask(task_names[1]) == nullptr);
+        CHECK(task_list[1] == nullptr);
+        // should do nothing since there are no tasks
+        scheduler.RemoveTask(task_names[0]);
+        CHECK(vTaskDelete_fake.call_count == 2);
+    }
+    SECTION("Start")
+    {
+        constexpr uint32_t kPreRunSyncBits = (1 << 0) | (1 << 1);
+        xEventGroupCreateStatic_fake.custom_fake =
+            xEventGroupCreateStatic_custom_fake;
+        TaskScheduler scheduler = TaskScheduler::Instance();
+        // scheduler should initialize and start since there are tasks
+        // scheduled
+        scheduler.AddTask(&task_one);
+        scheduler.AddTask(&task_two);
+        CHECK(scheduler.GetTaskCount() == 2);
+        scheduler.Start();
+        Verify(Method(mock_task_one, Setup), Method(mock_task_two, Setup))
+            .Exactly(1);
+        CHECK(xTaskCreateStatic_fake.call_count == kTotalTestTaskCount);
+        CHECK(xEventGroupCreateStatic_fake.call_count == 1);
+        CHECK(scheduler.GetPreRunEventGroupHandle() == test_event_group_handle);
+        CHECK(scheduler.GetPreRunSyncBits() == kPreRunSyncBits);
+        CHECK(vTaskStartScheduler_fake.call_count == 1);
+    }
+}

--- a/firmware/library/config.hpp
+++ b/firmware/library/config.hpp
@@ -85,4 +85,10 @@ SJ2_DECLARE_CONSTANT(INCLUDE_BACKTRACE, bool, kIncludeBacktrace);
 #endif  // !defined SJ2_DEBUG_PRINT_ENABLED
 SJ2_DECLARE_CONSTANT(DEBUG_PRINT_ENABLED, bool, kDebugPrintEnabled);
 
+// Used to set the default scheduler size for the TaskScheduler.
+#if !defined SJ2_TASK_SCHEDULER_SIZE
+#define SJ2_TASK_SCHEDULER_SIZE 16
+#endif  // !defined SJ2_TASK_SCHEDULER_SIZE
+SJ2_DECLARE_CONSTANT(TASK_SCHEDULER_SIZE, uint8_t, kTaskSchedulerSize);
+
 }  // namespace config

--- a/firmware/library/third_party/FreeRTOS/Source/include/FreeRTOS.h
+++ b/firmware/library/third_party/FreeRTOS/Source/include/FreeRTOS.h
@@ -812,7 +812,7 @@ extern "C" {
 
 #ifndef configSUPPORT_STATIC_ALLOCATION
 	/* Defaults to 0 for backward compatibility. */
-	#define configSUPPORT_STATIC_ALLOCATION 0
+	#define configSUPPORT_STATIC_ALLOCATION 1
 #endif
 
 #ifndef configSUPPORT_DYNAMIC_ALLOCATION


### PR DESCRIPTION
The TaskScheduler can be used to schedule and manage any tasks that inherits TaskInterface.
An example project can be found in the firmware/examples/TaskScheduler directory.

Other changes:
* Added default scheduler size constant in config.hpp
* Added vApplicationGetIdleTaskMemory to startup.hpp