### PR TITLE
Ssp Updated Driver

### DIFF
--- a/firmware/examples/Ssp/source/main.cpp
+++ b/firmware/examples/Ssp/source/main.cpp
@@ -1,0 +1,65 @@
+#include "L0_LowLevel/LPC40xx.h"
+#include "L1_Drivers/gpio.hpp"
+#include "L1_Drivers/ssp.hpp"
+#include "utility/log.hpp"
+
+int main(void)
+{
+  constexpr uint8_t kBytesToRead = 4;
+  constexpr uint8_t kReadDeviceId = 0x9F;
+  constexpr uint8_t kPort1 = 1;
+  constexpr uint8_t kPin10 = 10;
+  uint8_t data[kBytesToRead];
+
+  // This application sets up the SSP peripheral as a SPI master and will
+  // interact with the external SPI flash memory chip on the SJ2 board.
+  // Once the connection is established, the LPC master will request the
+  // device ID from the flash memory. NOTE: the flash memory is connected
+  // to SSP2. Device ID (part 1) = 40h; Manufacturer ID = 1Fh.
+  DEBUG_PRINT("SSP Application Starting...");
+
+  // Select SSP1 peripheral
+  DEBUG_PRINT("Setting up peripheral pins: MOSI on Port 1.1.");
+  DEBUG_PRINT("MISO on Port 1.4, and SCK on Port 1.0.");
+  Ssp spi2(Ssp::Peripheral::kSsp2);
+
+  // Set SSP1 as SPI master. Note that the function SetSpiMasterDefault()
+  // could be used instead of SetPeripheralMode() and SetClock().
+  DEBUG_PRINT("Set SSP1 as SPI master.");
+  spi2.SetPeripheralMode(SspInterface::MasterSlaveMode::kMaster,
+                             SspInterface::FrameMode::kSpi,
+                             SspInterface::DataSize::kEight);
+
+  // Set up SPI clock polarity and phase
+  DEBUG_PRINT("MOSI will read low when inactive.");
+  DEBUG_PRINT("SCK will read high when inactive.");
+  spi2.SetClock(1, 1, 2, 0);
+
+  // Initialize SSP
+  DEBUG_PRINT("SSP initialization");
+  spi2.Initialize();
+
+  // Set up chip select as GPIO pin
+  Gpio chip_select(kPort1, kPin10);
+  chip_select.SetAsOutput();
+  chip_select.SetHigh();
+  DEBUG_PRINT("Chip select on Port 1.10 and initialized high.");
+
+  // Get Device ID from flash memory
+  DEBUG_PRINT("Observe the logic analyzer for SPI interaction.");
+  DEBUG_PRINT("Sending command 9Fh to read device ID.");
+  chip_select.SetLow();
+  spi2.Transfer(kReadDeviceId);
+  for (uint8_t i = 0; i < kBytesToRead; i++)
+  {
+    // Cannot read from register until transfer is complete
+    while (spi2.GetTransferStatus())
+    {
+      continue;
+    }
+    data[i] = static_cast<uint8_t>(spi2.Transfer(0));
+  }
+  chip_select.SetHigh();
+  DEBUG_PRINT("Device ID: 0x%.2x", data[1]);
+  DEBUG_PRINT("Manufacturer ID: 0x%.2x", data[0]);
+}

--- a/firmware/examples/Ssp/source/main.cpp
+++ b/firmware/examples/Ssp/source/main.cpp
@@ -16,50 +16,45 @@ int main(void)
   // Once the connection is established, the LPC master will request the
   // device ID from the flash memory. NOTE: the flash memory is connected
   // to SSP2. Device ID (part 1) = 40h; Manufacturer ID = 1Fh.
-  DEBUG_PRINT("SSP Application Starting...");
+  LOG_INFO("SSP Application Starting...");
 
   // Select SSP1 peripheral
