### PR TITLE
Move from config::kSystemFreq -> GetSystemFreq()

### DIFF
--- a/firmware/Hyperload/source/main.cpp
+++ b/firmware/Hyperload/source/main.cpp
@@ -25,8 +25,12 @@
        test. Please build this software using 'make bootloader'
 #endif
 
+namespace
+{
+Lpc40xxSystemController system_controller;
 Uart uart3(Uart::Channels::kUart3);
 bool debug_print_button_was_pressed = false;
+}  // namespace
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 void puts3(const char * str)
@@ -270,8 +274,9 @@ int main(void)
     // correctly It calculates the baud rate by: 48Mhz/(16//BAUD) - 1 = CW
     // (control word) So we solve for BAUD:  BAUD = (48/(CW + 1))/16
     float control_word_f = static_cast<float>(control.word);
-    float approx_baud =
-        (config::kSystemClockRate / (control_word_f + 1.0f)) / 16.0f;
+    float system_frequency =
+        static_cast<float>(system_controller.GetSystemFrequency());
+    float approx_baud = (system_frequency / (control_word_f + 1.0f)) / 16.0f;
     uint32_t baud_rate =
         static_cast<uint32_t>(hyperload::FindNearestBaudRate(approx_baud));
     uart0.SetBaudRate(baud_rate);
@@ -428,7 +433,7 @@ IapResult EraseSector(uint32_t start, uint32_t end)
     command.command       = IapCommands::kEraseSector;
     command.parameters[0] = start;
     command.parameters[1] = end;
-    command.parameters[2] = config::kSystemClockRate / 1000;
+    command.parameters[2] = system_controller.GetSystemFrequency() / 1000;
     iap(&command, &status);
   }
   else
@@ -453,7 +458,7 @@ IapResult FlashBlock(Block_t * block, uint32_t sector_number,
     command.parameters[0] = reinterpret_cast<intptr_t>(flash_address);
     command.parameters[1] = reinterpret_cast<intptr_t>(block);
     command.parameters[2] = kBlockSize;
-    command.parameters[3] = config::kSystemClockRate / 1000;
+    command.parameters[3] = system_controller.GetSystemFrequency() / 1000;
     iap(&command, &status);
     printf3("Flash Attempted! %p %s\n", flash_address,
             kIapResultString[static_cast<uint32_t>(status.result)]);

--- a/firmware/examples/SystemClock/source/main.cpp
+++ b/firmware/examples/SystemClock/source/main.cpp
@@ -27,7 +27,7 @@ int main(void)
     Delay(5000);
     clock.SetClockFrequency(48);
     Delay(5000);
-    speed = clock.GetClockFrequency();
+    speed = clock.GetSystemFrequency();
     DEBUG_PRINT("Speed is %" PRIu32, speed);
   }
   return 0;

--- a/firmware/library/L1_Drivers/i2c.hpp
+++ b/firmware/library/L1_Drivers/i2c.hpp
@@ -348,9 +348,10 @@ class I2c final : public I2cInterface, protected Lpc40xxSystemController
       scl_.SetMode(PinInterface::Mode::kInactive);
     }
     PowerUpPeripheral(Lpc40xxSystemController::PeripheralPowerUp::kI2c2);
