### PR TITLE
Adding runtime task location check to Task class

### DIFF
--- a/firmware/examples/TaskScheduler/project_config.hpp
+++ b/firmware/examples/TaskScheduler/project_config.hpp
@@ -1,0 +1,10 @@
+// This file overrides the default configuration options in the
+// library/config.hpp file. Open library/config.hpp to see which configuration
+// options you can change.
+#pragma once
+
+#include "log_levels.hpp"
+
+#define SJ2_LOG_LEVEL SJ2_LOG_LEVEL_DEBUG
+
+#include "config.hpp"

--- a/firmware/examples/TaskScheduler/source/main.cpp
+++ b/firmware/examples/TaskScheduler/source/main.cpp
@@ -4,7 +4,7 @@
 #include "L4_Application/task.hpp"
 #include "semphr.h"
 
-class PrinterTask : public rtos::Task<256>
+class PrinterTask : public rtos::Task<512>
 {
  public:
   constexpr PrinterTask(const char * task_name, const char * message)

--- a/firmware/library/L0_LowLevel/startup.cpp
+++ b/firmware/library/L0_LowLevel/startup.cpp
@@ -79,17 +79,6 @@ SJ2_IGNORE_STACK_TRACE(void __libc_init_array());
 SJ2_IGNORE_STACK_TRACE(void LowLevelInit());
 SJ2_IGNORE_STACK_TRACE(void SystemInit());
 
-// .data Section Table Information
-SJ2_PACKED(struct)
-DataSectionTable_t
-{
-  uint32_t * rom_location;
-  uint32_t * ram_location;
-  uint32_t length;
-};
-extern DataSectionTable_t data_section_table[];
-extern DataSectionTable_t data_section_table_end;
-
 // Functions to carry out the initialization of RW and BSS data sections.
 SJ2_SECTION(".after_vectors")
 void InitDataSection()
@@ -102,16 +91,6 @@ void InitDataSection()
     memcpy(ram_location, rom_location, length);
   }
 }
-
-// .bss Section Table Information
-SJ2_PACKED(struct)
-BssSectionTable_t
-{
-  uint32_t * ram_location;
-  uint32_t length;
-};
-extern BssSectionTable_t bss_section_table[];
-extern BssSectionTable_t bss_section_table_end;
 
 // Functions to initialization BSS data sections. This is important because
 // the std c libs assume that BSS is set to zero.

--- a/firmware/library/L2_Utilities/log.hpp
+++ b/firmware/library/L2_Utilities/log.hpp
@@ -95,8 +95,8 @@
   {                                                                           \
     if (!(condition))                                                         \
     {                                                                         \
-      LOG_CRITICAL("Assertion Failed: " #condition                            \
-                   " " fatal_message SJ2_COLOR_RESET,                         \
+      LOG_CRITICAL("Assertion Failure, Condition Tested: " #condition         \
+                   "\n          " fatal_message SJ2_COLOR_RESET,             \
                    ##__VA_ARGS__);                                            \
       if ((with_dump))                                                        \
       {                                                                       \

--- a/firmware/library/L4_Application/globals.hpp
+++ b/firmware/library/L4_Application/globals.hpp
@@ -4,10 +4,43 @@
 #include "L1_Drivers/system_timer.hpp"
 #include "L1_Drivers/uart.hpp"
 
-// extern SystemClock system_clock;
-// extern SystemTimer system_timer;
-// extern Uart uart0;
+// ========================
+// Memory Map information
+// ========================
+// .data Section Table Information
+SJ2_PACKED(struct)
+DataSectionTable_t
+{
+  uint32_t * rom_location;
+  uint32_t * ram_location;
+  uint32_t length;
+};
+extern DataSectionTable_t data_section_table[];
+extern DataSectionTable_t data_section_table_end;
 
+// .bss Section Table Information
+SJ2_PACKED(struct)
+BssSectionTable_t
+{
+  uint32_t * ram_location;
+  uint32_t length;
+};
+extern BssSectionTable_t bss_section_table[];
+extern BssSectionTable_t bss_section_table_end;
+
+// The address of this array starts at the beginning of RAM2 which is used
+// exclusively for heap.
+#if defined(HOST_TEST)
+inline uint8_t heap;
+inline uint8_t heap_end;
+#else
+extern uint8_t heap;
+extern uint8_t heap_end;
+#endif
+
+// ========================
+// System Objects
+// ========================
 inline SystemTimer system_timer;
 inline SystemClock system_clock;
 inline Uart uart0(Uart::Channels::kUart0);

--- a/firmware/library/L4_Application/task_scheduler.cpp
+++ b/firmware/library/L4_Application/task_scheduler.cpp
@@ -45,7 +45,7 @@ void rtos::TaskScheduler::RunTask(void * task_ptr)
       vTaskDelayUntil(&last_wake_time, delay_time);
     }
   }
-};
+}
 
 void rtos::TaskScheduler::InitializeAllTasks()
 {
@@ -69,7 +69,7 @@ void rtos::TaskScheduler::InitializeAllTasks()
       xEventGroupCreateStatic(&pre_run_event_group_buffer_);
   SJ2_ASSERT_FATAL(pre_run_event_group_handle_ != nullptr,
                    "Failed to create PreRun Event Group!");
-};
+}
 
 void rtos::TaskScheduler::RemoveTask(const char * task_name)
 {
@@ -85,7 +85,7 @@ void rtos::TaskScheduler::RemoveTask(const char * task_name)
   }
   task_list_[kTaskIndex] = nullptr;
   task_count_--;