-  DEBUG_PRINT("Setting up peripheral pins: MOSI on Port 1.1.");
-  DEBUG_PRINT("MISO on Port 1.4, and SCK on Port 1.0.");
+  LOG_INFO("Setting up peripheral pins: MOSI on Port 1.1.");
+  LOG_INFO("MISO on Port 1.4, and SCK on Port 1.0.");
   Ssp spi2(Ssp::Peripheral::kSsp2);
 
   // Set SSP1 as SPI master. Note that the function SetSpiMasterDefault()
   // could be used instead of SetPeripheralMode() and SetClock().
-  DEBUG_PRINT("Set SSP1 as SPI master.");
+  LOG_INFO("Set SSP1 as SPI master.");
   spi2.SetPeripheralMode(SspInterface::MasterSlaveMode::kMaster,
                              SspInterface::FrameMode::kSpi,
                              SspInterface::DataSize::kEight);
 
   // Set up SPI clock polarity and phase
-  DEBUG_PRINT("MOSI will read low when inactive.");
-  DEBUG_PRINT("SCK will read high when inactive.");
+  LOG_INFO("MOSI will read low when inactive.");
+  LOG_INFO("SCK will read high when inactive.");
   spi2.SetClock(1, 1, 2, 0);
 
   // Initialize SSP
-  DEBUG_PRINT("SSP initialization");
+  LOG_INFO("SSP initialization");
   spi2.Initialize();
 
   // Set up chip select as GPIO pin
   Gpio chip_select(kPort1, kPin10);
   chip_select.SetAsOutput();
   chip_select.SetHigh();
-  DEBUG_PRINT("Chip select on Port 1.10 and initialized high.");
+  LOG_INFO("Chip select on Port 1.10 and initialized high.");
 
   // Get Device ID from flash memory
-  DEBUG_PRINT("Observe the logic analyzer for SPI interaction.");
-  DEBUG_PRINT("Sending command 9Fh to read device ID.");
+  LOG_INFO("Observe the logic analyzer for SPI interaction.");
+  LOG_INFO("Sending command 9Fh to read device ID.");
   chip_select.SetLow();
   spi2.Transfer(kReadDeviceId);
   for (uint8_t i = 0; i < kBytesToRead; i++)
   {
-    // Cannot read from register until transfer is complete
-    while (spi2.GetTransferStatus())
-    {
-      continue;
-    }
     data[i] = static_cast<uint8_t>(spi2.Transfer(0));
   }
   chip_select.SetHigh();
-  DEBUG_PRINT("Device ID: 0x%.2x", data[1]);
-  DEBUG_PRINT("Manufacturer ID: 0x%.2x", data[0]);
+  LOG_INFO("Device ID: 0x%.2x", data[1]);
+  LOG_INFO("Manufacturer ID: 0x%.2x", data[0]);
 }

--- a/firmware/library/L1_Drivers/ssp.hpp
+++ b/firmware/library/L1_Drivers/ssp.hpp
@@ -13,7 +13,7 @@
 /// Note that all register modifications must be made before the SSP
 /// is enabled in the CR1 register (see page 612 of user manual UM10562)
 /// If changes are desired after the Initialize function is called, the
-/// peripheral must be disable, and then re-enabled after changes are made.
+/// peripheral must be disabled, and then re-enabled after changes are made.
 
 #pragma once
 
@@ -61,6 +61,8 @@ class SspInterface
   virtual void Initialize()                     = 0;
   virtual bool GetTransferStatus()              = 0;
   virtual uint16_t Transfer(uint16_t data)      = 0;
+  // virtual void TxData(uint16_t data)            = 0;
+  // virtual uint16_t RxData(uint16_t data)        = 0;
   virtual void SetSpiMasterDefault()            = 0;
   virtual void SetPeripheralMode(MasterSlaveMode mode, FrameMode frame,
                                  DataSize size) = 0;
@@ -125,12 +127,6 @@ class Ssp final : public SspInterface, protected Lpc40xxSystemController
       [MatrixLookup::kMiso] = Pin::CreatePin<1, 4>(),
       [MatrixLookup::kSck]  = Pin::CreatePin<1, 0>() }
   };
