### PR TITLE
Adding Periodic Scheduler

### DIFF
--- a/firmware/examples/PeriodicScheduler/source/main.cpp
+++ b/firmware/examples/PeriodicScheduler/source/main.cpp
@@ -1,0 +1,37 @@
+#include "L1_Drivers/gpio.hpp"
+#include "L2_HAL/displays/led/onboard_led.hpp"
+#include "L3_Application/periodic_scheduler.hpp"
+#include "utility/log.hpp"
+
+OnBoardLed leds;
+/// Toggles the led every 1s
+void BlinkLed1Hz(uint32_t)
+{
+  leds.Toggle(0);
+}
+/// Toggles the led every 0.1s
+void BlinkLed10Hz(uint32_t)
+{
+  leds.Toggle(1);
+}
+
+rtos::PeriodicScheduler scheduler = rtos::PeriodicScheduler();
+rtos::PeriodicTask<512> blinker_1_hz_task("BlinkLed1Hz", rtos::Priority::kLow,
+                                          BlinkLed1Hz);
+rtos::PeriodicTask<512> blinker_10_hz_task("BlinkLed10Hz", rtos::Priority::kLow,
+                                           BlinkLed10Hz);
+
+int main()
+{
+  LOG_INFO("Starting PeriodicScheduler example...");
+  // set initial state of the leds
+  leds.Initialize();
+  leds.On(0);
+  leds.On(1);
+  scheduler.SetTask(&blinker_1_hz_task,
+                    rtos::PeriodicScheduler::Frequency::k1Hz);
+  scheduler.SetTask(&blinker_10_hz_task,
+                    rtos::PeriodicScheduler::Frequency::k10Hz);
+  rtos::TaskScheduler::Instance().Start();
+  return 0;
+}

