### PR TITLE
Changing name of PinConfigure -> Pin

### DIFF
--- a/firmware/Hyperload/source/main.cpp
+++ b/firmware/Hyperload/source/main.cpp
@@ -198,7 +198,7 @@ void SetFlashAcceleratorSpeed(int32_t clocks_per_flash_access)
 int main(void)
 {
     Gpio button0(1, 0);
-    button0.SetPinMode(PinConfigure::PinMode::kPullDown);
+    button0.SetPinMode(Pin::PinMode::kPullDown);
     button0.SetAsInput();
     OnBoardLed leds;
     leds.Initialize();
@@ -297,7 +297,7 @@ int main(void)
 
     printf("Application Reset ISR value = %p\n", application_entry_isr);
     Delay(500);
-    button0.SetPinMode(PinConfigure::PinMode::kPullUp);
+    button0.SetPinMode(Pin::PinMode::kPullUp);
     leds.SetAll(0);
     // SystemTimerIrq must be disabled, otherwise it will continue to fire,
     // after the application is  executed. This can lead to a lot of problems

--- a/firmware/examples/PinConfigure/source/main.cpp
+++ b/firmware/examples/PinConfigure/source/main.cpp
@@ -12,25 +12,25 @@ int main(void)
 {
     // This application assumes that all pins are set to function 0 (GPIO)
     DEBUG_PRINT("Pin Configure Application Starting...");
-    // Using constructor directly to constuct PinConfigure object
+    // Using constructor directly to constuct Pin object
     // This is discouraged, since this constructor does not perform any compile
     // time checks on the port or pin value
-    PinConfigure p0_0(0, 7);
-    p0_0.SetPinMode(PinConfigureInterface::PinMode::kInactive);
+    Pin p0_0(0, 7);
+    p0_0.SetPinMode(PinInterface::PinMode::kInactive);
     DEBUG_PRINT("Disabling both pull up and down resistors for P0.0...");
-    // Prefered option of constructing PinConfigure, since this factory call is
+    // Prefered option of constructing Pin, since this factory call is
     // done in compile time and will perform compile time validation on the port
     // and pin template parameters.
-    PinConfigure p1_24 = PinConfigure::CreatePinConfigure<1, 24>();
-    p1_24.SetPinMode(PinConfigureInterface::PinMode::kPullDown);
+    Pin p1_24 = Pin::CreatePin<1, 24>();
+    p1_24.SetPinMode(PinInterface::PinMode::kPullDown);
     DEBUG_PRINT("Enabling P1.24 pull down resistor...");
 
-    PinConfigure p2_0 = PinConfigure::CreatePinConfigure<2, 0>();
-    p2_0.SetPinMode(PinConfigureInterface::PinMode::kPullUp);
+    Pin p2_0 = Pin::CreatePin<2, 0>();
+    p2_0.SetPinMode(PinInterface::PinMode::kPullUp);
     DEBUG_PRINT("Enabling P2.0 pull up resistor...");
 
-    PinConfigure p4_28 = PinConfigure::CreatePinConfigure<4, 29>();
-    p4_28.SetPinMode(PinConfigureInterface::PinMode::kRepeater);
+    Pin p4_28 = Pin::CreatePin<4, 29>();
+    p4_28.SetPinMode(PinInterface::PinMode::kRepeater);
     DEBUG_PRINT("Setting P4.29 to repeater mode...");
 
     DEBUG_PRINT(

--- a/firmware/examples/SystemClock/source/main.cpp
+++ b/firmware/examples/SystemClock/source/main.cpp
@@ -10,9 +10,9 @@
 int main(void)
 {
     SystemClock clock;
-    PinConfigure clock_pin(1, 25);
+    Pin clock_pin(1, 25);
     clock_pin.SetPinFunction(0b101);  //  set clock to putput mode
-    clock_pin.SetPinMode(clock_pin.PinConfigureInterface::kInactive);
+    clock_pin.SetPinMode(clock_pin.PinInterface::kInactive);
     clock_pin.EnableHysteresis(false);
     clock_pin.SetAsActiveLow(false);
     clock_pin.EnableFastMode(false);

--- a/firmware/examples/SystemTimer/source/low_level_init.cpp
+++ b/firmware/examples/SystemTimer/source/low_level_init.cpp
@@ -6,7 +6,7 @@
 #include "L2_Utilities/debug_print.hpp"
 
 constexpr uint8_t kGpioFunction = 0b000;
-PinConfigure led3(PinConfigure::CreatePinConfigure<1, 15>());
+Pin led3(Pin::CreatePin<1, 15>());
 
 void DemoSystemIsr()
 {

--- a/firmware/library/L0_LowLevel/uart0.cpp
+++ b/firmware/library/L0_LowLevel/uart0.cpp
@@ -10,11 +10,11 @@
 
 namespace uart0
 {
-PinConfigure rx_pin(0, 3);
-PinConfigureInterface * rx = &rx_pin;
+Pin rx_pin(0, 3);
+PinInterface * rx = &rx_pin;
 
-PinConfigure tx_pin(0, 2);
-PinConfigureInterface * tx = &tx_pin;
+Pin tx_pin(0, 2);
+PinInterface * tx = &tx_pin;
 
 LPC_UART_TypeDef * uart0_register = LPC_UART0;
 LPC_SC_TypeDef * sc               = LPC_SC;
@@ -163,8 +163,8 @@ void Init(uint32_t baud_rate)
     constexpr uint8_t kUartFunction       = 1;
     constexpr uint8_t kDlabBit            = (1 << 7);
 
-    tx->SetPinMode(PinConfigureInterface::PinMode::kPullUp);
-    rx->SetPinMode(PinConfigureInterface::PinMode::kPullUp);
+    tx->SetPinMode(PinInterface::PinMode::kPullUp);
+    rx->SetPinMode(PinInterface::PinMode::kPullUp);
     tx->SetPinFunction(kUartFunction);
     rx->SetPinFunction(kUartFunction);
 

--- a/firmware/library/L0_LowLevel/uart0.hpp
+++ b/firmware/library/L0_LowLevel/uart0.hpp
@@ -10,8 +10,8 @@
 
 namespace uart0
 {
-extern PinConfigureInterface * rx;
-extern PinConfigureInterface * tx;
+extern PinInterface * rx;
+extern PinInterface * tx;
 
 extern LPC_UART_TypeDef * uart0_register;
 extern LPC_SC_TypeDef * sc;

--- a/firmware/library/L0_LowLevel/uart0_test.cpp
+++ b/firmware/library/L0_LowLevel/uart0_test.cpp
@@ -17,10 +17,10 @@ TEST_CASE("Testing Uart0", "[uart0]")
     memset(&local_uart0_register, 0, sizeof(local_uart0_register));
     memset(&local_sc, 0, sizeof(local_sc));
 
-    Mock<PinConfigureInterface> mock_gpio_rx;
+    Mock<PinInterface> mock_gpio_rx;
     Fake(Method(mock_gpio_rx, SetPinFunction));
     Fake(Method(mock_gpio_rx, SetPinMode));
-    Mock<PinConfigureInterface> mock_gpio_tx;
+    Mock<PinInterface> mock_gpio_tx;
     Fake(Method(mock_gpio_tx, SetPinFunction));
     Fake(Method(mock_gpio_tx, SetPinMode));
 
@@ -48,11 +48,11 @@ TEST_CASE("Testing Uart0", "[uart0]")
         CHECK(kPconpUart0 == (kPconpUart0 & local_sc.PCONP));
 
         Verify(Method(mock_gpio_tx, SetPinMode)
-                   .Using(PinConfigureInterface::PinMode::kPullUp))
+                   .Using(PinInterface::PinMode::kPullUp))
             .Once();
         Verify(Method(mock_gpio_tx, SetPinFunction).Using(1)).Once();
         Verify(Method(mock_gpio_rx, SetPinMode)
-                   .Using(PinConfigureInterface::PinMode::kPullUp))
+                   .Using(PinInterface::PinMode::kPullUp))
             .Once();
         Verify(Method(mock_gpio_rx, SetPinFunction).Using(1)).Once();
 

--- a/firmware/library/L0_LowLevel/uart2.cpp
+++ b/firmware/library/L0_LowLevel/uart2.cpp
@@ -11,11 +11,11 @@
 namespace uart2
 {
 
-PinConfigure rx_pin(2, 9);
-PinConfigureInterface * rx = &rx_pin;
+Pin rx_pin(2, 9);
+PinInterface * rx = &rx_pin;
 
-PinConfigure tx_pin(2, 8);
-PinConfigureInterface * tx = &tx_pin;
+Pin tx_pin(2, 8);
+PinInterface * tx = &tx_pin;
 
 LPC_UART_TypeDef * uart2_register = LPC_UART2;
 LPC_SC_TypeDef * sc               = LPC_SC;
@@ -164,8 +164,8 @@ void Init(uint32_t baud_rate)
     constexpr uint8_t kUartFunction       = 0b010;
     constexpr uint8_t kDlabBit            = (1 << 7);
 
-    tx->SetPinMode(PinConfigureInterface::PinMode::kPullUp);
-    rx->SetPinMode(PinConfigureInterface::PinMode::kPullUp);
+    tx->SetPinMode(PinInterface::PinMode::kPullUp);
+    rx->SetPinMode(PinInterface::PinMode::kPullUp);
     tx->SetPinFunction(kUartFunction);
     rx->SetPinFunction(kUartFunction);
 

--- a/firmware/library/L0_LowLevel/uart2.hpp
+++ b/firmware/library/L0_LowLevel/uart2.hpp
@@ -10,8 +10,8 @@
 
 namespace uart2
 {
-extern PinConfigureInterface * rx;
-extern PinConfigureInterface * tx;
+extern PinInterface * rx;
+extern PinInterface * tx;
 
 extern LPC_UART_TypeDef * uart2_register;
 extern LPC_SC_TypeDef * sc;

--- a/firmware/library/L1_Drivers/adc.hpp
+++ b/firmware/library/L1_Drivers/adc.hpp
@@ -87,15 +87,15 @@ class Adc : public AdcInterface
     }
     explicit constexpr Adc(Adc::Channel channel_bit)
         : adc_(&adc_pin_),
-          adc_pin_(PinConfigure(kAdcPorts[static_cast<uint8_t>(channel_bit)],
+          adc_pin_(Pin(kAdcPorts[static_cast<uint8_t>(channel_bit)],
                                 kAdcPins[static_cast<uint8_t>(channel_bit)])),
           channel_(static_cast<uint8_t>(channel_bit))
     {
     }
     // unit test constructor
-    explicit constexpr Adc(PinConfigureInterface * adc_pin)
+    explicit constexpr Adc(PinInterface * adc_pin)
         : adc_(adc_pin),
-          adc_pin_(PinConfigure::CreateInactivePin()),
+          adc_pin_(Pin::CreateInactivePin()),
           channel_(0)
     {
     }
@@ -125,7 +125,7 @@ class Adc : public AdcInterface
             adc_->SetPinFunction(static_cast<uint8_t>(AdcMode::kCh4567Pins));
         }
         adc_->SetAsAnalogMode(true);
-        adc_->SetPinMode(PinConfigureInterface::kInactive);
+        adc_->SetPinMode(PinInterface::kInactive);
 
         for (uint32_t i = 2; i < 255; i++)
         {
@@ -169,8 +169,8 @@ class Adc : public AdcInterface
     }
     ~Adc() { /* do nothing */ }
  private:
-    PinConfigureInterface * adc_;
-    PinConfigure adc_pin_;
+    PinInterface * adc_;
+    Pin adc_pin_;
 
     uint8_t channel_;
 

--- a/firmware/library/L1_Drivers/adc_test.cpp
+++ b/firmware/library/L1_Drivers/adc_test.cpp
@@ -20,15 +20,15 @@ TEST_CASE("Testing adc", "[adc]")
     // Any manipulation will be directed to the respective local registers
     Adc::adc_base = &local_adc;
     Adc::sysclk_register = &local_sc;
-    PinConfigure::pin_map =
-        reinterpret_cast<PinConfigure::PinMap_t *>(&local_io);
-    PinConfigure adc_test(0, 23);
-    // Set mock for PinConfigureInterface
-    Mock<PinConfigureInterface> mock_adc;
+    Pin::pin_map =
+        reinterpret_cast<Pin::PinMap_t *>(&local_io);
+    Pin adc_test(0, 23);
+    // Set mock for PinInterface
+    Mock<PinInterface> mock_adc;
     Fake(Method(mock_adc, SetAsAnalogMode),
          Method(mock_adc, SetPinMode),
          Method(mock_adc, SetPinFunction));
-    PinConfigureInterface & adc = mock_adc.get();
+    PinInterface & adc = mock_adc.get();
 
     // Create ports and pins to test and mock
     // Using channel 0 (0.23)
@@ -55,7 +55,7 @@ TEST_CASE("Testing adc", "[adc]")
                 SetPinFunction).Using(Adc::AdcMode::kCh0123Pins),
                Method(mock_adc, SetAsAnalogMode).Using(true),
                Method(mock_adc,
-                SetPinMode).Using(PinConfigureInterface::kInactive));
+                SetPinMode).Using(PinInterface::kInactive));
         // Check if any bits in the clock divider are set
         CHECK(((local_adc.CR >> kChannelClkDivBit) & kChannelClkDivMask) != 0);
         // Check bit 21 to see if power down bit is set in local_adc.CR

--- a/firmware/library/L1_Drivers/dac.hpp
+++ b/firmware/library/L1_Drivers/dac.hpp
@@ -42,9 +42,9 @@ class Dac : public DacInterface
      {
      }
      // For unit testing mocking purposes
-     explicit constexpr Dac(PinConfigureInterface * dac_pin) :
+     explicit constexpr Dac(PinInterface * dac_pin) :
                       dac_(dac_pin),
-                      dac_pin_(PinConfigure::CreateInactivePin())   // P0.26
+                      dac_pin_(Pin::CreateInactivePin())   // P0.26
      {
      }
     // Initialize Dac by setting the clock divider and enabling
@@ -54,7 +54,7 @@ class Dac : public DacInterface
         dac_->SetPinFunction(kDacMode);
         dac_->EnableDac(true);
         dac_->SetAsAnalogMode(true);
-        dac_->SetPinMode(PinConfigureInterface::kInactive);
+        dac_->SetPinMode(PinInterface::kInactive);
         // Set Update Rate to 1MHz
         SetBias(BiasLevel::kBiasHigh);
     }
@@ -92,6 +92,6 @@ class Dac : public DacInterface
                             |(bias << kBiasReg);
     }
  private:
-    PinConfigureInterface * dac_;
-    PinConfigure dac_pin_;
+    PinInterface * dac_;
+    Pin dac_pin_;
 };