-  // static constexpr Lpc40xxSystemController::PeripheralPowerUp kPowerBit[] = {
-  //   Lpc40xxSystemController::PeripheralPowerUp::kSsp0,
-  //   Lpc40xxSystemController::PeripheralPowerUp::kSsp1,
-  //   Lpc40xxSystemController::PeripheralPowerUp::kSsp2,
-  // };
-
   static constexpr Lpc40xxSystemController::PeripheralID kPowerBit[] = {
     Lpc40xxSystemController::Peripherals::kSsp0,
     Lpc40xxSystemController::Peripherals::kSsp1,
@@ -219,6 +215,23 @@ class Ssp final : public SspInterface, protected Lpc40xxSystemController
     }
     return static_cast<uint16_t>(ssp_registers[pssp]->DR);
   }
+
+  /// Transfers a data frame to an external device using the SSP
+  /// data register.
+  /// @param data - information to be placed in data register
+  // void TxData(uint16_t data) override
+  // {
+  //   uint32_t pssp = util::Value(pssp_);
+
+  //   ssp_registers[pssp]->DR = data;
+  // }
+
+  /// Reads a byte of data from the SSP data register.
+  /// @param data - information to be read from data register
+  // uint16_t RxData(uint16_t data) override
+  // {
+  //   return static_cast<uint16_t>(ssp_registers[pssp]->DR);
+  // }
 
   /// Sets up SSP peripheral as SPI master
   void SetSpiMasterDefault() override

--- a/firmware/library/L1_Drivers/ssp.hpp
+++ b/firmware/library/L1_Drivers/ssp.hpp
@@ -1,11 +1,20 @@
-// SSP provides the ability for serial communication over SPI, SSI, or
-// Microwire on the LPC407x chipset. NOTE: The SSP2 peripheral is not
-// available on the SJTwo board, as such this driver does not support
-// it. Only one set of pins are available for either SSP0 or SSP1 as
-// follows:
-//      Peripheral  |   MISO    |   MOSI    |   SCK
-//          SSP0    |   P0.17   |   P0.18   |   P0.15
-//          SSP1    |   P0.8    |   P0.9    |   P0.7
+/// SSP provides the ability for serial communication over SPI, SSI, or
+/// Microwire on the LPC407x chipset. NOTE: The SSP2 peripheral is a
+/// selectable option in this driver, it is not currently available on
+/// the SJTwo board. Only one set of pins are available for either SSP0
+/// or SSP1 as follows:
+///      Peripheral  |   MISO    |   MOSI    |   SCK
+///          SSP0    |   P0.17   |   P0.18   |   P0.15
+///          SSP1    |   P0.8    |   P0.9    |   P0.7
+/// Order of function calls should be as follows:
+///     constructor
+///     setter functions
+///     Initialize
+/// Note that all register modifications must be made before the SSP
+/// is enabled in the CR1 register (see page 612 of user manual UM10562)
+/// If changes are desired after the Initialize function is called, the
+/// peripheral must be disable, and then re-enabled after changes are made.
+
 #pragma once
 
 #include "L0_LowLevel/LPC40xx.h"
@@ -52,12 +61,16 @@ class SspInterface
   virtual void Initialize()                     = 0;
   virtual bool GetTransferStatus()              = 0;
   virtual uint16_t Transfer(uint16_t data)      = 0;
+  virtual void SetSpiMasterDefault()            = 0;
   virtual void SetPeripheralMode(MasterSlaveMode mode, FrameMode frame,
                                  DataSize size) = 0;
+  virtual uint16_t GetPeripheralMode()          = 0;
+
   // NOTE: "divider" is the number of prescaler-output clocks per bit.
   // See page 611 of UM10562 for SCR-Serial Clock Rate for more info.
   virtual void SetClock(bool polarity, bool phase, uint8_t prescaler,
                         uint8_t divider) = 0;
+  virtual uint32_t GetClock()                   = 0;
 };
 
 class Ssp final : public SspInterface, protected Lpc40xxSystemController
@@ -84,7 +97,8 @@ class Ssp final : public SspInterface, protected Lpc40xxSystemController
     kPhaseBit        = 7,
     kDividerBit      = 8,
     kMasterModeBit   = 2,
-    kDataLineIdleBit = 4
+    kDataLineIdleBit = 4,
+    kPrescalerBit    = 0
   };
 
   enum MatrixLookup