--- a/firmware/examples/TaskScheduler/source/main.cpp
+++ b/firmware/examples/TaskScheduler/source/main.cpp
@@ -14,7 +14,7 @@ class PrinterTask : public rtos::Task<512>
         message_(message),
         run_count_(0)
   {
-    print_mutex = {0};
+    print_mutex = { 0 };
   };
   bool Setup() override
   {

--- a/firmware/library/L3_Application/L3.mk
+++ b/firmware/library/L3_Application/L3.mk
@@ -6,3 +6,4 @@ TESTS += $(LIB_DIR)/L3_Application/task_scheduler.cpp
 TESTS += $(LIB_DIR)/L3_Application/test/task_scheduler_test.cpp
 TESTS += $(LIB_DIR)/L3_Application/test/commandline_test.cpp
 TESTS += $(LIB_DIR)/L3_Application/test/graphics_test.cpp
+TESTS += $(LIB_DIR)/L3_Application/test/periodic_scheduler_test.cpp

--- a/firmware/library/L3_Application/periodic_scheduler.hpp
+++ b/firmware/library/L3_Application/periodic_scheduler.hpp
@@ -1,0 +1,199 @@
+// This file contains the PeriodicTask and PeriodicScheduler class that allows
+// task functions to be scheduled and executed at fixed frequencies of 1Hz,
+// 10Hz, 100Hz, and 1000Hz.
+//
+// NOTE: Both the PeriodicTask and PeriodicScheduler inherits from the Task
+//       class and must be persistent or in global space.
+//
+// Usage:
+//    void TaskFunction10Hz(uint32_t count)
+//    {
+//      // do something...
+//    }
+//    rtos::PeriodicScheduler scheduler = rtos::PeriodicScheduler<512>();
+//    rtos::PeriodicTask<512> task_10Hz("Task10Hz",
+//                                      rtos::Priority::kLow,
+//                                      TaskFunction10Hz);
+//    scheduler.SetTask(&task_10Hz, rtos::PeriodicScheduler::Frequency::k10Hz);
+//    rtos::TaskScheduler::Instance().Start();
+#pragma once
+
+#include "L3_Application/task.hpp"
+#include "semphr.h"
+#include "utility/enum.hpp"
+#include "utility/log.hpp"
+
+namespace rtos
+{
+/// Pointer to the function containing the code to be executed periodically.
+/// The functions should not containing any blocking code.
+/// eg. vTaskDelay() and vTaskDelayUntil() should not be used within the
+/// function.
+///
+/// @param count Number of times the task function has been run.
+using PeriodicTaskFunction = void (*)(uint32_t count);
+
+class PeriodicTaskInterface
+{
+ public:
+  virtual PeriodicTaskFunction GetTaskFunction() const = 0;
+  virtual SemaphoreHandle_t GetPeriodicSemaphore()     = 0;
+  virtual uint32_t GetRunCount()                       = 0;
+};
+
+/// @tparam kTaskStackSize Task stack size in bytes.
+template <size_t kTaskStackSize>
+class PeriodicTask : public Task<kTaskStackSize>,
+                     public virtual PeriodicTaskInterface
+{
+ public:
+  PeriodicTask(const char * name, Priority priority,
+               PeriodicTaskFunction task_function)
+      : Task<kTaskStackSize>(name, priority), task_function_(task_function)
+  {
+    SJ2_ASSERT_FATAL(task_function_ != nullptr,
+                     "Task function cannot be null for task: %s", name);
+    semaphore_ = xSemaphoreCreateBinaryStatic(&semaphore_buffer_);
+    SJ2_ASSERT_FATAL(semaphore_ != nullptr,
+                     "Error creating periodic semaphore for task: %s", name);
+    run_count_ = 0;
+  }
+  bool Run() override
+  {
+    while (xSemaphoreTake(semaphore_, portMAX_DELAY))
+    {
+      task_function_(++run_count_);
+    }
+    return true;
+  }
+  PeriodicTaskFunction GetTaskFunction() const override
+  {
+    return task_function_;
+  }
+  /// @return Returns the periodic semaphore that is used by the
+  ///         PeriodicScheduler to manager the PeriodicTask
+  SemaphoreHandle_t GetPeriodicSemaphore() override
+  {
+    return semaphore_;
+  }
+  /// @return Returns the number of times the task has been executed.
+  uint32_t GetRunCount() override
+  {
+    return run_count_;
+  }
+
+ protected:
+  PeriodicTaskFunction task_function_;
+  /// Pointer references to statically allocated buffer for each
+  /// semaphore in periodic_semaphores
+  StaticSemaphore_t semaphore_buffer_;
+  /// Periodic semaphore used by the PeriodicScheduler to ensure the task that
+  /// doesnt overrun its allocated time.
+  SemaphoreHandle_t semaphore_;
+  /// Number of times the task function has been executed.
+  uint32_t run_count_;
+};
+
+class PeriodicScheduler final : public Task<512>
+{
+ public:
+  enum class Frequency : uint8_t
+  {
+    k1Hz = 0,  // NOLINT(readability-identifier-naming)
+    k10Hz,     // NOLINT(readability-identifier-naming)
+    k100Hz,    // NOLINT(readability-identifier-naming)
+    k1000Hz,   // NOLINT(readability-identifier-naming)
+    kCount
+  };
+
+  static constexpr size_t kMaxTaskCount = util::Value(Frequency::kCount);
+
+  PeriodicScheduler()
+      : Task("Periodic Scheduler", Priority::kHigh),
+        task_list_{ nullptr },
+        counters_{ 0 }
+  {
+    // The delay time should be 1 since the FreeRTOS tick rate is set to
+    // 1 tick = 1000Hz and 1000Hz is fastest rate for the PeriodicScheduler
+    SetDelayTime(1);
+  }
+  bool Run() override
+  {
+    // Since the FreeRTOS tick rate is set to 1000Hz, the 1000Hz task should be
+    // executed every 1 tick and the 100Hz, 10Hz, and 1Hz tasks would execute at
+    // 1/10th of the subsequent rates
+    if (HandlePeriodicSemaphore(Frequency::k1000Hz, 1))
+    {
+      if (HandlePeriodicSemaphore(Frequency::k100Hz, 10))
+      {
+        if (HandlePeriodicSemaphore(Frequency::k10Hz, 10))
+        {
+          if (HandlePeriodicSemaphore(Frequency::k1Hz, 10))
+          {
+            // NOLINT
+          }
+        }
+      }
+    }
+    return true;
+  }
+  /// Adds a periodic task to the scheduler.
+  ///
+  /// @param task       Pointer to the task that is to be executed periodically.
+  /// @param frequency  Desired frequency the task should be executed.
+  void SetTask(PeriodicTaskInterface * task, Frequency frequency)
+  {
+    task_list_[util::Value(frequency)] = task;
+  }
+  /// @return Returns the scheduled task for a specified frequency.
+  PeriodicTaskInterface * GetTask(Frequency frequency) const
+  {
+    return task_list_[util::Value(frequency)];
+  }
+
+ protected:
+  /// Array containing the 1Hz, 10Hz, 100Hz, and 1000Hz tasks.
+  PeriodicTaskInterface * task_list_[kMaxTaskCount];
+  /// Frequency counters used in HandlePeriodicSemaphore() to determine if a
+  /// semphore should be given for a task to be executed.
+  uint8_t counters_[kMaxTaskCount];
+  /// Handles semaphore of the specified periodic task function to ensure the
+  /// task does not overrun. Each time the function is invokes, the counter for
+  /// the respective frequecy in counters_ is incremented.
+  ///
+  /// When the counter matches the period it is reset, at this time, if there is
+  /// an existing scheduled task and the semaphore is taken before it can be
+  /// given, then the task has exceeded its allocated run-time; otherwise, the
+  /// semaphore is given to allow the task to be executed at the specified
+  /// frequency.
+  ///
+  /// @param frequency  Frequency at which the task executes.
+  /// @param period     Since the FreeRTOS frequency rate is set to 1000Hz,
+  ///                   period = 1 would be 1 RTOS tick.
+  /// @return           Returns true if the counters_[frequency] matches the
+  ///                   specified period.
+  bool HandlePeriodicSemaphore(Frequency frequency, uint8_t period)
+  {
+    bool semaphore_given = false;
+    if (++counters_[util::Value(frequency)] == period)
+    {
+      counters_[util::Value(frequency)] = 0;
+      PeriodicTaskInterface * task      = task_list_[util::Value(frequency)];
+      // do nothing if no task is scheduled for the specified frequency
+      if (task == nullptr)
+      {
+        return true;
+      }
+      SemaphoreHandle_t semaphore                = task->GetPeriodicSemaphore();
+      [[maybe_unused]] const char * task_names[] = { "1Hz", "10Hz", "100Hz",
+                                                     "1000Hz" };
+      SJ2_ASSERT_FATAL(xSemaphoreTake(semaphore, 0) == false,
+                       "Overrun occured for task with frequency: %s",
+                       task_names[util::Value(frequency)]);
+      semaphore_given = true;
+      xSemaphoreGive(semaphore);
+    }
+    return semaphore_given;
+  }
+};
+};  // namespace rtos

--- a/firmware/library/L3_Application/task.hpp
+++ b/firmware/library/L3_Application/task.hpp
@@ -132,6 +132,7 @@ class Task : public TaskInterface
   }
   bool DeclaredOnStackCheck()
   {
+#if !defined(HOST_TEST)
     // This task's position in memory
     intptr_t address = reinterpret_cast<intptr_t>(this);
     // The .data section starts at RAM address 0. The .bss section follows
@@ -154,7 +155,7 @@ class Task : public TaskInterface
             (start_of_heap <= address && address <= end_of_heap),
         "Must define tasks globally or within heap using new or malloc. "
         "Cannot exist on the stack.\n");