--- a/firmware/library/L1_Drivers/dac_test.cpp
+++ b/firmware/library/L1_Drivers/dac_test.cpp
@@ -14,16 +14,16 @@ TEST_CASE("Testing Dac", "[dac]")
     memset(&local_iocon, 0, sizeof(local_iocon));
     LPC_DAC_TypeDef local_dac_port;
     Dac::dac_register = &local_dac_port;
-    PinConfigure iocon_pin_config(0, 26);
-    PinConfigure::pin_map =
-        reinterpret_cast<PinConfigure::PinMap_t *>(&local_iocon);
-    PinConfigure test_pin(0, 26);
-    Mock<PinConfigureInterface> mock_dac_pin;
+    Pin iocon_pin_config(0, 26);
+    Pin::pin_map =
+        reinterpret_cast<Pin::PinMap_t *>(&local_iocon);
+    Pin test_pin(0, 26);
+    Mock<PinInterface> mock_dac_pin;
     Fake(Method(mock_dac_pin, SetPinFunction),
          Method(mock_dac_pin, EnableDac),
          Method(mock_dac_pin, SetAsAnalogMode),
          Method(mock_dac_pin, SetPinMode));
-    PinConfigureInterface & dac = mock_dac_pin.get();
+    PinInterface & dac = mock_dac_pin.get();
     Dac test_subject00(&dac);
     Dac test_subject01;
     SECTION("Initialize Dac")