@@ -111,13 +125,20 @@ class Ssp final : public SspInterface, protected Lpc40xxSystemController
       [MatrixLookup::kMiso] = Pin::CreatePin<1, 4>(),
       [MatrixLookup::kSck]  = Pin::CreatePin<1, 0>() }
   };
+  // static constexpr Lpc40xxSystemController::PeripheralPowerUp kPowerBit[] = {
+  //   Lpc40xxSystemController::PeripheralPowerUp::kSsp0,
+  //   Lpc40xxSystemController::PeripheralPowerUp::kSsp1,
+  //   Lpc40xxSystemController::PeripheralPowerUp::kSsp2,
+  // };
+
   static constexpr Lpc40xxSystemController::PeripheralID kPowerBit[] = {
     Lpc40xxSystemController::Peripherals::kSsp0,
     Lpc40xxSystemController::Peripherals::kSsp1,
     Lpc40xxSystemController::Peripherals::kSsp2,
   };
 
-  /// Default constructor sets up SSP0 peripheral as SPI master
+  /// Default constructor sets up SSP0 peripheral as SPI master, should
+  /// be followed by SetSpiMasterDefault() function.
   constexpr Ssp()
       : mosi_(&mosi_pin_),
         miso_(&miso_pin_),
@@ -125,19 +146,11 @@ class Ssp final : public SspInterface, protected Lpc40xxSystemController
         mosi_pin_(kSspPinMatrix[0][MatrixLookup::kMosi]),
         miso_pin_(kSspPinMatrix[0][MatrixLookup::kMiso]),
         sck_pin_(kSspPinMatrix[0][MatrixLookup::kSck]),
-        pssp_(Peripheral::kSsp0),
-        master_mode_(kMaster),
-        data_size_(kEight),
-        frame_format_(kSpi),
-        clock_polarity_(1),
-        clock_phase_(0),
-        clock_divider_(0),
-        clock_prescaler_(2)
+        pssp_(Peripheral::kSsp0)
   {
   }
 
-  /// User modified constructor. **MUST** be followed by the setter functions
-  /// for Power, Clock, and Frame format found below.
+  /// User modified constructor. Must be followed by Set functions.
   explicit constexpr Ssp(Peripheral set_pssp)
       : mosi_(&mosi_pin_),
         miso_(&miso_pin_),
@@ -145,19 +158,11 @@ class Ssp final : public SspInterface, protected Lpc40xxSystemController
         mosi_pin_(kSspPinMatrix[util::Value(set_pssp)][MatrixLookup::kMosi]),
         miso_pin_(kSspPinMatrix[util::Value(set_pssp)][MatrixLookup::kMiso]),
         sck_pin_(kSspPinMatrix[util::Value(set_pssp)][MatrixLookup::kSck]),
-        // Must set all these values, default to 0
-        pssp_(set_pssp),
-        master_mode_(static_cast<MasterSlaveMode>(0)),
-        data_size_(static_cast<DataSize>(0)),
-        frame_format_(static_cast<FrameMode>(0)),
-        clock_polarity_(0),
-        clock_phase_(0),
-        clock_divider_(0),
-        clock_prescaler_(0)
+        pssp_(set_pssp)
   {
   }
 
-  /// Constructor to pass in your own pins
+  /// Constructor to pass in your own pins. Must be followed by Set functions.
   constexpr Ssp(Peripheral pssp, PinInterface * mosi_pin,
                 PinInterface * miso_pin, PinInterface * sck_pin)
       : mosi_(mosi_pin),
@@ -166,14 +171,7 @@ class Ssp final : public SspInterface, protected Lpc40xxSystemController
         mosi_pin_(Pin::CreateInactivePin()),
         miso_pin_(Pin::CreateInactivePin()),
         sck_pin_(Pin::CreateInactivePin()),
-        pssp_(pssp),
-        master_mode_(static_cast<MasterSlaveMode>(0)),
-        data_size_(static_cast<DataSize>(0)),
-        frame_format_(static_cast<FrameMode>(0)),
-        clock_polarity_(0),
-        clock_phase_(0),
-        clock_divider_(0),
-        clock_prescaler_(0)
+        pssp_(pssp)
   {
   }
 
