### PR TITLE
Adding putchar in newlib.cpp to remove malloc

### DIFF
--- a/firmware/library/newlib/newlib.cpp
+++ b/firmware/library/newlib/newlib.cpp
@@ -133,6 +133,11 @@ extern "C"
   {
     out(character);
   }
+  // Needed by third party printf library
+  int putchar(int character)  // NOLINT
+  {
+    return out(character);
+  }
   // Overload default nano puts() with a more optimal version of puts
   int puts(const char * str)  // NOLINT
   {


### PR DESCRIPTION
If printf or puts is used to print a single character, it is substituted
with putchar. The nano implementation uses _malloc_r so a defined
version will keep malloc from being added into the project.