### PR TITLE
Fix bootloader break by unwind implementation

### DIFF
--- a/firmware/library/L0_LowLevel/startup.cpp
+++ b/firmware/library/L0_LowLevel/startup.cpp
@@ -64,7 +64,7 @@ extern "C"
   // Forward declaration of the default handlers. These are aliased.
   // When the application defines a handler (with the same name), this will
   // automatically take precedence over these weak definitions
-  void ResetIsr(void);
+  SJ2_IGNORE_STACK_TRACE(void ResetIsr(void));
   SJ2_VECTOR_OPTIMIZE void NmiHandler(void);
   SJ2_VECTOR_OPTIMIZE void HardFaultHandler(void);
   SJ2_VECTOR_OPTIMIZE void MemManageHandler(void);
@@ -245,6 +245,13 @@ IsrPointer dynamic_isr_vector_table[] = {
   Pwm0IrqHandler,         // 55, 0xdc - PWM0
   EepromIrqHandler,       // 56, 0xe0 - EEPROM
 };
+
+
+SJ2_IGNORE_STACK_TRACE(void InitDataSection());
+SJ2_IGNORE_STACK_TRACE(void InitBssSection());
+SJ2_IGNORE_STACK_TRACE(void InitFpu());
+SJ2_IGNORE_STACK_TRACE(void __libc_init_array());
+SJ2_IGNORE_STACK_TRACE(void LowLevelInit());
 
 extern "C" void vPortSetupTimerInterrupt(void)  // NOLINT
 {

--- a/makefile
+++ b/makefile
@@ -99,7 +99,7 @@ CORTEX_M4F = -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 # CORTEX_M4F  = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
 # -fsingle-precision-constant
 OPTIMIZE  = -O0 -fmessage-length=0 -ffunction-sections -fdata-sections \
-            -fno-exceptions -fomit-frame-pointer -finstrument-functions
+            -fno-exceptions -fomit-frame-pointer
 CPPOPTIMIZE = -fno-rtti
 DEBUG     = -g
 WARNINGS  = -Wall -Wextra -Wshadow -Wlogical-op -Wfloat-equal \


### PR DESCRIPTION
Needed to removed a the following startup functions from the unwind call
in order to get the bootloader to work. If the unwind functions are
called before everything has been initialized, the system would crash.

- void ResetIsr(void)
- void InitDataSection());
- void InitBssSection());
- void InitFpu());
- void __libc_init_array());
- void LowLevelInit());

My hypothesis about why it doesn't crash during application runs, is due to the fact that the bootloader does a lot of the work of setting up the global variables before the application runs. Variables initialized in the bootloader overlap with the variables present in the application, but not always.

With regards to the bootloader crashing before, if it attempts to jump to the "enter" profiler functions that stores the function address into the `stack_trace` array, a read from the `stack_depth` is required. Since the InitDataSection() function hasn't done its work yet, that variable is still uninitialized, which means it could be anything, and that probably caused a write to an invalid memory space, resulting in a fault.