### PR TITLE
Adding ADC powerup to ADC driver LPC40xx

### DIFF
--- a/firmware/HelloWorld/project.mk
+++ b/firmware/HelloWorld/project.mk
@@ -3,4 +3,4 @@
 # If you require a source .cpp file to be linked into the test executable as
 # well, add it to the USER_TESTS list as well.
 USER_TESTS += $(LIB_DIR)/utility/test/bit_test.cpp
-USER_TESTS += $(LIB_DIR)/L1_Drivers/test/pin_test.cpp
+USER_TESTS += $(LIB_DIR)/L1_Drivers/test/adc_test.cpp

--- a/firmware/examples/Adc/source/main.cpp
+++ b/firmware/examples/Adc/source/main.cpp
@@ -1,0 +1,39 @@
+#include <cstdint>
+
+#include "L1_Drivers/adc.hpp"
+#include "utility/log.hpp"
+#include "utility/map.hpp"
+#include "utility/time.hpp"
+
+int main(void)
+{
+  LOG_INFO("Analog-to-Ditial Application Starting...");
+
+  LOG_INFO("Creating Adc object and selecting ADC channel 0");
+  LOG_INFO("ADC channel 0 is connected to pin P0.23");
+  Adc adc0(Adc::Channel::kChannel0);
+  LOG_INFO("Initializing ADC ...");
+  adc0.Initialize();
+  LOG_INFO("Initializing ADC Complete!");
+  LOG_INFO("Enabling ADC to burst mode!");
+  LOG_INFO(
+      "Burst mode is useful in that you do not need to turn on conversion. You "
+      "simply need to run the ReadResult() method!");
+  adc0.BurstMode(true);
+
+  LOG_INFO(
+      "Apply a voltage from 0 to 3.3V (BE SUPER SURE not to accidently apply "
+      "more then 3.3V or you WILL damage your board).");
+
+  while (true)
+  {
+    uint16_t adc_digital_value = adc0.ReadResult();
+    // For the LPC40xx with a 12-bit ADC, lowest and highest values are 0 to
+    // 1023, where as the lowest and highest voltages are between 0 and 3.3V
+    float voltage = Map(adc_digital_value, 0, 1023, 0.0f, 3.3f);
+    LOG_INFO("Voltage on pin P0.23 = %f, raw value = %u\n",
+             static_cast<double>(voltage), adc_digital_value);
+    Delay(250);
+  }
+  return 0;
+}

--- a/firmware/library/utility/map.hpp
+++ b/firmware/library/utility/map.hpp
@@ -35,7 +35,7 @@
 ///
 /// Mapping equation is as follows:
 ///
-///               /                    (max - min)     \
+///               /                    (max - min)     \_
 ///      value = | (value - min) x -------------------  | + new_min
 ///               \                (new_max - new_min) /
 ///
@@ -45,7 +45,7 @@
 /// @param new_minimum the new minimum value to scale and shift the old value to
 /// @param new_maximum the new maximum value to scale and shift the old value to
 template <typename Input, typename Range, typename NewRange>
-[[gnu::always_inline]] NewRange Map(Input value, Range min, Range max,
+NewRange Map(Input value, Range min, Range max,
                                     NewRange new_min, NewRange new_max) {
   static_assert(std::is_arithmetic<Input>::value,
                 "Input value variable type must be an arithmetic type (like "

--- a/makefile
+++ b/makefile
@@ -184,12 +184,10 @@ endif
 # Set of ALL compilable test files in the current library.
 # This also includes any source AND test to be tested.
 # MUST NOT contain source files that contain a "main()" implementation
-# TODO(#296): Add a seperation between library and user tests
 TESTS ?=
 # Set of compilable test files specified by the user.
 # This also includes any source AND test to be tested.
 # MUST NOT contain source files that contain a "main()" implementation
-# TODO(#296): Add a seperation between library and user tests
 USER_TESTS ?=
 # Include a project specific makefile. Using -include to keep make form exiting
 # if the project.mk file does not exist.
@@ -211,8 +209,6 @@ endif
 INCLUDES         := $(addsuffix ", $(addprefix -I", $(INCLUDES)))
 SYSTEM_INCLUDES  := $(addsuffix ", $(addprefix -idirafter", $(SYSTEM_INCLUDES)))
 OBJECTS           = $(addprefix $(OBJECT_DIR)/, $(COMPILABLES:=.o))
-# TEST_OBJECTS      = $(addprefix $(OBJECT_DIR)/, $(TESTS:=.o))
-# USER_TEST_OBJECTS = $(addprefix $(OBJECT_DIR)/, $(USER_TESTS:=.o))
 
 # ===========================
 # Compilation Flags
@@ -220,8 +216,9 @@ OBJECTS           = $(addprefix $(OBJECT_DIR)/, $(COMPILABLES:=.o))
 CORTEX_M4F = -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 			       -fabi-version=0 -mtpcs-frame -mtpcs-leaf-frame
 OPTIMIZE  = -O$(OPT) -fmessage-length=0 -ffunction-sections -fdata-sections \
-            -fno-exceptions -fno-omit-frame-pointer -fasynchronous-unwind-tables
-CPPOPTIMIZE = -fno-rtti
+            -fno-exceptions -fno-omit-frame-pointer \
+            -fasynchronous-unwind-tables
+CPPOPTIMIZE = -fno-rtti -fno-threadsafe-statics
 DEBUG     = -g
 WARNINGS  = -Wall -Wextra -Wshadow -Wlogical-op -Wfloat-equal \
             -Wdouble-promotion -Wduplicated-cond -Wswitch \


### PR DESCRIPTION
Also adding -fno-threadsafe-statics as the architcture does not support
stdc++ thread libraries.

Also cleaning up register manipulation to use register bitfields.

Cleaning up/simplifying clock division code.

Resolves #286