### PR TITLE
Moving from instrument functions to unwind tables

### DIFF
--- a/firmware/Hyperload/project_config.hpp
+++ b/firmware/Hyperload/project_config.hpp
@@ -5,7 +5,6 @@
 
 #define SJ2_ENABLE_ANSI_CODES false
 #define SJ2_SYSTEM_CLOCK_RATE_MHZ 48
-#define SJ2_LOG_INFO_ENABLED true
 #define SJ2_BAUD_RATE 38400
 
 #include "config.hpp"

--- a/firmware/Hyperload/source/main.cpp
+++ b/firmware/Hyperload/source/main.cpp
@@ -16,6 +16,7 @@
 #include "L1_Drivers/uart.hpp"
 #include "L2_HAL/displays/led/onboard_led.hpp"
 #include "L4_Testing/factory_test.hpp"
+#include "utility/build_info.hpp"
 #include "utility/debug.hpp"
 #include "utility/macros.hpp"
 #include "utility/time.hpp"
@@ -24,10 +25,12 @@
 // have been defined.
 //    BOOTLOADER is defined when using "make bootloader"
 //    CLANG_TIDY is defined when using "make tidy"
-#if !defined(BOOTLOADER) && !defined(CLANG_TIDY)
-#error Hyperload must be built as a 'bootloader' and not as an application or \
-       test. Please build this software using 'make bootloader'
-#endif
+
+static_assert(
+    build::kTarget == build::Target::Bootloader ||
+        build::kTarget == build::Target::HostTest,
+    "Hyperload must be built as a 'bootloader' and not as an application or "
+    "test. Please build this software using 'make bootloader'");
 
 namespace
 {

--- a/firmware/library/L0_LowLevel/interrupt.cpp
+++ b/firmware/library/L0_LowLevel/interrupt.cpp
@@ -243,7 +243,6 @@ void DeregisterIsr(IRQn_Type irq)
 }
 
 extern "C"
-[[gnu::no_instrument_function]]
 void GetRegistersFromStack(uint32_t * fault_stack_address)
 {
   // These are volatile to try and prevent the compiler/linker optimizing them

--- a/firmware/library/L0_LowLevel/interrupt.hpp
+++ b/firmware/library/L0_LowLevel/interrupt.hpp
@@ -43,8 +43,8 @@ extern "C" void xPortSysTickHandler(void);  // NOLINT
 // When the application defines a handler (with the same name), the
 // application's handler will automatically take precedence over these weak
 // definitions.
-extern "C" SJ2_IGNORE_STACK_TRACE(void ResetIsr(void));
-extern "C" SJ2_IGNORE_STACK_TRACE(void HardFaultHandler(void));
+extern "C" void ResetIsr(void);
+extern "C" void HardFaultHandler(void);
 extern "C" void InterruptLookupHandler(void);
 
 void RegisterIsr(IRQn_Type irq, IsrPointer isr, bool enable_interrupt = true,

--- a/firmware/library/L0_LowLevel/startup.cpp
+++ b/firmware/library/L0_LowLevel/startup.cpp
@@ -96,15 +96,7 @@ extern "C"
   }
 }
 
-SJ2_IGNORE_STACK_TRACE(void InitializeFreeRTOSSystemTick());
-SJ2_IGNORE_STACK_TRACE(void SetupTimerInterrupt());
-SJ2_IGNORE_STACK_TRACE(void InitDataSection());
-SJ2_IGNORE_STACK_TRACE(void InitBssSection());
-SJ2_IGNORE_STACK_TRACE(void InitFpu());
-SJ2_IGNORE_STACK_TRACE(void __libc_init_array());
-SJ2_IGNORE_STACK_TRACE(void LowLevelInit());
 SJ2_WEAK(void LowLevelInit());
-SJ2_IGNORE_STACK_TRACE(void SystemInit());
 
 // Functions to carry out the initialization of RW and BSS data sections.
 SJ2_SECTION(".after_vectors")

--- a/firmware/library/L0_LowLevel/system_controller.hpp
+++ b/firmware/library/L0_LowLevel/system_controller.hpp
@@ -6,6 +6,7 @@
 #include "project_config.hpp"
 
 #include "L0_LowLevel/LPC40xx.h"