-
+#endif
     return true;
   }
 

--- a/firmware/library/L3_Application/test/periodic_scheduler_test.cpp
+++ b/firmware/library/L3_Application/test/periodic_scheduler_test.cpp
@@ -1,0 +1,82 @@
+// Tests for the PeriodicTask and PeriodicScheduler class.
+#include "L3_Application/periodic_scheduler.hpp"
+#include "L4_Testing/testing_frameworks.hpp"
+
+namespace
+{
+SemaphoreHandle_t test_semaphore;
+SemaphoreHandle_t xQueueGenericCreateStatic_custom_fake(  // NOLINT
+    UBaseType_t, UBaseType_t, uint8_t *, StaticQueue_t *, uint8_t)
+{
+  return test_semaphore;
+}
+
+FAKE_VOID_FUNC(PeriodicTaskTestFunction1Hz, uint32_t);
+FAKE_VOID_FUNC(PeriodicTaskTestFunction10Hz, uint32_t);
+FAKE_VOID_FUNC(PeriodicTaskTestFunction100Hz, uint32_t);
+FAKE_VOID_FUNC(PeriodicTaskTestFunction1000Hz, uint32_t);
+}  // namespace
+
+TEST_CASE("Testing PeriodicTask", "[periodic_task]")
+{
+  using namespace rtos;  // NOLINT
+
+  const char kTaskName[]           = "Test Periodic Task";
+  constexpr Priority kTaskPriority = Priority::kLow;
+
+  RESET_FAKE(xQueueGenericCreateStatic);
+  RESET_FAKE(xQueueSemaphoreTake);
+
+  SECTION("Get periodic semaphore")
+  {
+    xQueueGenericCreateStatic_fake.custom_fake =
+        xQueueGenericCreateStatic_custom_fake;
+    PeriodicTask<512> test_task(kTaskName, kTaskPriority,
+                                PeriodicTaskTestFunction1Hz);
+    CHECK(xQueueGenericCreateStatic_fake.call_count == 1);
+    CHECK(test_task.GetPeriodicSemaphore() == test_semaphore);
+  }
+  SECTION("Get task function")
+  {
+    PeriodicTask<512> test_task(kTaskName, kTaskPriority,
+                                PeriodicTaskTestFunction1Hz);
+    CHECK(test_task.GetTaskFunction() == PeriodicTaskTestFunction1Hz);
+  }
+}
+
+TEST_CASE("Testing PeriodicScheduler", "[periodic_scheduler]")
+{
+  using namespace rtos;  // NOLINT
+
+  constexpr uint8_t kMaxTaskCount = PeriodicScheduler::kMaxTaskCount;
+  constexpr PeriodicTaskFunction kTaskFunctions[] = {
+    PeriodicTaskTestFunction1Hz, PeriodicTaskTestFunction10Hz,
+    PeriodicTaskTestFunction100Hz, PeriodicTaskTestFunction1000Hz
+  };
+  Mock<PeriodicTaskInterface> mock_tasks[kMaxTaskCount];
+  for (uint8_t i = 0; i < kMaxTaskCount; i++)
+  {
+    When(Method(mock_tasks[i], GetPeriodicSemaphore))
+        .AlwaysReturn(test_semaphore);
+    When(Method(mock_tasks[i], GetTaskFunction))
+        .AlwaysReturn(kTaskFunctions[i]);
+  }
+
+  SECTION("Initialization")
+  {
+    PeriodicScheduler scheduler = PeriodicScheduler();
+    CHECK(scheduler.GetPriority() == Priority::kHigh);
+    CHECK(scheduler.GetDelayTime() == 1);
+  }
+  SECTION("Setting and getting a task function")
+  {
+    PeriodicScheduler scheduler = PeriodicScheduler();
+    for (uint8_t i = 0; i < kMaxTaskCount; i++)
+    {
+      PeriodicTaskInterface * task           = &(mock_tasks[i].get());
+      PeriodicScheduler::Frequency frequency = PeriodicScheduler::Frequency(i);
+      scheduler.SetTask(task, frequency);
+      CHECK(scheduler.GetTask(frequency) == task);
+    }
+  }
+}

