### PR TITLE
Decoupling Pin from Gpio

### DIFF
--- a/firmware/Hyperload/source/main.cpp
+++ b/firmware/Hyperload/source/main.cpp
@@ -224,13 +224,13 @@ int main(void)
   Gpio button2(0, 30);
   Gpio button3(0, 29);
 
-  button0.SetMode(Pin::Mode::kPullDown);
+  button0.GetPin().SetMode(Pin::Mode::kPullDown);
   button0.SetAsInput();
-  button1.SetMode(Pin::Mode::kPullDown);
+  button1.GetPin().SetMode(Pin::Mode::kPullDown);
   button1.SetAsInput();
-  button2.SetMode(Pin::Mode::kPullDown);
+  button2.GetPin().SetMode(Pin::Mode::kPullDown);
   button2.SetAsInput();
-  button3.SetMode(Pin::Mode::kPullDown);
+  button3.GetPin().SetMode(Pin::Mode::kPullDown);
   button3.SetAsInput();
 
   debug_print_button_was_pressed = button3.Read();
@@ -339,7 +339,6 @@ int main(void)
 
   printf("Application Reset ISR value = %p\n", application_entry_isr);
   Delay(500);
-  button0.SetMode(Pin::Mode::kPullUp);
   leds.SetAll(0);
   // SystemTimerIrq must be disabled, otherwise it will continue to fire,
   // after the application is  executed. This can lead to a lot of problems

--- a/firmware/library/L1_Drivers/example_driver.hpp
+++ b/firmware/library/L1_Drivers/example_driver.hpp
@@ -6,6 +6,10 @@
 //      For example, include how to setup and initialize the driver, and how to
 //      do something simple with the driver.
 //      See library/L1_Drivers/pin.hpp for an example.
+//
+// Refrain at all costs from including any libary above L1. So you can include
+// from L0, L1 and Utilities, but no higher
+//
 // The first none comment line of the driver hpp MUST be this:
 #pragma once
 // Include any C-header files first, in alphabetical order.

--- a/firmware/library/L1_Drivers/gpio.hpp
+++ b/firmware/library/L1_Drivers/gpio.hpp
@@ -18,17 +18,18 @@ class GpioInterface
     kLow  = 0,
     kHigh = 1
   };
-  virtual void SetAsInput(void)                  = 0;
-  virtual void SetAsOutput(void)                 = 0;
+  virtual void SetAsInput()                      = 0;
+  virtual void SetAsOutput()                     = 0;
   virtual void SetDirection(Direction direction) = 0;
-  virtual void SetHigh(void)                     = 0;
-  virtual void SetLow(void)                      = 0;
+  virtual void SetHigh()                         = 0;
+  virtual void SetLow()                          = 0;
   virtual void Set(State output = kHigh)         = 0;
   virtual void Toggle()                          = 0;
-  virtual State ReadState(void)                  = 0;
-  virtual bool Read(void)                        = 0;
+  virtual State ReadState()                      = 0;
+  virtual bool Read()                            = 0;
+  virtual PinInterface & GetPin()                = 0;
 };
-class Gpio : public GpioInterface, public Pin
+class Gpio final : public GpioInterface
 {
  public:
   // Mode zero is the GPIO function for all pins.
@@ -39,20 +40,25 @@ class Gpio : public GpioInterface, public Pin
   };
   // For port 0-4, pins 0-31 are available. Port 5 only has pins 0-4 available.
   constexpr Gpio(uint8_t port_number, uint8_t pin_number)
-      : Pin(port_number, pin_number)
+      : pin_(&lpc40xx_pin_), lpc40xx_pin_(port_number, pin_number)
+  {
+  }
+  // For port 0-4, pins 0-31 are available. Port 5 only has pins 0-4 available.
+  constexpr explicit Gpio(PinInterface * pin)
+      : pin_(pin), lpc40xx_pin_(Pin::CreateInactivePin())
   {
   }
   // Sets the GPIO pin direction as input
   void SetAsInput(void) override
   {
-    SetPinFunction(kGpioFunction);
-    gpio_port[port_]->DIR &= ~(1 << pin_);
+    pin_->SetPinFunction(kGpioFunction);
+    gpio_port[pin_->GetPort()]->DIR &= ~(1 << pin_->GetPin());
   }
   // Sets the GPIO pin direction as output
   void SetAsOutput(void) override
   {
-    SetPinFunction(kGpioFunction);
-    gpio_port[port_]->DIR |= (1 << pin_);
+    pin_->SetPinFunction(kGpioFunction);
+    gpio_port[pin_->GetPort()]->DIR |= (1 << pin_->GetPin());
   }
   // Sets the GPIO pin direction as output or input depending on the
   // Direction enum parameter
@@ -63,12 +69,12 @@ class Gpio : public GpioInterface, public Pin
   // Sets the GPIO output pin to high
   void SetHigh(void) override
   {
-    gpio_port[port_]->SET = (1 << pin_);
+    gpio_port[pin_->GetPort()]->SET = (1 << pin_->GetPin());
   }
   // Sets the GPIO output pin to low
   void SetLow(void) override
   {
-    gpio_port[port_]->CLR = (1 << pin_);
+    gpio_port[pin_->GetPort()]->CLR = (1 << pin_->GetPin());
   }
   // Sets the GPIO output pin to high or low depending on the State enum
   // parameter
