### PR TITLE
Refactor SystemController's PowerOn Enumeration

### DIFF
--- a/firmware/library/L1_Drivers/adc.hpp
+++ b/firmware/library/L1_Drivers/adc.hpp
@@ -103,7 +103,7 @@ class Adc final : public AdcInterface, protected Lpc40xxSystemController
     SJ2_ASSERT_FATAL(adc_clk_hz < kMaxAdcClock,
                      "Adc clock has to be less than or equal to 12MHz");
 
-    PowerUpPeripheral(Lpc40xxSystemController::PeripheralPowerUp::kAdc);
+    PowerUpPeripheral(Lpc40xxSystemController::Peripherals::kAdc);
     adc_base->CR |= (1 << ControlBit::kPowerUp);
     adc_base->CR |= (1 << channel_);
     if (channel_ < 4)

--- a/firmware/library/L1_Drivers/example_driver.hpp
+++ b/firmware/library/L1_Drivers/example_driver.hpp
@@ -166,7 +166,7 @@ class Example final : public ExampleInterface, protected Lpc40xxSystemController
   {
     // Typically you will need to power up your peripheral. Use the inherited
     // method rather than directly using the LPC_SC register.
-    PowerUpPeripheral(Lpc40xxSystemController::PeripheralPowerUp::kCan2);
+    PowerUpPeripheral(Lpc40xxSystemController::Peripherals::kCan2);
     // Refrain from manipulating the CPU clock speed or peripheral clock speed
     // at this point. It would be very confusing for the user if using, lets say
     // the PWM driver, results in the CPU speed dropping by half or the

--- a/firmware/library/L1_Drivers/i2c.hpp
+++ b/firmware/library/L1_Drivers/i2c.hpp
@@ -347,7 +347,7 @@ class I2c final : public I2cInterface, protected Lpc40xxSystemController
       sda_.SetMode(PinInterface::Mode::kInactive);
       scl_.SetMode(PinInterface::Mode::kInactive);
     }
-    PowerUpPeripheral(Lpc40xxSystemController::PeripheralPowerUp::kI2c2);
+    PowerUpPeripheral(Lpc40xxSystemController::Peripherals::kI2c2);
     float peripheral_frequency = static_cast<float>(GetPeripheralFrequency());
     float scll         = ((peripheral_frequency / 75'000.0f) / 2.0f) * 0.7f;
     i2c[port_]->SCLL   = static_cast<uint32_t>(scll);

--- a/firmware/library/L1_Drivers/pwm.hpp
+++ b/firmware/library/L1_Drivers/pwm.hpp
@@ -77,7 +77,7 @@ class Pwm final : public PwmInterface, protected Lpc40xxSystemController
                      "Channel must be between 1 and 6.");
     // Enables PWM1 power/clock control bit
     // TODO(#): Replace direct manipulation of system clock register.
-    PowerUpPeripheral(Lpc40xxSystemController::PeripheralPowerUp::kPwm1);
+    PowerUpPeripheral(Lpc40xxSystemController::Peripherals::kPwm1);
     // Resets PWMTC on Match with MR0
     pwm1->MCR |= PwmConfigure::kResetMr0;
     pwm1->MR0 = GetPeripheralFrequency() / frequency_hz;

--- a/firmware/library/L1_Drivers/ssp.hpp
+++ b/firmware/library/L1_Drivers/ssp.hpp
@@ -111,10 +111,10 @@ class Ssp final : public SspInterface, protected Lpc40xxSystemController
       [MatrixLookup::kMiso] = Pin::CreatePin<1, 4>(),
       [MatrixLookup::kSck]  = Pin::CreatePin<1, 0>() }
   };
-  static constexpr Lpc40xxSystemController::PeripheralPowerUp kPowerBit[] = {
-    Lpc40xxSystemController::PeripheralPowerUp::kSsp0,
-    Lpc40xxSystemController::PeripheralPowerUp::kSsp1,
-    Lpc40xxSystemController::PeripheralPowerUp::kSsp2,
+  static constexpr Lpc40xxSystemController::PeripheralID kPowerBit[] = {
+    Lpc40xxSystemController::Peripherals::kSsp0,
+    Lpc40xxSystemController::Peripherals::kSsp1,
+    Lpc40xxSystemController::Peripherals::kSsp2,
   };
 
   /// Default constructor sets up SSP0 peripheral as SPI master

--- a/firmware/library/L1_Drivers/uart.hpp
+++ b/firmware/library/L1_Drivers/uart.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cmath>
 #include <cstdint>
 
@@ -64,11 +65,11 @@ class Uart final : public UartInterface, protected Lpc40xxSystemController
                                                       0b101 };
   static constexpr uint8_t kRxUartPortFunction[4] = { 0b001, 0b010, 0b010,
                                                       0b011 };
-  static constexpr Lpc40xxSystemController::PeripheralPowerUp kPowerbit[] = {
-    Lpc40xxSystemController::PeripheralPowerUp::kUart0,
-    Lpc40xxSystemController::PeripheralPowerUp::kUart2,
-    Lpc40xxSystemController::PeripheralPowerUp::kUart3,
-    Lpc40xxSystemController::PeripheralPowerUp::kUart4
+  static constexpr Lpc40xxSystemController::PeripheralID kPowerbit[] = {
+    Lpc40xxSystemController::Peripherals::kUart0,
+    Lpc40xxSystemController::Peripherals::kUart2,
+    Lpc40xxSystemController::Peripherals::kUart3,
+    Lpc40xxSystemController::Peripherals::kUart4
   };
 
   inline static LPC_UART_TypeDef * uart[4] = {


### PR DESCRIPTION
Moved from enum class to a Peripheral struct type to make creating new
peripheral types easier as we expand to other platforms.