### PR TITLE
Fixed an issue with static allocation of Tasks

### DIFF
--- a/firmware/examples/TaskScheduler/source/main.cpp
+++ b/firmware/examples/TaskScheduler/source/main.cpp
@@ -2,28 +2,40 @@
 
 #include "L2_Utilities/log.hpp"
 #include "L4_Application/task.hpp"
+#include "semphr.h"
 
-class PrinterTask : public rtos::Task<1024>
+class PrinterTask : public rtos::Task<256>
 {
  public:
-  PrinterTask(const char * task_name, const char * message)
+  constexpr PrinterTask(const char * task_name, const char * message)
       : Task(task_name, rtos::Priority::kMedium),
         message_(message),
-        run_count_(0){};
+        run_count_(0)
+  {
+    print_mutex = {0};
+  };
   bool Setup() override
   {
-    DEBUG_PRINT("Setup() for: %s", kName);
+    if (print_mutex == NULL)
+    {
+      print_mutex = xSemaphoreCreateMutex();
+    }
+    LOG_INFO("Setup() for: %s", kName);
     return true;
   };
   bool PreRun() override
   {
-    DEBUG_PRINT("PreRun() for: %s", kName);
+    xSemaphoreTake(print_mutex, portMAX_DELAY);
+    LOG_INFO("PreRun() for: %s", kName);
+    xSemaphoreGive(print_mutex);
     return true;
   };
   bool Run() override
   {
     run_count_ += 1;
-    DEBUG_PRINT("%s: %ld", message_, run_count_);
+    xSemaphoreTake(print_mutex, portMAX_DELAY);
+    LOG_INFO("%s: %ld", message_, run_count_);
+    xSemaphoreGive(print_mutex);
     if (run_count_ == 10)
     {
       Delete();
@@ -32,30 +44,27 @@ class PrinterTask : public rtos::Task<1024>
   };
 
  private:
+  inline static SemaphoreHandle_t print_mutex;
   const char * message_;
   uint32_t run_count_;
 };
 
+PrinterTask printer_one("Printer A", "I am a printer, I am faster");
+PrinterTask printer_two("Printer B", "I am also a printer");
+
 int main()
 {
-  DEBUG_PRINT("Starting TaskScheduler example...");
-  // TODO(#210): Should remove the use of new and use static allocation for
-  //             constructing tasks when the issue is fixed.
-  PrinterTask * printer_one =
-      new PrinterTask("Printer A", "I am a printer, I am faster");
-  printer_one->SetDelayTime(500);
-  PrinterTask * printer_two =
-      new PrinterTask("Printer B", "I am also a printer");
-  printer_two->SetDelayTime(1000);
+  LOG_INFO("Starting TaskScheduler example...");
+  printer_one.SetDelayTime(500);
+  printer_two.SetDelayTime(1000);
 
-  DEBUG_PRINT("Attempting to search for Printer A in the scheduler...");
+  LOG_INFO("Attempting to search for Printer A in the scheduler...");
   rtos::TaskInterface & task =
       *(rtos::TaskScheduler::Instance().GetTask("Printer A"));
-  DEBUG_PRINT("Found task: %s", task.GetName());
+  LOG_INFO("Found task: %s", task.GetName());
 
+  LOG_INFO("Starting scheduler");
   rtos::TaskScheduler::Instance().Start();
-  DEBUG_PRINT("This point should not be reached!");
-  delete printer_one;
-  delete printer_two;
+  LOG_INFO("This point should not be reached!");
   return 0;
 }

--- a/firmware/library/L4_Application/task.hpp
+++ b/firmware/library/L4_Application/task.hpp
@@ -1,10 +1,12 @@
 // This file contains the TaskInterface class.
 // All tasks must inherit TaskInterface and override the Run() function.
+//
+// NOTE: All tasks must be persistent or in global space.
+//
 // Usage:
 //      class PrinterTask : public rtos::Task<1024>;
-//      PrinterTask * printer_one =
-//          new PrinterTask("Printer A", "I am a printer, I am faster");
-//      printer_one->SetDelayTime(500);
+//      PrinterTask printer_one("Printer A", "I am a printer, I am faster");
+//      printer_one.SetDelayTime(500);
 //      rtos::TaskScheduler::Instance().Start();
 #pragma once
 

--- a/firmware/library/L4_Application/task_scheduler.cpp
+++ b/firmware/library/L4_Application/task_scheduler.cpp
@@ -78,7 +78,11 @@ void rtos::TaskScheduler::RemoveTask(const char * task_name)
   {
     return;
   }
-  vTaskDelete(task_list_[kTaskIndex]->GetHandle());
+  TaskHandle_t handle = task_list_[kTaskIndex]->GetHandle();
+  if (handle != nullptr)
+  {
+    vTaskDelete(handle);
+  }
   task_list_[kTaskIndex] = nullptr;
   task_count_--;
 };


### PR DESCRIPTION
When declaring cstring pointer arrays, the string length should be specified to
prevent memory issues or hard fault errors.

Added a nullptr check to Delete() and RemoveTask() to allow tasks to be removed
even if the scheduler has not been started.