@@ -41,7 +41,7 @@ TEST_CASE("Testing Dac", "[dac]")
         Method(mock_dac_pin, EnableDac).Using(true),
         Method(mock_dac_pin, SetAsAnalogMode).Using(true),
         Method(mock_dac_pin,
-               SetPinMode).Using(PinConfigureInterface::kInactive));
+               SetPinMode).Using(PinInterface::kInactive));
     }
     SECTION("Write Dac")
     {
@@ -84,6 +84,6 @@ TEST_CASE("Testing Dac", "[dac]")
         CHECK(kMask == (local_dac_port.CR & kMask));
     }
     Dac::dac_register = LPC_DAC;
-    PinConfigure::pin_map =
-        reinterpret_cast<PinConfigure::PinMap_t *>(LPC_IOCON);
+    Pin::pin_map =
+        reinterpret_cast<Pin::PinMap_t *>(LPC_IOCON);
 }

--- a/firmware/library/L1_Drivers/example_driver.hpp
+++ b/firmware/library/L1_Drivers/example_driver.hpp
@@ -91,10 +91,10 @@ class Example : public ExampleInterface
           can_tx_(can_tx_pin_),
           usb_d_minus_(usb_d_minus_pin_),
           usb_d_plus_(usb_d_plus_pin_),
