### PR TITLE
Fixed conversion warning for GetStates()

### DIFF
--- a/firmware/library/L3_HAL/onboard_led.hpp
+++ b/firmware/library/L3_HAL/onboard_led.hpp
@@ -116,12 +116,12 @@ class OnBoardLed : public OnBoardLedInterface
     // significant bits will be used. The four most significant bits will be 0s.
     uint8_t GetStates(void) override
     {
-        uint8_t led_states = 0x00;
+        uint32_t led_states = 0x0000;
         for (uint8_t i = 0; i < 4; i++)
         {
-            led_states |= static_cast<uint8_t>(led[i].ReadPin()) << i;
+            led_states |= led[i].ReadPin() << i;
         }
-        return led_states;
+        return static_cast<uint8_t>(led_states);
     }
 
  protected:


### PR DESCRIPTION
This conversion warning referenced a conversion from uint32_t to uint8_t
possibly being an issue, causing Travis to constantly reject the
integration of this file. This has been fixed by performing the algorithm
using a 32-bit data type and explicitly returning an 8-bit data type from the
result to fit within the rest of the convention of onboard_led.hpp.