### PR TITLE
Giving direct path to clang llvm-cov in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
           dist: xenial
           after_success:
             - cd ../../
-            - coveralls --gcov "$(pwd)/tools/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04/bin/llvm-cov"
+            - coveralls --gcov "$(pwd)/tools/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04/bin/llvm-cov gcov"
               --include "firmware/library/L0_LowLevel"
               --include "firmware/library/L1_Drivers"
               --include "firmware/library/Utility"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
           dist: xenial
           after_success:
             - cd ../../
-            - coveralls --gcov $(which gcov-7)
+            - coveralls --gcov "$(pwd)/tools/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04/bin/llvm-cov"
               --include "firmware/library/L0_LowLevel"
               --include "firmware/library/L1_Drivers"
               --include "firmware/library/Utility"


### PR DESCRIPTION
This should fix the Travis not sending coverage report to coveralls