@@ -184,57 +182,32 @@ class Ssp final : public SspInterface, protected Lpc40xxSystemController
   {
     uint32_t pssp = static_cast<uint32_t>(pssp_);
 
-    DataSize check_data_size;
-    if (frame_format_ == kMicro)
-    {
-      check_data_size = kEight;
-    }
-    else
-    {
-      check_data_size = data_size_;
-    }
     // Power up peripheral
     PowerUpPeripheral(kPowerBit[pssp]);
-    ssp_registers[pssp]->CPSR &= ~(0xFF);
-    ssp_registers[pssp]->CPSR |= (clock_prescaler_);
 
     // Enable SSP pins
     mosi_->SetPinFunction(kPinSelect[pssp]);
     miso_->SetPinFunction(kPinSelect[pssp]);
     sck_->SetPinFunction(kPinSelect[pssp]);
 
-    // Clear and Set Control Register values
-    ssp_registers[pssp]->CR0 &=
-        ~((0xF << kDataBit) | (0x3 << kFrameBit) | (0x3 << kPolarityBit) |
-          (0xFF << kDividerBit));
-    ssp_registers[pssp]->CR0 |=
-        (check_data_size << kDataBit) | (frame_format_ << kFrameBit);
-
-    // Set clk polarity = 1, clk phase set to 0
-    ssp_registers[pssp]->CR0 |=
-        (clock_polarity_ << kPolarityBit) | (clock_phase_ << kPhaseBit);
-    ssp_registers[pssp]->CR0 |= (clock_divider_ << kDividerBit);
     // Enable SSP
     ssp_registers[pssp]->CR1 |= (1 << 1);
-    // Set SSP as master or slave
-    ssp_registers[pssp]->CR1 &= ~(1 << kMasterModeBit);
-    ssp_registers[pssp]->CR1 |= (master_mode_ << kMasterModeBit);
   }
 
-  // Checks if the SSP controller is idle.
-  // @return 1 - the controller is sending or receiving a data frame.
-  // @return 0 - the controller is idle.
+  /// Checks if the SSP controller is idle.
+  /// @return 1 - the controller is sending or receiving a data frame.
+  /// @return 0 - the controller is idle.
   bool GetTransferStatus() override
   {
     return (ssp_registers[util::Value(pssp_)]->SR & (1 << kDataLineIdleBit));
   }
 
-  // Transfers a data frame to an external device using the SSP
-  // data register. This functions for both transmitting and
-  // receiving data. It is recommended this region be protected
-  // by a mutex.
-  // @param data - information to be placed in data register
-  // @return - received data from external device
+  /// Transfers a data frame to an external device using the SSP
+  /// data register. This functions for both transmitting and
+  /// receiving data. It is recommended this region be protected
+  /// by a mutex.
+  /// @param data - information to be placed in data register
+  /// @return - received data from external device
   uint16_t Transfer(uint16_t data) override
   {
     uint32_t pssp = util::Value(pssp_);
@@ -246,27 +219,113 @@ class Ssp final : public SspInterface, protected Lpc40xxSystemController
     }
     return static_cast<uint16_t>(ssp_registers[pssp]->DR);
   }
-  // Sets the various modes for the Peripheral
-  // @param mode - master or slave mode
-  // @param frame - format for Peripheral data to use
-  // @param size - number of bits per frame
-  void SetPeripheralMode(MasterSlaveMode mode, FrameMode frame,
-                         DataSize size) override
+
+  /// Sets up SSP peripheral as SPI master
+  void SetSpiMasterDefault() override
   {
-    master_mode_  = mode;
-    frame_format_ = frame;
-    data_size_    = size;
+    uint32_t pssp = static_cast<uint32_t>(pssp_);
+
+    // first clear the appropriate register locations
+    ssp_registers[pssp]->CR0 &=
+        ~((0xF << kDataBit) | (0x3 << kFrameBit) | (0x3 << kPolarityBit) |
+        (0xFF << kDividerBit));
+    ssp_registers[pssp]->CR1 &= ~(1 << kMasterModeBit);
+    ssp_registers[pssp]->CPSR &= ~(0xFF);
+
+    // set master mode, 8-bit datasize, and SPI frame
+    ssp_registers[pssp]->CR1 |= (kMaster << kMasterModeBit);
+    ssp_registers[pssp]->CR0 |= (kEight << kDataBit) | (kSpi << kFrameBit);
+
+    // Set clk polarity, clk phase, and SCR divider
+    ssp_registers[pssp]->CR0 |= (0x1 << kPolarityBit) | (0x0 << kPhaseBit);
+    ssp_registers[pssp]->CR0 |= (0x0 << kDividerBit);
+    // Set prescaler
+    ssp_registers[pssp]->CPSR |= (0x2);
   }
 
