### PR TITLE
Adding graphvis to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ after_success:
     --include "firmware/library/L2_Utilities"
     --include "firmware/library/L3_HAL"
     --include "firmware/library/L4_Application"
-  - sudo apt-get -y install doxygen
+  - sudo apt-get -y install doxygen graphviz
   - cd documentation/api/
   - doxygen sjsu-dev2-doxygen.conf
 deploy:

--- a/setup
+++ b/setup
@@ -109,7 +109,7 @@ case "$OS" in
         echo "               Extracting Clang 6.0                 "
         echo "└────────────────────────────────────────────────── "
         echo "$CLANG_PKG"
-        tar --extract  --verbose --xz --file="$CLANG_PKG"
+        tar --extract --xz --file="$CLANG_PKG"
         echo " ───────────────────────────────────────────────────┐"
         echo "                Installing OpenOCD                   "
         echo "└─────────────────────────────────────────────────── "
@@ -202,7 +202,6 @@ echo " ────────────────────────�
 echo "            Extracting gcc-arm-embedded             "
 echo "└────────────────────────────────────────────────── "
 tar --extract \
-    --verbose \
     --bzip2 \
     --file="$GCC_PKG" \
     --exclude='share/doc'


### PR DESCRIPTION
In order to generate images for the classes in the doxygen documentation
generation, graphviz needs to installed. It has been added to the
travis.yml file.