--- a/firmware/library/L4_Testing/freertos_mocks.cpp
+++ b/firmware/library/L4_Testing/freertos_mocks.cpp
@@ -8,12 +8,22 @@ DEFINE_FAKE_VOID_FUNC(vTaskDelete, TaskHandle_t);
 DEFINE_FAKE_VOID_FUNC(vTaskDelayUntil, TickType_t *, TickType_t);
 DEFINE_FAKE_VOID_FUNC(vApplicationGetIdleTaskMemory, StaticTask_t **,
                       StackType_t **, uint32_t *);
+
 DEFINE_FAKE_VALUE_FUNC(TickType_t, xTaskGetTickCount);
 DEFINE_FAKE_VALUE_FUNC(TaskHandle_t, xTaskCreateStatic, TaskFunction_t,
                        const char *, uint32_t, void *, UBaseType_t,
                        StackType_t *, StaticTask_t *);
+
 DEFINE_FAKE_VALUE_FUNC(EventGroupHandle_t, xEventGroupCreateStatic,
                        StaticEventGroup_t *);
 DEFINE_FAKE_VALUE_FUNC(EventBits_t, xEventGroupSync, EventGroupHandle_t,
                        EventBits_t, EventBits_t, TickType_t);
+
+DEFINE_FAKE_VALUE_FUNC(QueueHandle_t, xQueueGenericCreateStatic,
+                       const UBaseType_t, const UBaseType_t, uint8_t *,
+                       StaticQueue_t *, const uint8_t);
+DEFINE_FAKE_VALUE_FUNC(BaseType_t, xQueueGenericSend, QueueHandle_t,
+                       const void *, TickType_t, BaseType_t);
+DEFINE_FAKE_VALUE_FUNC(BaseType_t, xQueueSemaphoreTake, QueueHandle_t,
+                       TickType_t);
 #endif  // HOST_TEST

