### PR TITLE
Fix FreeRTOS break due to -finstrucment-functions

### DIFF
--- a/firmware/library/L0_LowLevel/SystemFiles/FreeRTOSConfig.h
+++ b/firmware/library/L0_LowLevel/SystemFiles/FreeRTOSConfig.h
@@ -40,24 +40,25 @@
  * FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
  *----------------------------------------------------------*/
 
-#define configUSE_PREEMPTION		1
-#define configUSE_IDLE_HOOK			0
-#define configMAX_PRIORITIES		( 5 )
-#define configUSE_TICK_HOOK			0
-#define configCPU_CLOCK_HZ			( ( unsigned long ) 12000000 )
-#define configTICK_RATE_HZ			( ( TickType_t ) 1000 )
-#define configMINIMAL_STACK_SIZE	( ( unsigned short ) 80 )
-#define configTOTAL_HEAP_SIZE		( ( size_t ) ( 32 * 1024 ) )
-#define configMAX_TASK_NAME_LEN		( 12 )
-#define configUSE_TRACE_FACILITY	1
-#define configUSE_16_BIT_TICKS		0
-#define configIDLE_SHOULD_YIELD		0
-#define configUSE_CO_ROUTINES 		0
-#define configUSE_MUTEXES			1
+#define configUSE_PREEMPTION		        1
+#define configUSE_IDLE_HOOK			        0
+#define configMAX_PRIORITIES		      ( 5 )
+#define configUSE_TICK_HOOK			        0
+#define configCPU_CLOCK_HZ			      ( ( unsigned long ) 12000000 )
+#define configTICK_RATE_HZ			      ( ( TickType_t ) 1000 )
+#define configMINIMAL_STACK_SIZE	    ( ( unsigned short ) 80 )
+#define configTOTAL_HEAP_SIZE		      ( ( size_t ) ( 32 * 1024 ) )
+#define configMAX_TASK_NAME_LEN		    ( 32 )
+#define configUSE_TRACE_FACILITY	      1
+#define configUSE_16_BIT_TICKS		      0
+#define configIDLE_SHOULD_YIELD		      0
+#define configUSE_CO_ROUTINES 		      0
+#define configUSE_MUTEXES			          1
+#define configSUPPORT_STATIC_ALLOCATION 1
 
 #define configMAX_CO_ROUTINE_PRIORITIES ( 2 )
 
-#define configUSE_COUNTING_SEMAPHORES 	0
+#define configUSE_COUNTING_SEMAPHORES 	1
 #define configUSE_ALTERNATIVE_API 		0
 #define configCHECK_FOR_STACK_OVERFLOW	0
 #define configUSE_RECURSIVE_MUTEXES		1