+#include "utility/build_info.hpp"
 #include "utility/enum.hpp"
 #include "utility/log.hpp"
 #include "utility/macros.hpp"
@@ -177,20 +178,26 @@ class Lpc40xxSystemController : public SystemControllerInterface
 
   uint32_t GetPeripheralClockDivider() const override
   {
-#if defined(HOST_TEST)
-    return 1;
-#else
-    return system_controller->PCLKSEL;
-#endif
+    if constexpr (build::kTarget == build::Target::HostTest)
+    {
+      return 1;
+    }
+    else
+    {
+      return system_controller->PCLKSEL;
+    }
   }
 
   uint32_t GetSystemFrequency() const override
   {
-#if defined(HOST_TEST)
-    return config::kSystemClockRate;
-#else
-    return speed_in_hertz;
-#endif
+    if constexpr (build::kTarget == build::Target::HostTest)
+    {
+      return config::kSystemClockRate;
+    }
+    else
+    {
+      return speed_in_hertz;
+    }
   }
 
   uint32_t GetPeripheralFrequency() const override

--- a/firmware/library/config.hpp
+++ b/firmware/library/config.hpp
@@ -90,10 +90,17 @@ static_assert(4'800 <= kBaudRate && kBaudRate <= 4'000'000 &&
 #endif  // !defined(SJ2_INCLUDE_BACKTRACE)
 SJ2_DECLARE_CONSTANT(INCLUDE_BACKTRACE, bool, kIncludeBacktrace);
 
-#if !defined(SJ2_LOG_INFO_ENABLED)
-#define SJ2_LOG_INFO_ENABLED true
-#endif  // !defined(SJ2_LOG_INFO_ENABLED)
-SJ2_DECLARE_CONSTANT(LOG_INFO_ENABLED, bool, kDebugPrintEnabled);
+/// Used to offset the returned addresses from the libunwind GetIP function
+/// (get instruction pointer), in order to properly identify the line of code
+/// that caused the debug::PrintStackTrace function to be called. GetIP will
+/// retrieve the next instruction after a function has returned, which usually
+/// results in the file lookup showing the line right after the function was
+/// called. To fix this on ARM platforms, subtract 4 from the address pointer
+/// to move 1 line up to the exact call site.
+#if !defined(SJ2_BACKTRACE_ADDRESS_OFFSET)
+#define SJ2_BACKTRACE_ADDRESS_OFFSET 4
+#endif  // !defined(SJ2_BACKTRACE_ADDRESS_OFFSET)
+SJ2_DECLARE_CONSTANT(BACKTRACE_ADDRESS_OFFSET, size_t, kBacktraceAddressOffset);
 
 /// Used to set the default scheduler size for the TaskScheduler.
 #if !defined(SJ2_TASK_SCHEDULER_SIZE)

--- a/firmware/library/newlib/newlib.cpp
+++ b/firmware/library/newlib/newlib.cpp
@@ -157,30 +157,4 @@ extern "C"
     out('\n');
     return i;
   }
-
-  // =============================
-  // Backtrace Utility Functions
-  // =============================
-  void * stack_trace[config::kBacktraceDepth] = { nullptr };
-  size_t stack_depth = 0;
-
-  void __cyg_profile_func_enter(void *, void * call_site)  // NOLINT
-  {
-    stack_trace[stack_depth++] = call_site;
-  }
-
-  void __cyg_profile_func_exit(void *, void *)  // NOLINT
-  {
-    stack_depth--;
-  }
-}
-
-void ** GetStackTrace()
-{
-  return stack_trace;
-}
-
-size_t GetStackDepth()
-{
-  return stack_depth;
 }

--- a/firmware/library/newlib/newlib.hpp
+++ b/firmware/library/newlib/newlib.hpp
@@ -9,13 +9,3 @@ extern Stdout out;
 
 using Stdin = int (*)();
 extern Stdin in;
-
-void ** GetStackTrace();
-size_t GetStackDepth();
-
-// Not ignoring the profile functions within the stack trace will result in
-// an recursive loop.
-extern "C"
-SJ2_IGNORE_STACK_TRACE(void __cyg_profile_func_enter(void*, void*));  // NOLINT
-extern "C"
-SJ2_IGNORE_STACK_TRACE(void __cyg_profile_func_exit(void*, void*));  // NOLINT

