### PR TITLE
Optimized I2C Handler template

### DIFF
--- a/firmware/library/L1_Drivers/i2c.hpp
+++ b/firmware/library/L1_Drivers/i2c.hpp
@@ -139,13 +139,19 @@ class I2c final : public I2cInterface, protected Lpc40xxSystemController
                                                           [kI2c1] = LPC_I2C1,
                                                           [kI2c2] = LPC_I2C2 };
 
+
   template <Port port>
   static void I2cHandler()
   {
-    static constexpr uint8_t kPort = util::Value(port);
-    MasterState state              = MasterState(i2c[kPort]->STAT);
-    uint32_t clear_mask            = 0;
-    uint32_t set_mask              = 0;
+    I2cHandler(port);
+  }
+
+  static void I2cHandler(Port port)
+  {
+    const uint8_t kPort       = util::Value(port);
+    MasterState state   = MasterState(i2c[kPort]->STAT);
+    uint32_t clear_mask = 0;
+    uint32_t set_mask   = 0;
     switch (state)
     {
       case MasterState::kBusError:  // 0x00


### PR DESCRIPTION
Reduced example/I2C from 34688 bytes -> 32192 bytes (2496 bytes)
by implementing the templated I2CHandler as a handoff to a static
I2CHandler that takes a port argument.

This is more efficent since the statemachine doesn't have to be created
for each i2c port, but simply a function that passes the port number for
that i2c port into the static handler.

Resolves #402