-};
+}
 
 uint8_t rtos::TaskScheduler::GetTaskIndex(const char * task_name)
 {

--- a/firmware/library/L4_Application/task_scheduler.hpp
+++ b/firmware/library/L4_Application/task_scheduler.hpp
@@ -43,16 +43,16 @@ class TaskScheduler final : public TaskSchedulerInterface
     static TaskScheduler instance;
     return instance;
   };
-  inline EventGroupHandle_t GetPreRunEventGroupHandle() override
+  EventGroupHandle_t GetPreRunEventGroupHandle() override
   {
     return pre_run_event_group_handle_;
   };
-  inline EventBits_t GetPreRunSyncBits() override
+  EventBits_t GetPreRunSyncBits() override
   {
     return pre_run_sync_bits_;
   };
   // @return Returns the current number of scheduled tasks.
-  inline uint8_t GetTaskCount() override
+  uint8_t GetTaskCount() override
   {
     return task_count_;
   };
@@ -78,7 +78,7 @@ class TaskScheduler final : public TaskSchedulerInterface
         return;
       }
     }
-  };
+  }
   // Removes a specified task by its name and updates the task_list_ and
   // task_count_.
   // @param task_name  Name of the task to remove.
@@ -87,7 +87,7 @@ class TaskScheduler final : public TaskSchedulerInterface
   //
   // @param   task_name Name of the task.
   // @return  Returns nullptr if the task does not exist. Otherwise, returns a
-  //          pointer reference to the retreived task with the matching name.
+  //          pointer reference to the retrieved task with the matching name.
   TaskInterface * GetTask(const char * task_name) override
   {
     const uint32_t kTaskIndex = GetTaskIndex(task_name);
@@ -96,7 +96,7 @@ class TaskScheduler final : public TaskSchedulerInterface
       return nullptr;
     }
     return task_list_[kTaskIndex];
-  };
+  }
   // Used to get a task's index to determine the sync bit for the PreRun event
   // group.
   //
@@ -105,10 +105,10 @@ class TaskScheduler final : public TaskSchedulerInterface
   //          scheduled, kTaskSchedulerSize + 1 will be returned.
   uint8_t GetTaskIndex(const char * task_name) override;
   // @return Returns a pointer reference to all currently scheduled tasks.
-  inline TaskInterface ** GetAllTasks()
+  TaskInterface ** GetAllTasks()
   {
     return task_list_;
-  };
+  }
   // Starts the scheduler and attempts to initialize all tasks.
   // If there are currently no tasks scheduled, a fatal error will be
   // asserted.
@@ -121,7 +121,7 @@ class TaskScheduler final : public TaskSchedulerInterface
     InitializeAllTasks();
     vTaskStartScheduler();
     // does not reach this point
-  };
+  }
 
  private:
   // Array containing all scheduled tasks.

--- a/firmware/library/LPC4078_application.ld
+++ b/firmware/library/LPC4078_application.ld
@@ -29,6 +29,7 @@ MEMORY
   __base_RAM2 = 0x20000000 ; /* RAM2 */
   __top_RamPeriph32 = 0x20000000 + 0x8000 ; /* 32K bytes */
   __top_RAM2 = 0x20000000 + 0x8000 ; /* 32K bytes */
+  __user_heap_base = __base_RAM2 ; /* SJSU-Dev2: RAM2 is solely for heap */
 
 ENTRY(ResetIsr)
 
@@ -192,6 +193,7 @@ SECTIONS
     } > RamLoc64
 
     PROVIDE(heap = DEFINED(__user_heap_base) ? __user_heap_base : .);
+    PROVIDE(heap_end = __top_RAM2);
     PROVIDE(StackTop = DEFINED(__user_stack_top) ? __user_stack_top : __top_RamLoc64 - 0);
 
     /* ## Create checksum value (used in startup) ## */

--- a/firmware/library/newlib/newlib.cpp
+++ b/firmware/library/newlib/newlib.cpp
@@ -21,15 +21,12 @@ int GetChar()
   return static_cast<int>(uart0.Receive());
 }
 
-constexpr int32_t kHeapSize = 32768;
 #if defined(HOST_TEST)
 Stdout out = putchar;
 Stdin in   = getchar;
-uint8_t heap[kHeapSize];
 #else
 Stdout out = PutChar;
 Stdin in   = GetChar;
-extern uint8_t heap[kHeapSize];
 #endif
 
 extern "C"
@@ -74,16 +71,16 @@ extern "C"
   // NOLINTNEXTLINE(readability-identifier-naming)
   void * _sbrk(int increment)
   {
-    static uint8_t * heap_end = heap;
-    void * previous_heap_end  = static_cast<void *>(heap_end);
+    static uint8_t * heap_position = &heap;
+    void * previous_heap_position  = static_cast<void *>(heap_position);
 
     // Check that by allocating this space, we do not exceed the heap area.
-    if ((heap_end + increment) - heap > kHeapSize)
+    if ((heap_position + increment) > &heap_end)
     {
-      previous_heap_end = nullptr;
+      previous_heap_position = nullptr;
     }
-    heap_end += increment;
-    return previous_heap_end;
+    heap_position += increment;
+    return previous_heap_position;
   }
   // Dummy implementation of close
   // NOLINTNEXTLINE(readability-identifier-naming)


### PR DESCRIPTION
The only two places a task can exist is in the .data section or the
.heap, or any memory that is presistant.

If made on the stack, this will most likely lead to a hard fault.

To prevent developers from making this mistake, during construction,
tasks do a self test of their own address and make sure they are within
the bounds of the .data, .bss, or .heap sections. If this fails, a fatal
assertion is triggered the the program will halt. Othewise, the program
will continue.