--- a/firmware/library/L0_LowLevel/interrupt.cpp
+++ b/firmware/library/L0_LowLevel/interrupt.cpp
@@ -85,22 +85,22 @@ SJ2_SECTION(".isr_vector")
 // NOLINTNEXTLINE(readability-identifier-naming)
 const IsrPointer kInterruptVectorTable[] = {
   // Core Level - CM4
-  &StackTop,              // The initial stack pointer
-  ResetIsr,               // The reset handler
-  NmiHandler,             // The NMI handler
-  HardFaultHandler,       // The hard fault handler
-  MemManageHandler,       // The MPU fault handler
-  BusFaultHandler,        // The bus fault handler
-  UsageFaultHandler,      // The usage fault handler
-  ValidUserCodeChecksum,  // LPC MCU Checksum
-  kReservedVector,        // Reserved
-  kReservedVector,        // Reserved
-  kReservedVector,        // Reserved
-  vPortSVCHandler,        // SVCall handler  // vPortSVCHandler
-  DebugMonHandler,        // Debug monitor handler
-  kReservedVector,        // Reserved
-  xPortPendSVHandler,     // FreeRTOS PendSV Handler
-  SysTickHandler,         // The SysTick handler
+  &StackTop,              // 0, The initial stack pointer
+  ResetIsr,               // 1, The reset handler
+  NmiHandler,             // 2, The NMI handler
+  HardFaultHandler,       // 3, The hard fault handler
+  MemManageHandler,       // 4, The MPU fault handler
+  BusFaultHandler,        // 5, The bus fault handler
+  UsageFaultHandler,      // 6, The usage fault handler
+  ValidUserCodeChecksum,  // 7, LPC MCU Checksum
+  kReservedVector,        // 8, Reserved
+  kReservedVector,        // 9, Reserved
+  kReservedVector,        // 10, Reserved
+  vPortSVCHandler,        // 11, SVCall handler  // vPortSVCHandler
+  DebugMonHandler,        // 12, Debug monitor handler
+  kReservedVector,        // 13, Reserved
+  xPortPendSVHandler,     // 14, FreeRTOS PendSV Handler
+  SysTickHandler,         // 15, The SysTick handler
   // Chip Level - LPC40xx
   WdtIrqHandler,          // 16, 0x40 - WDT
   Timer0IrqHandler,       // 17, 0x44 - TIMER0
@@ -207,7 +207,7 @@ IsrPointer dynamic_isr_vector_table[] = {
   LcdIrqHandler,          // 53, 0xd4 - LCD
   GpioIrqHandler,         // 54, 0xd8 - GPIO
   Pwm0IrqHandler,         // 55, 0xdc - PWM0
-  EepromIrqHandler       // 56, 0xe0 - EEPROM
+  EepromIrqHandler        // 56, 0xe0 - EEPROM
 };
 #endif  // defined HOST_TEST
 

--- a/firmware/library/L0_LowLevel/interrupt.hpp
+++ b/firmware/library/L0_LowLevel/interrupt.hpp
@@ -45,8 +45,7 @@ extern "C" void xPortSysTickHandler(void);  // NOLINT
 // definitions.
 extern "C" SJ2_IGNORE_STACK_TRACE(void ResetIsr(void));
 extern "C" SJ2_IGNORE_STACK_TRACE(void HardFaultHandler(void));
-extern "C" SJ2_IGNORE_STACK_TRACE(void IntDefaultHandler(void));
-extern "C" SJ2_WEAK(void InterruptLookupHandler(void));
+extern "C" void InterruptLookupHandler(void);
 
 void RegisterIsr(IRQn_Type irq, IsrPointer isr, bool enable_interrupt = true,
                  int32_t priority = -1);

--- a/firmware/library/L1_Drivers/system_timer.hpp
+++ b/firmware/library/L1_Drivers/system_timer.hpp
@@ -1,10 +1,5 @@
 // SystemTimer abstracts the process of changing enabling and setting
 // up the SystemTimer.
-//
-//   Usage:
-//      Pin P0_0(0, 0);
-//      P0_0.SetAsActiveLow();
-//      P0_0.SetMode(PinInterface::Mode::kPullUp);
 #pragma once
 
 #include <cstring>
@@ -55,12 +50,7 @@ class SystemTimer final : public SystemTimerInterface,
     // This assumes that SysTickHandler is called every millisecond.
     // Changing that frequency will distort the milliseconds time.
     IncrementUptimeMs();
-    if (system_timer_isr == nullptr)
-    {
-      DEBUG_PRINT("System Timer ISR not defined, disabling System Timer");
-      DisableTimer();
-    }
-    else
+    if (system_timer_isr != nullptr)
     {
       system_timer_isr();
     }

--- a/firmware/library/config.hpp
+++ b/firmware/library/config.hpp
@@ -55,6 +55,7 @@ SJ2_DECLARE_CONSTANT(ENABLE_ANSI_CODES, bool, kEnableAnsiCodes);
 #define SJ2_SYSTEM_CLOCK_RATE_MHZ 48
 #endif  // !defined(SJ2_SYSTEM_CLOCK_RATE)
 SJ2_DECLARE_CONSTANT(SYSTEM_CLOCK_RATE_MHZ, uint8_t, kSystemClockRateMhz);
+#define SJ2_SYSTEM_CLOCK_RATE_HZ (SJ2_SYSTEM_CLOCK_RATE_MHZ * 1'000'000)
 constexpr uint32_t kSystemClockRate = SJ2_SYSTEM_CLOCK_RATE_MHZ * 1'000'000;
 static_assert(1 <= kSystemClockRateMhz && kSystemClockRateMhz <= 100,
               "SJ2_SYSTEM_CLOCK can only be between 1Hz and 100Mhz");

--- a/makefile
+++ b/makefile
@@ -201,7 +201,7 @@ DEFINES   = -DARM_MATH_CM4=1 -D__FPU_PRESENT=1U
 DISABLED_WARNINGS = -Wno-main -Wno-variadic-macros
 # Combine all of the flags together
 COMMON_FLAGS = $(CORTEX_M4F) $(OPTIMIZE) $(DEBUG) $(WARNINGS) $(DEFINES) \
-               $(DISABLED_WARNINGS)
+               $(DISABLED_WARNINGS) -fdiagnostics-color
 # Add the last touch for object files
 CFLAGS_COMMON = $(COMMON_FLAGS) $(INCLUDES) $(SYSTEM_INCLUDES) -MMD -MP -c
 LINKFLAGS = $(COMMON_FLAGS) -T $(LINKER) -specs=nano.specs \
@@ -221,7 +221,8 @@ ifeq ($(MAKECMDGOALS), $(filter \
 			$(MAKECMDGOALS), application flash build cleaninstall))
 LINKER = $(LIB_DIR)/LPC4078_application.ld
 CFLAGS_COMMON += -D APPLICATION=1
-CFLAGS_COMMON += -finstrument-functions
+CFLAGS_COMMON += -finstrument-functions \
+	-finstrument-functions-exclude-file-list=third_party/FreeRTOS/Source
 endif
 
 # Enable a whole different set of exceptions, checks, coverage tools and more


### PR DESCRIPTION
- Added flag to `make application` to removed instrument functions from all
  functions within the "third_party/FreeRTOS/Sources" folder.
- SystemTimer's handler now simply checks if the handler exists and
  increments a counter, rather than disabling the timer if the callback
  doesn't exist.
- Enabled counting semaphores, just because we may need them later.
- Removed the InitializeFreeRTOSSystemTick() from startup.cpp. This more
  than complicated function originally swaps out the systick handler for the
  tick handler form FreeRTOS when FreeRTOS's scheduler has started. This
  is complicated and hard to work with when using the bootloader. The
  better and more direct way of doing this is to override FreeRTOS's weak
  function vPortSetupTimerInterrupt() which is directly called after
  vStartScheduler() is called, and setup the timer there.