### PR TITLE
Adding function instrumentation back

### DIFF
--- a/firmware/library/L0_LowLevel/interrupt.hpp
+++ b/firmware/library/L0_LowLevel/interrupt.hpp
@@ -17,6 +17,7 @@ using IsrPointer = void (*)(void);
 #endif  // defined HOST_TEST
 
 #include "L0_LowLevel/LPC40xx.h"
+#include "L2_Utilities/macros.hpp"
 
 #if defined HOST_TEST
 // Remove the text replacement used to replace the variable names above.
@@ -37,11 +38,24 @@ void RegisterIsr(IRQn_Type irq, IsrPointer isr, bool enable_interrupt = true,
                  int32_t priority = -1);
 
 void DeregisterIsr(IRQn_Type irq);
-// External declaration for the pointer to the stack top from the linker
-// script
+// External declaration for the pointer to the stack top from the linker script
 extern "C" void StackTop(void);
 // These are defined after the compilation of the FreeRTOS port for Cortex M4F
 // These will link to those definitions.
 extern "C" void xPortPendSVHandler(void);   // NOLINT
 extern "C" void vPortSVCHandler(void);      // NOLINT
 extern "C" void xPortSysTickHandler(void);  // NOLINT
+// Forward declaration of the default handlers. These are aliased.
+// When the application defines a handler (with the same name), this will
+// automatically take precedence over these weak definitions
+extern "C" SJ2_IGNORE_STACK_TRACE(void ResetIsr(void));
+extern "C" SJ2_IGNORE_STACK_TRACE(void NmiHandler(void));
+extern "C" SJ2_IGNORE_STACK_TRACE(void HardFaultHandler(void));
+extern "C" SJ2_IGNORE_STACK_TRACE(void MemManageHandler(void));
+extern "C" SJ2_IGNORE_STACK_TRACE(void BusFaultHandler(void));
+extern "C" SJ2_IGNORE_STACK_TRACE(void UsageFaultHandler(void));
+extern "C" SJ2_IGNORE_STACK_TRACE(void SvcHandler(void));
+extern "C" SJ2_IGNORE_STACK_TRACE(void DebugMonHandler(void));
+extern "C" SJ2_IGNORE_STACK_TRACE(void PendSVHandler(void));
+extern "C" SJ2_IGNORE_STACK_TRACE(void SysTickHandler(void));
+extern "C" SJ2_IGNORE_STACK_TRACE(SJ2_WEAK void IntDefaultHandler(void));

--- a/firmware/library/L0_LowLevel/startup.cpp
+++ b/firmware/library/L0_LowLevel/startup.cpp
@@ -77,6 +77,7 @@ SJ2_IGNORE_STACK_TRACE(void InitBssSection());
 SJ2_IGNORE_STACK_TRACE(void InitFpu());
 SJ2_IGNORE_STACK_TRACE(void __libc_init_array());
 SJ2_IGNORE_STACK_TRACE(void LowLevelInit());
+SJ2_IGNORE_STACK_TRACE(void SystemInit());
 
 // .data Section Table Information
 SJ2_PACKED(struct)
@@ -89,10 +90,7 @@ DataSectionTable_t
 extern DataSectionTable_t data_section_table[];
 extern DataSectionTable_t data_section_table_end;
 
-// Functions to carry out the initialization of RW and BSS data sections. These
-// are written as separate functions rather than being inlined within the
-// ResetIsr() function in order to cope with MCUs with multiple banks of
-// memory.
+// Functions to carry out the initialization of RW and BSS data sections.
 SJ2_SECTION(".after_vectors")
 void InitDataSection()
 {
@@ -197,10 +195,12 @@ void SystemInit()
 }
 
 SJ2_SECTION(".crp") constexpr uint32_t kCrpWord = 0xFFFFFFFF;
-
 // Reset entry point for your code.
 // Sets up a simple runtime environment and initializes the C/C++ library.
-extern "C" void ResetIsr(void)
+
+extern "C"
+{
+void ResetIsr(void)
 {
   // The Hyperload bootloader takes up stack space to execute. The Hyperload
   // bootloader function launches this ISR manually, but it never returns thus
@@ -220,4 +220,5 @@ extern "C" void ResetIsr(void)
   // main() shouldn't return, but if it does, we'll just enter an infinite
   // loop
   Halt();
+}
 }

--- a/makefile
+++ b/makefile
@@ -96,10 +96,8 @@ endif
 # FLAGS #
 #########
 CORTEX_M4F = -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
-			 -fabi-version=0
-# -fno-omit-frame-pointer -rdynamic
-# CORTEX_M4F  = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
-# -fsingle-precision-constant
+			       -fabi-version=0 -finstrument-functions \
+			       -finstrument-functions-exclude-file-list=L0_LowLevel
 OPTIMIZE  = -O$(OPT) -fmessage-length=0 -ffunction-sections -fdata-sections \
             -fno-exceptions -fomit-frame-pointer
 CPPOPTIMIZE = -fno-rtti


### PR DESCRIPTION
When the Hyperload issue occured, instrumentation was removed from the
makefile, which disabled the backtracing. Adding it back, but setting
L0_LowLevel folder as an exclusion zone for instrumentation.