-  // Sets the clock rate for the Peripheral
-  void SetClock(bool polarity, bool phase, uint8_t divider,
-                uint8_t prescaler) override
+  /// Sets the various modes for the Peripheral
+  /// @param mode - master or slave mode
+  /// @param frame - format for Peripheral data to use
+  /// @param size - number of bits per frame
+  void SetPeripheralMode(MasterSlaveMode mode,
+                        FrameMode frame, DataSize size) override
   {
-    clock_polarity_  = polarity;
-    clock_phase_     = phase;
-    clock_divider_   = divider;
-    clock_prescaler_ = prescaler;
+    uint32_t pssp = static_cast<uint32_t>(pssp_);
+
+    // first clear the appropriate register locations
+    ssp_registers[pssp]->CR0 &= ~((0xF << kDataBit) | (0x3 << kFrameBit));
+    ssp_registers[pssp]->CR1 &= ~(0x1 << kMasterModeBit);
+    // ensure that datasize is set to 8 bits for Micro frame format
+    if (frame == kMicro)
+    {
+      size = kEight;
+    }
+    // set appropriate registers
+    ssp_registers[pssp]->CR1 |= (mode << kMasterModeBit);
+    ssp_registers[pssp]->CR0 |=
+        (size << kDataBit) | (frame << kFrameBit);
   }
+
+  /// Gets the Peripheral modes from registers
+  /// @return - returns a 16-bit value as follows: 0000_000x 0xx0_xxxx
+  ///       MasterSlaveMode = 1-bit @ bit 8
+  ///       FrameMode       = 2-bit @ bit 5
+  ///       DataSize        = 4-bit @ bit 0
+  uint16_t GetPeripheralMode() override
+  {
+    uint16_t return_val = 0;
+    uint32_t pssp = static_cast<uint32_t>(pssp_);
+
+    return_val = static_cast<uint16_t>(
+        (ssp_registers[pssp]->CR0 & (0xF << kDataBit)) +
+        ((ssp_registers[pssp]->CR0 & (0x3 << kFrameBit)) << 5) +
+        ((ssp_registers[pssp]->CR1 & (0x1 << kMasterModeBit)) << 8));
+
+    return return_val;
+  }
+
+  /// Sets the clock rate for the Peripheral
+  /// @param polarity - maintain bus on clock 0=low or 1=high between frames
+  /// @param phase - capture serial data on 0=first or 1=second clock cycle
+  /// @param divider - see notes in SSP_Interface above
+  /// @param prescaler - divides the PCLK, must be even value between 2-254
+  void SetClock(bool polarity, bool phase,
+                uint8_t divider, uint8_t prescaler) override
+  {
+    uint32_t pssp = static_cast<uint32_t>(pssp_);
+
+    // first clear the appropriate registers
+    ssp_registers[pssp]->CR0 &=
+        ~((0x3 << kPolarityBit) | (0xFF << kDividerBit));
+    ssp_registers[pssp]->CPSR &= ~(0xFF);
+
+    // then set appropraite registers
+    ssp_registers[pssp]->CR0 |=
+        (polarity << kPolarityBit) | (phase << kPhaseBit);
+    ssp_registers[pssp]->CR0 |= (divider << kDividerBit);
+    ssp_registers[pssp]->CPSR |= (prescaler);
+  }
+
+  /// Gets the Peripheral clock from registers
+  /// @return - returns a 32-bit value as follows:
+  ///   0000_0000 0000_0x0x xxxx_xxxx xxxx_xxxx
+  ///       polarity    = 1-bit @ bit 18
+  ///       phase       = 1-bit @ bit 16
+  ///       divider     = 8-bits @ bit 8
+  ///       prescaler   = 8-bits @ bit 0
+  uint32_t GetClock() override
+  {
+    uint32_t return_val = 0;
+    uint32_t pssp = static_cast<uint32_t>(pssp_);
+
+    return_val = (ssp_registers[pssp]->CPSR & (0xFF << kPrescalerBit)) +
+        ((ssp_registers[pssp]->CR0 & (0xFF << kDividerBit)) << 8) +
+        ((ssp_registers[pssp]->CR0 & (0x1 << kPhaseBit)) << 16) +
+        ((ssp_registers[pssp]->CR0 & (0x1 << kPolarityBit)) << 18);
+
+    return return_val;
+  }
+
  private:
   PinInterface * mosi_;
   PinInterface * miso_;
