### PR TITLE
Adding bit utlity implementation with tests

### DIFF
--- a/firmware/library/utility/bit.hpp
+++ b/firmware/library/utility/bit.hpp
@@ -6,16 +6,27 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 
 namespace bit
 {
+template <typename T>
+constexpr T GenerateFieldOfOnes()
+{
+  T result = 0;
+  for (size_t i = 0; i < sizeof(T); i++)
+  {
+    result |= 0xFF << (i * 8);
+  }
+  return result;
+}
 /// Extract a set of contiguous bits from a target value.
 ///
 /// target   =        0x00FE'DCBA
 ///                            ^
 ///                           /
 ///                          /
-/// payload  = 4 -----------+
+/// value  = 4 -----------+
 /// width    = 8
 ///
 /// return   = 0xCB
@@ -23,27 +34,78 @@ namespace bit
 /// @param target the target containing the bits to be extracted.
 /// @param position the starting position of the bits to extracted.
 /// @param width the number of bits from the starting position to be extracted.
-template<typename T>
-inline T Extract(T target, uint8_t position, uint8_t width = 1);
+template <typename T>
+[[gnu::always_inline]][[nodiscard]]
+constexpr T Extract(T target, uint32_t position, uint32_t width = 1)
+{
+  // Check the types at compile time
+  static_assert(std::numeric_limits<T>::is_integer,
+                "Extract only accepts intergers.");
+  // Need to use an unsigned version of the type T for the mask to make sure
+  // that the shift right doesn't result in a sign extended shift.
+  using UnsignedT = typename std::make_unsigned<T>::type;
+  // At compile time, generate variable containing all 1s with the size of the
+  // target parameter.
+  constexpr UnsignedT kFieldOfOnes = GenerateFieldOfOnes<T>();
+  // At compile time calculate the number of bits in the target parameter.
+  constexpr size_t kTargetWidth     = sizeof(T) * 8;
+  // Create mask by shifting the set of 1s down so that the number of 1s from
+  // bit position 0 is equal to the width parameter.
+  UnsignedT mask   = kFieldOfOnes >> (kTargetWidth - width);
+  // Shift target down to the right to get the bit position in the 0th bit
+  // location.
+  // Mask the value to clear any bit after the width's amount of bits.
+  return (target >> position) & mask;
+}
 /// Insert a set of continguous bits into a target value.
 ///
 /// target   =        0xXXXX'XXXX
 ///                        ^
 ///                       /
 ///                      /
-/// payload  = 0xABCD --+
+/// value   = 0xABCD --+
 /// position = 16
 /// width    = 16
 ///
 /// return   =        0xABCD'XXXX
 ///
 /// @param target the target that will have bits inserted into it.
-/// @param payload the bits to be inserted into the target
-/// @param position the position in the target to insert the payload of bits.
+/// @param value the bits to be inserted into the target
+/// @param position the position in the target to insert the value of bits.
 /// @param width the length of bits that will be overwritten in the target.
-template<typename T>
-inline T Insert(T target, uint8_t payload, uint8_t position,
-                       uint8_t width = 1);
+template <typename T, typename U>
+[[gnu::always_inline]][[nodiscard]]
+constexpr T Insert(T target, U value, uint32_t position, uint32_t width = 1)
+{
+  // Check the types at compile time
+  static_assert(
+      std::numeric_limits<T>::is_integer,
+      "1st parameter (target) of Insert function must be an interger.");
+  static_assert(
+      std::numeric_limits<U>::is_integer,
+      "2nd parameter (value) of Insert function must be an interger.");
+  static_assert(sizeof(T) >= sizeof(U),
+                "2nd parameter (value) must be smaller than or equal to the "
+                "size of the target value.");
+  // Need to use an unsigned version of the type T for the mask to make sure
+  // that the shift right doesn't result in a sign extended shift.
+  using UnsignedT = typename std::make_unsigned<T>::type;
+  // At compile time, generate variable containing all 1s with the size of the
+  // target parameter.
+  constexpr UnsignedT kFieldOfOnes = GenerateFieldOfOnes<T>();
+  // At compile time calculate the number of bits in the target parameter.
+  constexpr size_t kTargetWidth     = sizeof(T) * 8;
+  // Create mask by shifting the set of 1s down so that the number of 1s from
+  // bit position 0 is equal to the width parameter.
+  UnsignedT mask   = kFieldOfOnes >> (kTargetWidth - width);
+  // Clear width's number of bits in the target value at the bit position
+  // specified.
+  target &= ~(mask << position);
+  // AND value with mask to remove any bits beyond the specified width.
+  // Shift masked value into bit position and OR with target value.
+  target |= (value & mask) << position;
+  return target;
+}
 /// Set a bit in the target value at the position specifed to a 1 and return
 ///
 /// target   =        0b0000'1001
@@ -56,8 +118,14 @@ inline T Insert(T target, uint8_t payload, uint8_t position,
 ///
 /// @param target the value you want to change
 /// @param position the position of the bit you would like to change to 1
-template<typename T>
-inline T Set(T target, uint8_t position);
+template <typename T>
+[[gnu::always_inline]] [[nodiscard]]
+constexpr T Set(T target, uint32_t position)
+{
+  static_assert(std::numeric_limits<T>::is_integer,
+                "Set only accepts intergers.");
+  return target | (1 << position);
+}
 /// Set a bit in the target value at the position specifed to a 0 and return
 ///
 /// target   =        0b0000'1001
@@ -70,8 +138,14 @@ inline T Set(T target, uint8_t position);
 ///
 /// @param target the value you want to change
 /// @param position the position of the bit you would like to change to 0
-template<typename T>
-inline T Clear(T target, uint8_t position);
+template <typename T>
+[[gnu::always_inline]][[nodiscard]] constexpr T Clear(T target,
+                                                      uint32_t position)
+{
+  static_assert(std::numeric_limits<T>::is_integer,
+                "Clear only accepts intergers.");
+  return target & ~(1 << position);
+}
 /// Toggle a bit in the target value at the position specifed.
 /// If the bit was a 1, it will be changed to a 0.
 /// If the bit was a 0, it will be changed to a 1.
@@ -86,7 +160,37 @@ inline T Clear(T target, uint8_t position);
 ///
 /// @param target the value you want to change
 /// @param position the position of the bit you would like to toggle
-template<typename T>
-inline T Toggle(T target, uint8_t position);
+template <typename T>
+[[gnu::always_inline]][[nodiscard]] constexpr T Toggle(T target,
+                                                       uint32_t position)
+{
+  static_assert(std::numeric_limits<T>::is_integer,
+                "Toggle only accepts intergers.");
+  return target ^ (1 << position);
+}
+
+/// Read a bit from the target value at the position specifed.
+/// If the bit is 1 at the position given, return true.
+/// If the bit is 0 at the position given, return false.
+///
+/// target   =        0b0000'1001
+///                          |
+///                         /|
+///                        / |
+/// position = 3 ---------+  |
+///                         \|/
+///
+/// return   =               1
+///
+/// @param target the value you want to change
+/// @param position the position of the bit you would like to toggle
+template <typename T>
+[[gnu::always_inline]][[nodiscard]] constexpr bool Read(T target,
+                                                        uint32_t position)
+{
+  static_assert(std::numeric_limits<T>::is_integer,
+                "Read only accepts intergers.");
+  return static_cast<bool>(target & (1 << position));
+}
 }  // namespace bit
 // @}

--- a/firmware/library/utility/test/bit_test.cpp
+++ b/firmware/library/utility/test/bit_test.cpp
@@ -1,0 +1,136 @@
+#include <cstdint>
+
+#include "L4_Testing/testing_frameworks.hpp"
+#include "utility/bit.hpp"
+
+TEST_CASE("Testing Bit Manipulations", "[bit manipulation]")
+{
+  SECTION("Extract")
+  {
+    // Static_assert is used to make sure that the functions work at compile
+    // time.
+    CHECK(0b0011 == bit::Extract(0b0000'1111, 2, 4));
+    static_assert(0b0011 == bit::Extract(0b0000'1111, 2, 4));
+
+    CHECK(0b0000 == bit::Extract(0b0000'1111, 4, 4));
+    static_assert(0b0000 == bit::Extract(0b0000'1111, 4, 4));
+
+    CHECK(0b0001 == bit::Extract(0b0000'1111, 0, 1));
+    static_assert(0b0001 == bit::Extract(0b0000'1111, 0, 1));
+
+    CHECK(0x00AA == bit::Extract(0xAA00'0000, 24, 8));
+    static_assert(0x00AA == bit::Extract(0xAA00'0000, 24, 8));
+
+    CHECK(0xFFFF == bit::Extract(0xFFFF'FFFF, 15, 16));
+    static_assert(0xFFFF == bit::Extract(0xFFFF'FFFF, 15, 16));
+
+    CHECK(0b0001 == bit::Extract(0xFFFF'FFFF, 31, 16));
+    static_assert(0b0001 == bit::Extract(0xFFFF'FFFF, 31, 16));
+
+    CHECK(0xBEEF == bit::Extract(0xDEAD'BEEF, 0, 16));
+    static_assert(0xBEEF == bit::Extract(0xDEAD'BEEF, 0, 16));
+
+    CHECK(0xDEAD == bit::Extract(0xDEAD'BEEF, 16, 16));
+    static_assert(0xDEAD == bit::Extract(0xDEAD'BEEF, 16, 16));
+
+    CHECK(0x00AD == bit::Extract(0xDEAD'BEEF, 16, 8));
+    static_assert(0x00AD == bit::Extract(0xDEAD'BEEF, 16, 8));
+  }
+
+  SECTION("Insert")
+  {
+    CHECK(0b0110'0000 == bit::Insert(0, 0b11, 5, 2));
+    static_assert(0b0110'0000 == bit::Insert(0, 0b11, 5, 2));
+
+    CHECK(0b0000'1110 == bit::Insert(0, 0b111, 1, 3));
+    static_assert(0b0000'1110 == bit::Insert(0, 0b111, 1, 3));
+
+    CHECK(0b0000'1111 == bit::Insert(0, 0b1111, 0, 4));
+    static_assert(0b0000'1111 == bit::Insert(0, 0b1111, 0, 4));
+
+    CHECK(0xAB00'0000 == bit::Insert(0, 0xAB, 24, 8));
+    static_assert(0xAB00'0000 == bit::Insert(0, 0xAB, 24, 8));
+
+    CHECK(0xDEAD'BEEF == bit::Insert(0xD00D'BEEF, 0xEA, 20, 8));
+    static_assert(0xDEAD'BEEF == bit::Insert(0xD00D'BEEF, 0xEA, 20, 8));
+
+    // Shows replacement of DEAD -> BEEF
+    CHECK(0xDEAD'BEEF == bit::Insert(0xDEAD'DEAD, 0xBEEF, 0, 16));
+    static_assert(0xDEAD'BEEF == bit::Insert(0xDEAD'DEAD, 0xBEEF, 0, 16));
+
+    // Shows replacement of 0101 -> 1111 in the middle of byte
+    CHECK(0b1011'1101 == bit::Insert(0b1010'0101, 0b1111, 2, 4));
+    static_assert(0b1011'1101 == bit::Insert(0b1010'0101, 0b1111, 2, 4));
+
+    uint32_t target = 0xAAAA'BBBB;
+    int8_t value_to_insert = 0xCD;
+    // Shows replacement of 0101 -> 1111 in the middle of byte
+    CHECK(0xAAAA'BCDB == bit::Insert(target, value_to_insert, 4, 8));
+  }
+
+  SECTION("Set")
+  {
+    CHECK(0b0001'1111 == bit::Set(0b1111, 4));
+    static_assert(0b0001'1111 == bit::Set(0b1111, 4));
+
+    CHECK(0xFFFF'FFFF == bit::Set(0x7FFFFFFF, 31));
+    static_assert(0xFFFF'FFFF == bit::Set(0x7FFFFFFF, 31));
+
+    CHECK(0b0000'0001 == bit::Set(0, 0));
+    static_assert(0b0000'0001 == bit::Set(0, 0));
+
+    CHECK(0b1000'1001 == bit::Set(0b1000'0001, 3));
+    static_assert(0b1000'1001 == bit::Set(0b1000'0001, 3));
+  }
+
+  SECTION("Clear")
+  {
+    CHECK(0b0000'1111 == bit::Clear(0b0001'1111, 4));
+    static_assert(0b0000'1111 == bit::Clear(0b0001'1111, 4));
+
+    CHECK(0x7FFF'FFFF == bit::Clear(0xFFFF'FFFF, 31));
+    static_assert(0x7FFF'FFFF == bit::Clear(0xFFFF'FFFF, 31));
+
+    CHECK(0b0000'0000 == bit::Clear(0b0000'0001, 0));
+    static_assert(0b0000'0000 == bit::Clear(0b0000'0001, 0));
+
+    CHECK(0b1000'0001 == bit::Clear(0b1000'1001, 3));
+    static_assert(0b1000'0001 == bit::Clear(0b1000'1001, 3));
+  }
+
+  SECTION("Toggle")
+  {
+    CHECK(0b111 == bit::Clear(0b1111, 3));
+    static_assert(0b111 == bit::Clear(0b1111, 3));
+
+    CHECK(0xFFFFFFFE == bit::Clear(0xFFFFFFFF, 0));
+    static_assert(0xFFFFFFFE == bit::Clear(0xFFFFFFFF, 0));
+
+    CHECK(0x7FFFFFFF == bit::Clear(0XFFFFFFFF, 31));
+    static_assert(0x7FFFFFFF == bit::Clear(0XFFFFFFFF, 31));
+  }
+
+  SECTION("Read")
+  {
+    CHECK(true == bit::Read(0b1111, 3));
+    static_assert(true == bit::Read(0b1111, 3));
+
+    CHECK(false == bit::Read(0b01111, 4));
+    static_assert(false == bit::Read(0b01111, 4));
+
+    CHECK(true == bit::Read(0b1, 0));
+    static_assert(true == bit::Read(0b1, 0));
+
+    CHECK(false == bit::Read(0b0, 0));
+    static_assert(false == bit::Read(0b0, 0));
+
+    CHECK(true == bit::Read(0x80000000, 31));
+    static_assert(true == bit::Read(0x80000000, 31));
+
+    CHECK(false == bit::Read(0x80000000, 5));
+    static_assert(false == bit::Read(0x80000000, 5));
+
+    CHECK(false == bit::Read(0x0000, 31));
+    static_assert(false == bit::Read(0x0000, 31));
+  }
+}


### PR DESCRIPTION
Tests also test that the bit:: utils can be used at compile time.