-          can_rx_pin_(PinConfigure::CreatePinConfigure<0, 1>()),
-          can_tx_pin_(PinConfigure::CreatePinConfigure<0, 2>()),
-          usb_d_minus_pin_(PinConfigure::CreatePinConfigure<2, 3>()),
-          usb_d_plus_pin_(PinConfigure::CreatePinConfigure<2, 4>())
+          can_rx_pin_(Pin::CreatePin<0, 1>()),
+          can_tx_pin_(Pin::CreatePin<0, 2>()),
+          usb_d_minus_pin_(Pin::CreatePin<2, 3>()),
+          usb_d_plus_pin_(Pin::CreatePin<2, 4>())
     {
         SJ2_USED(port);
         SJ2_USED(speed);
@@ -103,18 +103,18 @@ class Example : public ExampleInterface
     }
     // Construction using externally constructed mosi, miso, and sck pins.
     // This is a dependency injection point
-    constexpr Example(const PinConfigureInterface & can_rx,
-                      const PinConfigureInterface & can_tx,
-                      const PinConfigureInterface & usb_d_minus,
-                      const PinConfigureInterface & usb_d_plus)
+    constexpr Example(const PinInterface & can_rx,
+                      const PinInterface & can_tx,
+                      const PinInterface & usb_d_minus,
+                      const PinInterface & usb_d_plus)
         : can_rx_(can_rx),
           can_tx_(can_tx),
           usb_d_minus_(usb_d_minus),
           usb_d_plus_(usb_d_plus),