@@ -79,16 +85,25 @@ class Gpio : public GpioInterface, public Pin
   // Toggle the output of a GPIO output pin
   void Toggle() override
   {
-    gpio_port[port_]->PIN ^= (1 << pin_);
+    gpio_port[pin_->GetPort()]->PIN ^= (1 << pin_->GetPin());
   }
   // Returns the current State state of the pin
   State ReadState(void) override
   {
-    return static_cast<State>((gpio_port[port_]->PIN >> pin_) & 1);
+    bool state = (gpio_port[pin_->GetPort()]->PIN >> pin_->GetPin()) & 1;
+    return static_cast<State>(state);
   }
   // Returns true if input or output pin is high
   bool Read(void) override
   {
-    return static_cast<bool>((gpio_port[port_]->PIN >> pin_) & 1);
+    return (gpio_port[pin_->GetPort()]->PIN >> pin_->GetPin()) & 1;
   }
+  PinInterface & GetPin() override
+  {
+    return *pin_;
+  }
+
+ private:
+  PinInterface * pin_;
+  Pin lpc40xx_pin_;
 };

--- a/firmware/library/L1_Drivers/pin.hpp
+++ b/firmware/library/L1_Drivers/pin.hpp
@@ -33,6 +33,8 @@ class PinInterface
   virtual void EnableI2cHighCurrentDrive(bool enable_high_current = true) = 0;
   virtual void SetAsOpenDrain(bool set_as_open_drain = true)              = 0;
   virtual void EnableDac(bool enable_dac = true)                          = 0;
+  virtual uint8_t GetPort() const                                         = 0;
+  virtual uint8_t GetPin() const                                          = 0;
 };
 
 class Pin : public PinInterface
@@ -158,11 +160,11 @@ class Pin : public PinInterface
     target |= (value & mask) << position;
     return target;
   }
-  uint8_t GetPort()
+  uint8_t GetPort() const override
   {
     return port_;
   }
-  uint8_t GetPin()
+  uint8_t GetPin() const override
   {
     return pin_;
   }

--- a/firmware/library/L3_HAL/button.hpp
+++ b/firmware/library/L3_HAL/button.hpp
@@ -14,30 +14,44 @@ class ButtonInterface
   virtual void InvertButtonSignal(bool enable_invert_signal = true) = 0;
 };
 
-
-class Button : public ButtonInterface, public Gpio
+class Button : public ButtonInterface
 {
  public:
-  constexpr Button(uint8_t port_num, uint8_t pin_num) : Gpio(port_num, pin_num)
+  constexpr Button(uint8_t port, uint8_t pin)
+      : button_(&button_gpio_),
+        button_gpio_(port, pin),
+        was_pressed_(false),
+        was_released_(false)
+  {
+  }
+  constexpr explicit Button(GpioInterface * button)
+      : button_(button),
+        button_gpio_(0, 0),
+        was_pressed_(false),
+        was_released_(false)
   {
   }
 
   void Initialize(void) override
   {
-    SetAsInput();
-    SetMode(PinInterface::Mode::kPullDown);
+    button_->SetAsInput();
+    button_->GetPin().SetMode(PinInterface::Mode::kPullDown);
+    InvertButtonSignal(false);
   }
-
+  void InvertButtonSignal(bool enable_invert_signal = true) override
+  {
+    button_->GetPin().SetAsActiveLow(enable_invert_signal);
+  }
   bool Released(void) override
   {
     bool result = false;
-    if (Read() && !was_pressed_)
+    if (button_->Read() && !was_pressed_)
     {
       was_pressed_ = true;
     }
-    else if (!Read() && was_pressed_)
+    else if (!button_->Read() && was_pressed_)
     {
-      result      = true;
+      result       = true;
       was_pressed_ = false;
     }
     return result;
@@ -46,30 +60,29 @@ class Button : public ButtonInterface, public Gpio
   bool Pressed(void) override
   {
     bool result = false;
-    if (Read() && !was_pressed_)
+    if (!button_->Read() && !was_released_)
     {
-      result      = true;
-      was_pressed_ = true;
+      was_released_ = true;
     }
-    else if (!Read() && was_pressed_)
+    else if (button_->Read() && was_released_)
     {
-      was_pressed_ = false;
+      result        = true;
+      was_released_ = false;
     }
     return result;
   }
 
   void ResetState(void) override
   {
-    was_pressed_ = false;
-  }
-
-  void InvertButtonSignal(bool enable_invert_signal = true) override
-  {
-    SetAsActiveLow(enable_invert_signal);
+    was_pressed_  = false;
+    was_released_ = false;
   }
 
   ~Button() {}
 
  private:
-  bool was_pressed_ = false;
+  GpioInterface * button_;
+  Gpio button_gpio_;
+  bool was_pressed_;
+  bool was_released_;
 };


### PR DESCRIPTION
Rather than having gpio inherit pin, gpio will contain a pin and return
a reference of a PinInterface derived from its GetPin() method.

GpioInterface has been extended to return a PinInterface using a GetPin()
method.

Updated button_test.cpp to use only mocks/stubs vs using side effects of
hard manipulation.