@@ -277,14 +336,4 @@ class Ssp final : public SspInterface, protected Lpc40xxSystemController
   Pin sck_pin_;
   // SSP member variables
   Peripheral pssp_;  // SSP interfaces
-  // TODO(#180): Replace following variables with get/set functions
-  MasterSlaveMode master_mode_;
-  DataSize data_size_;      // data size, number of bits
-  FrameMode frame_format_;  // frame format
-  bool clock_polarity_;     // clock polarity
-  bool clock_phase_;        // clock phase
-  // clock_divider_ is the number of prescaler-output clocks per bit
-  // see page 611 of UM10562 for SCR-Serial Clock Rate for more info
-  uint8_t clock_divider_;
-  uint8_t clock_prescaler_;  // clock prescaler
 };

--- a/firmware/library/L1_Drivers/test/ssp_test.cpp
+++ b/firmware/library/L1_Drivers/test/ssp_test.cpp
@@ -1,12 +1,43 @@
+// this is the ssp.hpp test file
+
 #include "L0_LowLevel/LPC40xx.h"
 #include "L1_Drivers/ssp.hpp"
 #include "L4_Testing/testing_frameworks.hpp"
 
 EMIT_ALL_METHODS(Ssp);
 
-TEST_CASE("Ssp", "[ssp]")
+TEST_CASE("Testing SSP", "[Ssp]")
 {
-  SECTION("Initialize")
+  // Simulate local version of LPC_SSP
+  LPC_SSP_TypeDef local_ssp;
+  LPC_SC_TypeDef local_sc;
+
+  // Clear memory locations
+  memset(&local_ssp, 0, sizeof(local_ssp));
+  memset(&local_sc, 0, sizeof(local_sc));
+
+  // Set up Mock for PinCongiure
+  Mock<PinInterface> mock_mosi;
+  Mock<PinInterface> mock_miso;
+  Mock<PinInterface> mock_sck;
+
+  Fake(Method(mock_mosi, CreateInactivePin));
+  Fake(Method(mock_miso, CreateInactivePin));
+  Fake(Method(mock_sck, CreateInactivePin));
+
+  // Set up SSP
+  Ssp::ssp_registers[0] = &local_ssp;
+  Lpc40xxSystemController::system_controller = &local_sc;
+
+  PinInterface &mosi = mock_mosi.get();
+  PinInterface &miso = mock_miso.get();
+  PinInterface &sck = mock_sck.get();
+
+  Ssp test_ssp(Ssp::Peripherals::kSsp0, mosi, miso, sck);
+  test_ssp.SetSpiMasterDefault();
+  test_ssp.Initialize();
+
+  SECTION("Verification")
   {
   }
 }