-          can_rx_pin_(PinConfigure::CreateInactivePin()),
-          can_tx_pin_(PinConfigure::CreateInactivePin()),
-          usb_d_minus_pin_(PinConfigure::CreateInactivePin()),
-          usb_d_plus_pin_(PinConfigure::CreateInactivePin())
+          can_rx_pin_(Pin::CreateInactivePin()),
+          can_tx_pin_(Pin::CreateInactivePin()),
+          usb_d_minus_pin_(Pin::CreateInactivePin()),
+          usb_d_plus_pin_(Pin::CreateInactivePin())
     {
         // Do constructor stuff here ...
     }
@@ -155,14 +155,14 @@ class Example : public ExampleInterface
     // Then private region, if you need one.
  private:
     // Interface objects come first in declaration order
-    const PinConfigureInterface & can_rx_;
-    const PinConfigureInterface & can_tx_;
-    const PinConfigureInterface & usb_d_minus_;
-    const PinConfigureInterface & usb_d_plus_;
+    const PinInterface & can_rx_;
+    const PinInterface & can_tx_;
+    const PinInterface & usb_d_minus_;
+    const PinInterface & usb_d_plus_;
     // Then objects ...
-    PinConfigure can_rx_pin_;
-    PinConfigure can_tx_pin_;
-    PinConfigure usb_d_minus_pin_;
-    PinConfigure usb_d_plus_pin_;
+    Pin can_rx_pin_;
+    Pin can_tx_pin_;
+    Pin usb_d_minus_pin_;
+    Pin usb_d_plus_pin_;
     // Then primatives ...
 };

--- a/firmware/library/L1_Drivers/gpio.hpp
+++ b/firmware/library/L1_Drivers/gpio.hpp
@@ -27,7 +27,7 @@ class GpioInterface
      virtual bool ReadPin(void)                                       = 0;
 };
 
-class Gpio : public GpioInterface, public PinConfigure
+class Gpio : public GpioInterface, public Pin
 {
  public:
     // Used to point to a certain port located in LPC memory map
@@ -37,7 +37,7 @@ class Gpio : public GpioInterface, public PinConfigure
     // For port 0-4, pins 0-31 are available
     // Port 5 only have pins 0-4 available
     constexpr Gpio(uint8_t port_number, uint8_t pin_number)
-        : PinConfigure(port_number, pin_number)
+        : Pin(port_number, pin_number)
     {
     }
     // Sets the GPIO pin direction as input

--- a/firmware/library/L1_Drivers/i2c.hpp
+++ b/firmware/library/L1_Drivers/i2c.hpp
@@ -310,8 +310,8 @@ class I2c : public I2cInterface
         scl_.SetPinFunction(kI2cPort2Function);
         sda_.SetAsOpenDrain();
         scl_.SetAsOpenDrain();
-        sda_.SetPinMode(PinConfigureInterface::kInactive);
-        scl_.SetPinMode(PinConfigureInterface::kInactive);
+        sda_.SetPinMode(PinInterface::kInactive);
+        scl_.SetPinMode(PinInterface::kInactive);
         // TODO(#6): Use a constexpr map to map out which duty cycle values are
         // used for this
         i2c[port_]->SCLL   = 60;
@@ -413,10 +413,10 @@ class I2c : public I2cInterface
         return transaction[port_].status;
     }
  private:
-    PinConfigureInterface & sda_;
-    PinConfigureInterface & scl_;
-    PinConfigure sda_pin_;
-    PinConfigure scl_pin_;
+    PinInterface & sda_;
+    PinInterface & scl_;
+    Pin sda_pin_;
+    Pin scl_pin_;
     uint8_t port_;
     bool initialized_;
 };

--- a/firmware/library/L1_Drivers/pin_configure.cpp
+++ b/firmware/library/L1_Drivers/pin_configure.cpp
@@ -1,6 +1,6 @@
 #include "L0_LowLevel/LPC40xx.h"
 #include "L1_Drivers/pin_configure.hpp"
 
-// Initialize PinConfigure::pin_map to LPC40xx memory mapped LPC_IOCON register
-PinConfigure::PinMap_t * PinConfigure::pin_map =
+// Initialize Pin::pin_map to LPC40xx memory mapped LPC_IOCON register
+Pin::PinMap_t * Pin::pin_map =
     reinterpret_cast<PinMap_t *>(LPC_IOCON);

--- a/firmware/library/L1_Drivers/pin_configure_test.cpp
+++ b/firmware/library/L1_Drivers/pin_configure_test.cpp
@@ -1,22 +1,22 @@
-// Test for PinConfigure class.
+// Test for Pin class.
 // Using a test by side effect on the LPC_IOCON register
 #include "L0_LowLevel/LPC40xx.h"
 #include "L1_Drivers/pin_configure.hpp"
 #include "L5_Testing/testing_frameworks.hpp"
 