-    float scll         = ((config::kSystemClockRate / 75'000.0f) / 2.0f) * 0.7f;
+    float peripheral_frequency = static_cast<float>(GetPeripheralFrequency());
+    float scll         = ((peripheral_frequency / 75'000.0f) / 2.0f) * 0.7f;
     i2c[port_]->SCLL   = static_cast<uint32_t>(scll);
-    float sclh         = ((config::kSystemClockRate / 75'000.0f) / 2.0f) * 1.3f;
+    float sclh         = ((peripheral_frequency / 75'000.0f) / 2.0f) * 1.3f;
     i2c[port_]->SCLH   = static_cast<uint32_t>(sclh);
     i2c[port_]->CONCLR = Control::kAssertAcknowledge | Control::kStart |
                          Control::kStop | Control::kInterrupt;

--- a/firmware/library/L1_Drivers/ssp.hpp
+++ b/firmware/library/L1_Drivers/ssp.hpp
@@ -157,7 +157,7 @@ class Ssp final : public SspInterface, protected Lpc40xxSystemController
   {
   }
 
-  // Constructor to pass in your own pins
+  /// Constructor to pass in your own pins
   constexpr Ssp(Peripheral pssp, PinInterface * mosi_pin,
                 PinInterface * miso_pin, PinInterface * sck_pin)
       : mosi_(mosi_pin),

--- a/firmware/library/L1_Drivers/system_timer.hpp
+++ b/firmware/library/L1_Drivers/system_timer.hpp
@@ -100,8 +100,8 @@ class SystemTimer final : public SystemTimerInterface,
     {
       return 0;
     }
-    uint32_t reload_value = (GetClockFrequency() / frequency) - 1;
-    int remainder         = GetClockFrequency() % frequency;
+    uint32_t reload_value = (GetSystemFrequency() / frequency) - 1;
+    int remainder         = (GetSystemFrequency() % frequency);
     if (reload_value > SysTick_LOAD_RELOAD_Msk)
     {
       reload_value = SysTick_LOAD_RELOAD_Msk;

--- a/firmware/library/L1_Drivers/test/system_timer_test.cpp
+++ b/firmware/library/L1_Drivers/test/system_timer_test.cpp
@@ -28,8 +28,7 @@ TEST_CASE("Testing SystemTimer", "[system_timer]")
 
     CHECK(0 == test_subject.SetTickFrequency(kDivisibleFrequency));
     constexpr uint32_t kExpectedLoadValue =
-        (Lpc40xxSystemController::kDefaultIRCFrequency / kDivisibleFrequency) -
-        1;
+        (config::kSystemClockRate / kDivisibleFrequency) - 1;
     CHECK(kExpectedLoadValue == local_systick.LOAD);
   }
   SECTION("SetTickFrequency should return remainder of ticks mismatch")
@@ -37,10 +36,9 @@ TEST_CASE("Testing SystemTimer", "[system_timer]")
     constexpr uint32_t kOddFrequency = 7;
     local_systick.LOAD               = 0;
 
-    CHECK(Lpc40xxSystemController::kDefaultIRCFrequency % kOddFrequency ==
+    CHECK(config::kSystemClockRate % kOddFrequency ==
           test_subject.SetTickFrequency(kOddFrequency));
-    CHECK((Lpc40xxSystemController::kDefaultIRCFrequency / kOddFrequency) - 1 ==
-          local_systick.LOAD);
+    CHECK((config::kSystemClockRate / kOddFrequency) - 1 == local_systick.LOAD);
   }
   SECTION("Start Timer should set necessary SysTick Ctrl bits and set VAL to 0")
   {

--- a/firmware/library/L1_Drivers/test/uart_test.cpp
+++ b/firmware/library/L1_Drivers/test/uart_test.cpp
@@ -57,4 +57,5 @@ TEST_CASE("Testing Uart", "[Uart]")
     CHECK(kFifo == (local_uart.FCR & kFifo));
   }
   Lpc40xxSystemController::system_controller = LPC_SC;
+  Uart::uart[1]  = LPC_UART2;
 }

--- a/firmware/library/L1_Drivers/uart.hpp
+++ b/firmware/library/L1_Drivers/uart.hpp
@@ -183,13 +183,13 @@ class Uart final : public UartInterface, protected Lpc40xxSystemController
 
   float DividerEstimate(float baud_rate, float fraction_estimate = 1)
   {
-    float clock_frequency = static_cast<float>(GetClockFrequency());
+    float clock_frequency = static_cast<float>(GetPeripheralFrequency());
     return clock_frequency / (16.0f * baud_rate * fraction_estimate);
   }
 
   float FractionalEstimate(float baud_rate, float divider)
   {
-    float clock_frequency = static_cast<float>(GetClockFrequency());
+    float clock_frequency = static_cast<float>(GetPeripheralFrequency());
     return clock_frequency / (16.0f * baud_rate * divider);
   }
 


### PR DESCRIPTION
Also added a new SystemController method GetPeripheralFrequency() which
calculates the clock rate provided to AHB bus using the PCLKSEL register
and the previously set system clock frequency.

It is prefered that L1 drivers use this rather than using the
config::kSystemFrequency or GetSystemFrequency().
config::kSystemFrequency only reflects the target frequency
that the system wants to achieve and not what it actually is, and
GetSystemFrequency() does not tell you what clock the peripheral is
running at.