--- a/firmware/library/utility/build_info.hpp
+++ b/firmware/library/utility/build_info.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#if !defined(TARGET)
+#define TARGET Application
+#endif
+
+namespace build
+{
+
+enum class Target
+{
+  Bootloader = 0,  // NOLINT
+  Application,  // NOLINT
+  HostTest,  // NOLINT
+};
+
+constexpr const Target kTarget = Target::TARGET;
+
+constexpr const char * Stringify(Target target)
+{
+  const char * result = "";
+  switch (target)
+  {
+    case Target::Bootloader:
+      result = "bootloader";
+      break;
+    case Target::Application:
+      result = "application";
+      break;
+    case Target::HostTest:
+      result = "host test";
+      break;
+    default:
+      break;
+  }
+  return result;
+}
+
+}  // namespace build
+

--- a/firmware/library/utility/debug.hpp
+++ b/firmware/library/utility/debug.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unwind.h>
+
 #include <cctype>
 #include <cinttypes>
 #include <cstdint>
@@ -9,11 +11,14 @@
 #include "config.hpp"
 #include "newlib/newlib.hpp"
 #include "utility/ansi_terminal_codes.hpp"
+#include "utility/build_info.hpp"
 #include "utility/macros.hpp"
 
 namespace debug
 {
-// Hexdump Utility Functions
+// =====================================
+// Hidden utility functions for Hexdump
+// =====================================
 static inline void PrintCharacterRow(uint8_t * bytes, size_t length)
 {
   putchar('|');
@@ -51,6 +56,25 @@ static inline void PrintHexBytesRow(uint8_t * bytes, size_t length)
   putchar(' ');
 }
 
+/// Similiar to the UNIX hexdump program, this function will read the bytes from
+/// the starting address and print them in hex. Any characters that can be
+/// translated into a viewable character will be display.
+///
+/// Example Usage:
+///
+///   char some_string[] = "Hello World, and Goodbye World!\n";
+///   // Subtract 1 to ignore null character
+///   debug::Hexdump(some_string, sizeof(some_string) - 1);
+///
+/// Output:
+/*
+  00000000  48 65 6c 6c 6f 20 57 6f  72 6c 64 2c 20 61 6e 64  |Hello World, and|
+  00000010  20 47 6f 6f 64 62 79 65  20 57 6f 72 6c 64 21 0a  | Goodbye World!.|
+  00000020
+*/
+///
+/// @param address - location to start reading bytes from
+/// @param length - the number of bytes to read from the starting location
 inline void Hexdump(void * address, uint32_t length)
 {
   uint8_t * bytes = static_cast<uint8_t *>(address);
@@ -64,49 +88,65 @@ inline void Hexdump(void * address, uint32_t length)
   printf("%08" PRIX32 "  \n", length);
 }
 
-[[gnu::no_instrument_function]]
+// ==============================================
+// Hidden Backtrace Utility Functions
+// ==============================================
+static inline _Unwind_Reason_Code PrintAddressAsList(_Unwind_Context * context,
+                                                     void * depth_pointer)
+{
+  int * depth      = static_cast<int *>(depth_pointer);
+  intptr_t address = static_cast<intptr_t>(_Unwind_GetIP(context));
+  printf("  %d) 0x%08" PRIXPTR "\n", *depth,
+         address - config::kBacktraceAddressOffset);
+  (*depth)++;
+  return _URC_NO_REASON;
+}
+static inline _Unwind_Reason_Code PrintAddressInRow(_Unwind_Context * context,
+                                                    void * depth_pointer)
+{
+  int * depth      = static_cast<int *>(depth_pointer);
+  intptr_t address = static_cast<intptr_t>(_Unwind_GetIP(context));
+  printf(" 0x%08" PRIXPTR, address - config::kBacktraceAddressOffset);
+  (*depth)++;
+  return _URC_NO_REASON;
+}
+/// Similiar to the UNIX hexdump program, this function will read the bytes from
+/// the starting address and print them in hex. Any characters that can be
+/// translated into a viewable character will be display.
+///
+/// Example Usage:
+///
+///   debug::PrintBacktrace();
+///
+/// @param show_make_command - if true, print the make command that can be used
+///        to print the file and line number that corrisponds to the printed
+///        addresses.
+/// @param length - the number of bytes to read from the starting location
 inline void PrintBacktrace(bool show_make_command = false,
                            void * final_address   = nullptr)
 {
-  printf("Stack Depth = %zd\n", GetStackDepth());
-  // stack_depth-1 to ignore PrintBacktrace()
-  // PrintBacktrace shouldn't be ignored in profiling because it causes
-  // the exit to still fire, which can result in a negative stack_depth
-  void ** list_of_called_functions = GetStackTrace();
-  size_t stack_depth               = GetStackDepth();
-  // Ignore the last function as it is the Backtrace function
-  for (size_t pos = 0; pos < stack_depth - 1; pos++)
+  int depth = 0;
+
+  _Unwind_Backtrace(&PrintAddressAsList, &depth);
+  if (final_address)
   {
-    printf("  #%zu: 0x%p\n", pos, list_of_called_functions[pos]);
+    printf("  %d) 0x%p\n", depth, final_address);
   }
-  if (final_address != nullptr)
-  {
-    printf("  #%zu: 0x%p\n", stack_depth - 1, final_address);
-  }
+
   if (show_make_command)
   {
-    constexpr const char kBuildType[] =
-#if defined(APPLICATION)
-        "application";
-#else
-        "bootloader";
-#endif
-    puts("\nRun: the following command in your project directory");
-    printf("\n  " SJ2_BOLD_WHITE "make stacktrace-%s TRACES=\"", kBuildType);
-    for (size_t pos = 0; pos < stack_depth - 1; pos++)
-    {
-      if (pos != 0)
-      {
-        putchar(' ');
-      }
-      printf("0x%p", list_of_called_functions[pos]);
-    }
-    if (final_address != nullptr)
+    printf("\nRun: the following command in your project directory");
+    printf("\n\n  " SJ2_BOLD_WHITE);
+    printf("make stacktrace-%s TRACES=\"", Stringify(build::kTarget));
+
+    _Unwind_Backtrace(&PrintAddressInRow, &depth);
+    if (final_address)
     {
       printf(" 0x%p", final_address);
     }
-    puts("\"\n" SJ2_COLOR_RESET);
-    puts(
+
+    printf("\"\n\n" SJ2_COLOR_RESET);
+    printf(
         "This will report the file and line number that led to this function "
         "being called.");
   }

--- a/firmware/library/utility/macros.hpp
+++ b/firmware/library/utility/macros.hpp
@@ -44,11 +44,6 @@ inline void UsedVariadicFunction(...) {}
 #define SJ2_STRINGIFY2(s) #s
 /// SJ2_PACKED give a specified type a packed attribute
 #define SJ2_PACKED(type) type __attribute__((packed))
-// SJ2_IGNORE_STACK_TRACE will remove function profiling for this
-// specific function which means it will not be recoreded in the stack_trace
-// array and will not show up when a SJ2_DUMP_BACKTRACE() is called.
-#define SJ2_IGNORE_STACK_TRACE(function) \
-  function __attribute__((no_instrument_function))
 /// Set a function as a "weak" function. This means that if there is another
 /// declaration of this exact function somewhere else in the software, the
 /// non-weak function will be used instead of the weak function.

--- a/firmware/library/utility/time.hpp
+++ b/firmware/library/utility/time.hpp
@@ -84,7 +84,7 @@ inline void Delay([[maybe_unused]] uint64_t delay_time_ms)
 #endif  // HOST_TEST
 }
 // Halt system by putting it into infinite loop
-SJ2_FUNCTION_INLINE(SJ2_IGNORE_STACK_TRACE(inline void Halt()));
+SJ2_FUNCTION_INLINE(inline void Halt());
 inline void Halt()
 {
   while (true)


### PR DESCRIPTION
Instrument functions has a linear growth increase with the number
of functions created, where unwind has a constant amount of RAM.

Removed SJ2_ macro that removes instrumentation as well as
instrumentation functions.

Resolves #404 