--- a/firmware/library/L1_Drivers/test/ssp_test.cpp
+++ b/firmware/library/L1_Drivers/test/ssp_test.cpp
@@ -9,35 +9,74 @@ EMIT_ALL_METHODS(Ssp);
 TEST_CASE("Testing SSP", "[Ssp]")
 {
   // Simulate local version of LPC_SSP
-  LPC_SSP_TypeDef local_ssp;
+  LPC_SSP_TypeDef local_ssp[3];
   LPC_SC_TypeDef local_sc;
+  LPC_IOCON_TypeDef local_iocon;
 
   // Clear memory locations
   memset(&local_ssp, 0, sizeof(local_ssp));
   memset(&local_sc, 0, sizeof(local_sc));
+  memset(&local_iocon, 0, sizeof(local_iocon));
+
+  // Set up SSP
+  Ssp::ssp_registers[0] = &local_ssp[0];
+  Lpc40xxSystemController::system_controller = &local_sc;
+  Pin::pin_map = reinterpret_cast<Pin::PinMap_t *>(&local_iocon);
 
   // Set up Mock for PinCongiure
   Mock<PinInterface> mock_mosi;
   Mock<PinInterface> mock_miso;
   Mock<PinInterface> mock_sck;
 
-  Fake(Method(mock_mosi, CreateInactivePin));
-  Fake(Method(mock_miso, CreateInactivePin));
-  Fake(Method(mock_sck, CreateInactivePin));
+  Fake(Method(mock_mosi, SetPinFunction));
+  Fake(Method(mock_miso, SetPinFunction));
+  Fake(Method(mock_sck, SetPinFunction));
 
-  // Set up SSP
-  Ssp::ssp_registers[0] = &local_ssp;
-  Lpc40xxSystemController::system_controller = &local_sc;
+  PinInterface & mosi = mock_mosi.get();
+  PinInterface & miso = mock_miso.get();
+  PinInterface & sck = mock_sck.get();
 
-  PinInterface &mosi = mock_mosi.get();
-  PinInterface &miso = mock_miso.get();
-  PinInterface &sck = mock_sck.get();
-
-  Ssp test_ssp(Ssp::Peripherals::kSsp0, mosi, miso, sck);
+  Ssp test_ssp(Ssp::Peripheral::kSsp0, &mosi, &miso, &sck);
   test_ssp.SetSpiMasterDefault();
   test_ssp.Initialize();
 
-  SECTION("Verification")
+  SECTION("Verify Mode and Frame")
   {
+    constexpr uint8_t kMasterBit = 2;
+    constexpr uint8_t kDataBit = 0;
+    constexpr uint8_t kFrameBit = 4;
+
+    CHECK((local_ssp[0].CR1 & (0x1 << kMasterBit)) ==
+      SspInterface::MasterSlaveMode::kMaster);
+    CHECK((local_ssp[0].CR0 & (0x3 << kFrameBit)) ==
+      SspInterface::FrameMode::kSpi);
+    CHECK((local_ssp[0].CR0 & (0xF << kDataBit)) ==
+      SspInterface::DataSize::kEight);
   }
+
+  SECTION("Verify Clock Polarity and Prescaler")
+  {
+    constexpr uint8_t kPolarityBit = 6;
+    constexpr uint8_t kPolarity = 1;
+    constexpr uint8_t kPrescaleBit = 0;
+    constexpr uint8_t kPrescaler = 2;
+
+    CHECK(((local_ssp[0].CR0 & (0x1 << kPolarityBit)) >> kPolarityBit)
+      == kPolarity);
+    CHECK((local_ssp[0].CPSR & (0xFF << kPrescaleBit)) == kPrescaler);
+  }
+
+  SECTION("Check Transfer Register")
+  {
+    constexpr uint8_t kIdle = 0;
+    constexpr uint8_t kIdleBit = 4;
+
+    CHECK((local_ssp[0].SR & (0x1 << kIdleBit)) == kIdle);
+  }
+
+  Ssp::ssp_registers[0] = LPC_SSP0;
+  Ssp::ssp_registers[1] = LPC_SSP1;
+  Ssp::ssp_registers[2] = LPC_SSP2;
+  Lpc40xxSystemController::system_controller = LPC_SC;
+  Pin::pin_map = reinterpret_cast<Pin::PinMap_t *>(LPC_IOCON);
 }


### PR DESCRIPTION
This updated driver addresses the get/set registers from #180 as well as update/add the example on how to use the driver and unit test.

Unable to incorporate bit fields.