--- a/firmware/library/utility/rtos.hpp
+++ b/firmware/library/utility/rtos.hpp
@@ -8,8 +8,10 @@
 #include <cstdint>
 
 #if defined HOST_TEST
-#include "event_groups.h"
 #include "L4_Testing/testing_frameworks.hpp"
+
+#include "event_groups.h"
+#include "semphr.h"
 
 DECLARE_FAKE_VOID_FUNC(vTaskStartScheduler);
 DECLARE_FAKE_VOID_FUNC(vTaskSuspend, TaskHandle_t);
@@ -18,14 +20,23 @@ DECLARE_FAKE_VOID_FUNC(vTaskDelete, TaskHandle_t);
 DECLARE_FAKE_VOID_FUNC(vTaskDelayUntil, TickType_t *, TickType_t);
 DECLARE_FAKE_VOID_FUNC(vApplicationGetIdleTaskMemory, StaticTask_t **,
                        StackType_t **, uint32_t *);
+
 DECLARE_FAKE_VALUE_FUNC(TickType_t, xTaskGetTickCount);
 DECLARE_FAKE_VALUE_FUNC(TaskHandle_t, xTaskCreateStatic, TaskFunction_t,
                         const char *, uint32_t, void *, UBaseType_t,
                         StackType_t *, StaticTask_t *);
+
 DECLARE_FAKE_VALUE_FUNC(EventGroupHandle_t, xEventGroupCreateStatic,
                         StaticEventGroup_t *);
 DECLARE_FAKE_VALUE_FUNC(EventBits_t, xEventGroupSync, EventGroupHandle_t,
                         EventBits_t, EventBits_t, TickType_t);
+
+DECLARE_FAKE_VALUE_FUNC(QueueHandle_t, xQueueGenericCreateStatic, UBaseType_t,
+                        UBaseType_t, uint8_t *, StaticQueue_t *, uint8_t);
+DECLARE_FAKE_VALUE_FUNC(BaseType_t, xQueueGenericSend, QueueHandle_t,
+                        const void *, TickType_t, BaseType_t);
+DECLARE_FAKE_VALUE_FUNC(BaseType_t, xQueueSemaphoreTake, QueueHandle_t,
+                        TickType_t);
 #endif  // HOST_TEST
 
 namespace rtos


### PR DESCRIPTION
- Added PeriodicScheduler class to schedule  tasks to run at 1Hz, 10Hz, 100Hz, and 1000Hz,
- Increased the maximum priority levels for FreeRTOS from 5 to 9 to add 4 more priority
  levels for the periodic tasks.
- Added the following fake functions to rtos.hpp for unit testing:
	- xQueueGenericCreateStatic
	- xQueueGenericSend
	- xQueueSemaphoreTake