### PR TITLE
Removed Unnecessary Bool from Toggle()

### DIFF
--- a/firmware/library/L3_HAL/onboard_led.hpp
+++ b/firmware/library/L3_HAL/onboard_led.hpp
@@ -82,8 +82,7 @@ class OnBoardLed : public OnBoardLedInterface
             led_number < 4,
             "Input Led number can't be greater than 3, input = %d.\n",
             led_number);
-        bool swap = led[led_number].ReadPin();
-        if (swap)
+        if (led[led_number].ReadPin())
         {
             Set(led_number, LightState::kOn);
         }


### PR DESCRIPTION
Previously there was an extra bool there to see the state of the pin, but
that has just been integrated into the if statement to save on memory.