-TEST_CASE("Testing PinConfigure", "[pin_configure]")
+TEST_CASE("Testing Pin", "[pin_configure]")
 {
     // Simulated local version of LPC_IOCON register to verify register
-    // manipulation by side effect of PinConfigure method calls
+    // manipulation by side effect of Pin method calls
     LPC_IOCON_TypeDef local_iocon;
     memset(&local_iocon, 0, sizeof(local_iocon));
     // Substitute the memory mapped LPC_IOCON with the local_iocon test struture
     // Redirects manipulation to the 'local_iocon'
-    PinConfigure::pin_map =
-        reinterpret_cast<PinConfigure::PinMap_t *>(&local_iocon);
+    Pin::pin_map =
+        reinterpret_cast<Pin::PinMap_t *>(&local_iocon);
 
-    PinConfigure test_subject00(0, 0);
-    PinConfigure test_subject25(2, 5);
+    Pin test_subject00(0, 0);
+    Pin test_subject25(2, 5);
 
     SECTION("Pin Function")
     {
@@ -39,35 +39,35 @@ TEST_CASE("Testing PinConfigure", "[pin_configure]")
         constexpr uint8_t kModePosition = 3;
         constexpr uint32_t kMask        = 0b11 << kModePosition;
 
-        test_subject00.SetPinMode(PinConfigureInterface::kInactive);
-        test_subject25.SetPinMode(PinConfigureInterface::kInactive);
-        CHECK(PinConfigureInterface::kInactive << kModePosition ==
+        test_subject00.SetPinMode(PinInterface::kInactive);
+        test_subject25.SetPinMode(PinInterface::kInactive);
+        CHECK(PinInterface::kInactive << kModePosition ==
               (local_iocon.P0_0 & kMask));
-        CHECK(PinConfigureInterface::kInactive << kModePosition ==
+        CHECK(PinInterface::kInactive << kModePosition ==
               (local_iocon.P2_5 & kMask));
 
-        test_subject00.SetPinMode(PinConfigureInterface::kPullDown);
-        test_subject25.SetPinMode(PinConfigureInterface::kPullDown);
+        test_subject00.SetPinMode(PinInterface::kPullDown);
+        test_subject25.SetPinMode(PinInterface::kPullDown);
 
-        CHECK(PinConfigureInterface::kPullDown << kModePosition ==
+        CHECK(PinInterface::kPullDown << kModePosition ==
               (local_iocon.P0_0 & kMask));
-        CHECK(PinConfigureInterface::kPullDown << kModePosition ==
+        CHECK(PinInterface::kPullDown << kModePosition ==
               (local_iocon.P2_5 & kMask));
 
-        test_subject00.SetPinMode(PinConfigureInterface::kPullUp);
-        test_subject25.SetPinMode(PinConfigureInterface::kPullUp);
+        test_subject00.SetPinMode(PinInterface::kPullUp);
+        test_subject25.SetPinMode(PinInterface::kPullUp);
 
-        CHECK(PinConfigureInterface::kPullUp << kModePosition ==
+        CHECK(PinInterface::kPullUp << kModePosition ==
               (local_iocon.P0_0 & kMask));
-        CHECK(PinConfigureInterface::kPullUp << kModePosition ==
+        CHECK(PinInterface::kPullUp << kModePosition ==
               (local_iocon.P2_5 & kMask));
 
-        test_subject00.SetPinMode(PinConfigureInterface::kRepeater);
-        test_subject25.SetPinMode(PinConfigureInterface::kRepeater);
+        test_subject00.SetPinMode(PinInterface::kRepeater);
+        test_subject25.SetPinMode(PinInterface::kRepeater);
 
-        CHECK(PinConfigureInterface::kRepeater << kModePosition ==
+        CHECK(PinInterface::kRepeater << kModePosition ==
               (local_iocon.P0_0 & kMask));
-        CHECK(PinConfigureInterface::kRepeater << kModePosition ==
+        CHECK(PinInterface::kRepeater << kModePosition ==
               (local_iocon.P2_5 & kMask));
     }
     SECTION("Set and clear Hysteresis modes")
@@ -225,6 +225,6 @@ TEST_CASE("Testing PinConfigure", "[pin_configure]")
         CHECK(0 == (local_iocon.P0_0 & kMask));
         CHECK(kMask == (local_iocon.P2_5 & kMask));
     }
-    PinConfigure::pin_map =
-        reinterpret_cast<PinConfigure::PinMap_t *>(LPC_IOCON);
+    Pin::pin_map =
+        reinterpret_cast<Pin::PinMap_t *>(LPC_IOCON);
 }

--- a/firmware/library/L1_Drivers/pwm.hpp
+++ b/firmware/library/L1_Drivers/pwm.hpp
@@ -63,9 +63,9 @@ class Pwm : public PwmInterface
     {
     }
 
-    explicit constexpr Pwm(const PinConfigureInterface & pin):
+    explicit constexpr Pwm(const PinInterface & pin):
         pwm_(pin),
-        pwm_pin_(PinConfigure::CreateInactivePin()),
+        pwm_pin_(Pin::CreateInactivePin()),
         channel_(1)
     {
     }
@@ -162,9 +162,9 @@ class Pwm : public PwmInterface
     }
 
  private:
-    const PinConfigureInterface & pwm_;
+    const PinInterface & pwm_;
 
-    PinConfigure pwm_pin_;
+    Pin pwm_pin_;
 
     // Will signify current PWM1 channel
     uint8_t channel_;

--- a/firmware/library/L1_Drivers/pwm_test.cpp
+++ b/firmware/library/L1_Drivers/pwm_test.cpp
@@ -19,10 +19,10 @@ TEST_CASE("Testing PWM instantiation", "[pwm]")
     Pwm::sc = &local_sc;
     Pwm::match_register_table[0] = &local_pwm.MR0;
     Pwm::match_register_table[1] = &local_pwm.MR1;
-    PinConfigure::pin_map =
-        reinterpret_cast<PinConfigure::PinMap_t *>(&local_iocon);
+    Pin::pin_map =
+        reinterpret_cast<Pin::PinMap_t *>(&local_iocon);
 
-    Mock<PinConfigureInterface> mock_pwm_pin;
+    Mock<PinInterface> mock_pwm_pin;
 
     Fake(Method(mock_pwm_pin, SetPinFunction));
     Pwm test2_0(1);

--- a/firmware/library/L1_Drivers/ssp.hpp
+++ b/firmware/library/L1_Drivers/ssp.hpp
@@ -146,15 +146,15 @@ class Ssp : public SspInterface
 
     // Unit-testing constructor, removed for production
     constexpr Ssp(Peripheral pssp,
-                PinConfigureInterface * mosi_pin,
-                PinConfigureInterface * miso_pin,
-                PinConfigureInterface * sck_pin)
+                PinInterface * mosi_pin,
+                PinInterface * miso_pin,
+                PinInterface * sck_pin)
         : mosi_(*mosi_pin),
         miso_(*miso_pin),
         sck_(*sck_pin),
-        mosi_pin_(PinConfigure::CreateInactivePin()),
-        miso_pin_(PinConfigure::CreateInactivePin()),
-        sck_pin_(PinConfigure::CreateInactivePin()),
+        mosi_pin_(Pin::CreateInactivePin()),
+        miso_pin_(Pin::CreateInactivePin()),
+        sck_pin_(Pin::CreateInactivePin()),
         pssp_(pssp),
         pconp_bits_(static_cast<PowerOn>(0)),
         master_mode_(static_cast<MasterSlaveMode>(0)),
@@ -280,13 +280,13 @@ class Ssp : public SspInterface
     }
 
  private:
-    PinConfigureInterface & mosi_;
-    PinConfigureInterface & miso_;
-    PinConfigureInterface & sck_;
+    PinInterface & mosi_;
+    PinInterface & miso_;
+    PinInterface & sck_;
 
-    PinConfigure mosi_pin_;
-    PinConfigure miso_pin_;
-    PinConfigure sck_pin_;
+    Pin mosi_pin_;
+    Pin miso_pin_;
+    Pin sck_pin_;
 
     // SSP member variables
     Peripheral pssp_;                // SSP interfaces

--- a/firmware/library/L1_Drivers/ssp_test.cpp
+++ b/firmware/library/L1_Drivers/ssp_test.cpp
@@ -19,22 +19,22 @@
 //     LPC_SC_TypeDef local_sysclock;
 
 //     Ssp::ssp_registers[0] = &local_ssp[0];
-//     PinConfigure::pin_map =
-//         reinterpret_cast<PinConfigure::PinMap_t *>(&local_iocon);
+//     Pin::pin_map =
+//         reinterpret_cast<Pin::PinMap_t *>(&local_iocon);
 //     Ssp::sysclock_register = &local_sysclock;
 
 //     // Set up Mock for PinCongiure
-//     fakeit::Mock<PinConfigureInterface> mock_mosi;
-//     fakeit::Mock<PinConfigureInterface> mock_miso;
-//     fakeit::Mock<PinConfigureInterface> mock_sck;
+//     fakeit::Mock<PinInterface> mock_mosi;
+//     fakeit::Mock<PinInterface> mock_miso;
+//     fakeit::Mock<PinInterface> mock_sck;
 
 //     fakeit::Fake(Method(mock_mosi, SetPinFunction));
 //     fakeit::Fake(Method(mock_miso, SetPinFunction));
 //     fakeit::Fake(Method(mock_sck, SetPinFunction));
 
-//     PinConfigureInterface &mosi = mock_mosi.get();
-//     PinConfigureInterface &miso = mock_miso.get();
-//     PinConfigureInterface &sck = mock_sck.get();
+//     PinInterface &mosi = mock_mosi.get();
+//     PinInterface &miso = mock_miso.get();
+//     PinInterface &sck = mock_sck.get();
 
 //     Ssp test_spi(SspInterface::Peripheral::kSsp0, mosi, miso, sck);
 //     test_spi.Initialize();

--- a/firmware/library/L1_Drivers/system_timer.hpp
+++ b/firmware/library/L1_Drivers/system_timer.hpp
@@ -2,9 +2,9 @@
 // up the SystemTimer.
 //
 //   Usage:
-//      PinConfigure P0_0(0, 0);
+//      Pin P0_0(0, 0);
 //      P0_0.SetAsActiveLow();
-//      P0_0.SetPinMode(PinConfigureInterface::PinMode::kPullUp);
+//      P0_0.SetPinMode(PinInterface::PinMode::kPullUp);
 #pragma once
 
 // #include <cstdio>

--- a/firmware/library/L1_Drivers/system_timer_test.cpp
+++ b/firmware/library/L1_Drivers/system_timer_test.cpp
@@ -1,4 +1,4 @@
-// Test for PinConfigure class.
+// Test for Pin class.
 // Using a test by side effect on the Cortex M4 SysTick register
 #include "config.hpp"
 #include "L0_LowLevel/LPC40xx.h"
@@ -10,7 +10,7 @@ static void DummyFunction(void) {}
 TEST_CASE("Testing SystemTimer", "[system_timer]")
 {
     // Simulated local version of SysTick register to verify register
-    // manipulation by side effect of PinConfigure method calls
+    // manipulation by side effect of Pin method calls
     // Default figure 552 page 703
     SysTick_Type local_systick = { 0x4, 0, 0, 0x000F'423F };
     // Substitute the memory mapped SysTick with the local_systick test struture


### PR DESCRIPTION
PinConfigure is a bulky and large name to write as well as to read and
say out loud. Its means seems a bit confusing. Simply calling it a Pin
makes more sense.

It also makes Gpio's inheritance of Pin make more sense.

Gpio "is a" pin VS Gpio "is a" PinConfigure

Where the later doesn't make a whole lot of sense.