### PR TITLE
Speed up compilation with precompiled static libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 firmware/*
 firmware/**/build
 firmware/**/makefile
+firmware/library/static_libraries
 
 !firmware/library
 !firmware/HelloWorld

--- a/firmware/HelloWorld/project_config.hpp
+++ b/firmware/HelloWorld/project_config.hpp
@@ -3,6 +3,6 @@
 // options you can change.
 #pragma once
 
-#define SJ2_ENABLE_ANSI_CODES true
+#define SJ2_LOG_LEVEL SJ2_LOG_LEVEL_DEBUG
 
 #include "config.hpp"

--- a/firmware/library/L0_LowLevel/L0.mk
+++ b/firmware/library/L0_LowLevel/L0.mk
@@ -2,9 +2,12 @@ INCLUDES += $(LIB_DIR)/L0_LowLevel/SystemFiles
 
 SYSTEM_INCLUDES +=
 
-SOURCES += $(LIB_DIR)/L0_LowLevel/startup.cpp
-SOURCES += $(LIB_DIR)/L0_LowLevel/interrupt.cpp
+LIBRARY_LPC40XX += $(LIB_DIR)/L0_LowLevel/startup.cpp
+LIBRARY_LPC40XX += $(LIB_DIR)/L0_LowLevel/interrupt.cpp
 
 TESTS += $(LIB_DIR)/L0_LowLevel/interrupt.cpp
 TESTS += $(LIB_DIR)/L0_LowLevel/test/interrupt_test.cpp
 TESTS += $(LIB_DIR)/L0_LowLevel/test/system_controller_test.cpp
+
+# TODO(#435): Consider adding this library, but also for each platform
+$(eval $(call BUILD_LIRBARY,liblpc40xx,LIBRARY_LPC40XX))

--- a/firmware/library/L0_LowLevel/ram.hpp
+++ b/firmware/library/L0_LowLevel/ram.hpp
@@ -1,4 +1,3 @@
-// TODO(kammce): rename this file to ram.hpp
 #pragma once
 #include <cstdint>
 #include "utility/macros.hpp"

--- a/firmware/library/L3_Application/L3.mk
+++ b/firmware/library/L3_Application/L3.mk
@@ -1,5 +1,6 @@
 INCLUDES +=
 SYSTEM_INCLUDES +=
+
 SOURCES += $(LIB_DIR)/L3_Application/task_scheduler.cpp
 
 TESTS += $(LIB_DIR)/L3_Application/task_scheduler.cpp

--- a/firmware/library/newlib/newlib.cpp
+++ b/firmware/library/newlib/newlib.cpp
@@ -3,6 +3,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <cstdarg>
 #include <cstdint>
 #include <cstdio>
 
@@ -158,3 +159,17 @@ extern "C"
     return i;
   }
 }
+
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+// The newlib nano version of scanf relies on malloc.
+// Overriding scanf with an efficient static memory variant.
+// NOLINTNEXTLINE(readability-identifier-naming)
+int scanf(const char * format, ...)
+{
+  va_list args;
+  va_start(args, format);
+  int items = vfscanf(stdin, format, args);
+  va_end(args);
+  return items;
+}
+#pragma GCC diagnostic warning "-Wformat-nonliteral"

--- a/firmware/library/newlib/newlib.mk
+++ b/firmware/library/newlib/newlib.mk
@@ -1,8 +1,10 @@
 INCLUDES +=
 SYSTEM_INCLUDES +=
 
-SOURCES += $(LIB_DIR)/newlib/newlib.cpp
-SOURCES += $(LIB_DIR)/newlib/scanf.cpp
+LIBRARY_NEWLIB += $(LIB_DIR)/newlib/newlib.cpp
 
 TESTS += $(LIB_DIR)/newlib/newlib.cpp
 TESTS += $(LIB_DIR)/newlib/scanf.cpp
+
+# TODO(#435): Consider adding this library to static libraries
+$(eval $(call BUILD_LIRBARY,libnewlib,LIBRARY_NEWLIB))

--- a/firmware/library/newlib/scanf.cpp
+++ b/firmware/library/newlib/scanf.cpp
@@ -1,16 +1,1 @@
-#include <cstdarg>
-#include <cstdio>
 
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-// nano.spec version of scanf relies on malloc.
-// Overriding scanf with an efficient static memory variant.
-// NOLINTNEXTLINE(readability-identifier-naming)
-int scanf(const char * format, ...)
-{
-  va_list args;
-  va_start(args, format);
-  int items = vfscanf(stdin, format, args);
-  va_end(args);
-  return items;
-}
-#pragma GCC diagnostic warning "-Wformat-nonliteral"

--- a/firmware/library/third_party/FreeRTOS/freertos.mk
+++ b/firmware/library/third_party/FreeRTOS/freertos.mk
@@ -3,12 +3,14 @@ SYSTEM_INCLUDES += $(LIB_DIR)/third_party/FreeRTOS/Source/trace
 SYSTEM_INCLUDES += $(LIB_DIR)/third_party/FreeRTOS/Source/portable
 SYSTEM_INCLUDES += $(LIB_DIR)/third_party/FreeRTOS/Source/portable/GCC/ARM_CM4F
 
-SOURCES += $(LIB_DIR)/third_party/FreeRTOS/Source/timers.c
-SOURCES += $(LIB_DIR)/third_party/FreeRTOS/Source/event_groups.c
-SOURCES += $(LIB_DIR)/third_party/FreeRTOS/Source/stream_buffer.c
-SOURCES += $(LIB_DIR)/third_party/FreeRTOS/Source/list.c
-SOURCES += $(LIB_DIR)/third_party/FreeRTOS/Source/croutine.c
-SOURCES += $(LIB_DIR)/third_party/FreeRTOS/Source/tasks.c
-SOURCES += $(LIB_DIR)/third_party/FreeRTOS/Source/queue.c
-SOURCES += $(LIB_DIR)/third_party/FreeRTOS/Source/portable/GCC/ARM_CM4F/port.c
-SOURCES += $(LIB_DIR)/third_party/FreeRTOS/Source/portable/MemMang/heap_3.c
+LIBRARY_FREERTOS += $(LIB_DIR)/third_party/FreeRTOS/Source/timers.c
+LIBRARY_FREERTOS += $(LIB_DIR)/third_party/FreeRTOS/Source/event_groups.c
+LIBRARY_FREERTOS += $(LIB_DIR)/third_party/FreeRTOS/Source/stream_buffer.c
+LIBRARY_FREERTOS += $(LIB_DIR)/third_party/FreeRTOS/Source/list.c
+LIBRARY_FREERTOS += $(LIB_DIR)/third_party/FreeRTOS/Source/croutine.c
+LIBRARY_FREERTOS += $(LIB_DIR)/third_party/FreeRTOS/Source/tasks.c
+LIBRARY_FREERTOS += $(LIB_DIR)/third_party/FreeRTOS/Source/queue.c
+LIBRARY_FREERTOS += $(LIB_DIR)/third_party/FreeRTOS/Source/portable/MemMang/heap_3.c
+LIBRARY_FREERTOS += $(LIB_DIR)/third_party/FreeRTOS/Source/portable/GCC/ARM_CM4F/port.c
+
+$(eval $(call BUILD_LIRBARY,libfreertos,LIBRARY_FREERTOS))

--- a/firmware/library/third_party/fatfs/fatfs.mk
+++ b/firmware/library/third_party/fatfs/fatfs.mk
@@ -1,6 +1,8 @@
 SYSTEM_INCLUDES +=$(LIB_DIR)/third_party/fatfs/source/
 
 SOURCES += $(LIB_DIR)/third_party/fatfs/source/diskio.cpp
-SOURCES += $(LIB_DIR)/third_party/fatfs/source/ff.c
-SOURCES += $(LIB_DIR)/third_party/fatfs/source/ffsystem.c
-SOURCES += $(LIB_DIR)/third_party/fatfs/source/ffunicode.c
+LIBRARY_FATFS += $(LIB_DIR)/third_party/fatfs/source/ff.c
+LIBRARY_FATFS += $(LIB_DIR)/third_party/fatfs/source/ffsystem.c
+LIBRARY_FATFS += $(LIB_DIR)/third_party/fatfs/source/ffunicode.c
+
+$(eval $(call BUILD_LIRBARY,libfatfs,LIBRARY_FATFS))

--- a/firmware/library/third_party/microrl/microrl.mk
+++ b/firmware/library/third_party/microrl/microrl.mk
@@ -1,6 +1,8 @@
 INCLUDES +=
 SYSTEM_INCLUDES +=
 
-SOURCES += $(LIB_DIR)/third_party/microrl/microrl.cpp
+LIBRARY_MICRORL += $(LIB_DIR)/third_party/microrl/microrl.cpp
 
 TESTS +=
+
+$(eval $(call BUILD_LIRBARY,libmicrorl,LIBRARY_MICRORL))

--- a/firmware/library/third_party/printf/printf.cpp
+++ b/firmware/library/third_party/printf/printf.cpp
@@ -32,7 +32,6 @@
 
 // SJSU-Dev2: Added config to define PRINTF_SUPPORT_FLOAT,
 // PRINTF_SUPPORT_LONG_LONG, PRINTF_SUPPORT_PTRDIFF_T
-#include "config.hpp"
 #include <stdbool.h>
 #include <stdint.h>
 #include "printf.h"

--- a/firmware/library/third_party/printf/printf.mk
+++ b/firmware/library/third_party/printf/printf.mk
@@ -2,6 +2,8 @@ INCLUDES +=
 
 SYSTEM_INCLUDES += $(LIB_DIR)/third_party/printf/
 
-SOURCES += $(LIB_DIR)/third_party/printf/printf.cpp
-
 TESTS += $(LIB_DIR)/third_party/printf/printf.cpp
+
+LIBRARY_PRINTF += $(LIB_DIR)/third_party/printf/printf.cpp
+
+$(eval $(call BUILD_LIRBARY,libprintf,LIBRARY_PRINTF))

--- a/firmware/library/utility/macros.hpp
+++ b/firmware/library/utility/macros.hpp
@@ -4,7 +4,6 @@
 /// across the SJSU-Dev2 environment.
 /// @{
 #pragma once
-#include "config.hpp"
 // SJ2_SECTION will place a variable or function within a given section of the
 // executable. It uses both attribute "section" and "used". Section attribute
 // places variable/function into that section and "used" labels the symbol as

--- a/tools/presubmit.sh
+++ b/tools/presubmit.sh
@@ -12,60 +12,60 @@ SJBASE=$(cd "$SJBASE/.." ; pwd -P)
 
 function print_divider
 {
-    printf "\e[1;33m======================================================= "
-    printf "\e[0m\n\n"
+  printf "\e[1;33m======================================================= "
+  printf "\e[0m\n\n"
 }
 
 function print_status
 {
-    if [ $1 -ne 0 ]
-    then
-        printf "\e[31m✘\e[0;31m"
-    else
-        printf "\e[32m✔\e[0;31m"
-    fi
+  if [ $1 -ne 0 ]
+  then
+    printf "\e[31m✘\e[0;31m"
+  else
+    printf "\e[32m✔\e[0;31m"
+  fi
 }
 
 function check
 {
-    if [ $1 -ne 0 ]
-        then
-        lint="$(print_status $LINT_CAPTURE)"
-        commit="$(print_status $STATUS_CAPTURE)"
-        test="$(print_status $TEST_CAPTURE)"
-        tidy="$(print_status $TIDY_CAPTURE)"
-        build="$(print_status $BUILD_CAPTURE)"
-        printf "\e[0;31m ================================ \e[0m\n"
-        printf "\e[1;31m|        None of this!           |\e[0m\n"
-        printf "\e[1;31m|                                |\e[0m\n"
-        printf "\e[1;31m|        (╯°□ °)╯︵ ┻━┻          |\e[0m\n"
-        printf "\e[1;31m|                                |\e[0m\n"
-        printf "\e[1;31m|      Don't even PUSH!          |\e[0m\n"
-        printf "\e[0;31m ================================ \e[0m\n"
-        printf "\e[0;31m|                                |\e[0m\n"
-        printf "\e[0;31m| Code style must be lint free %b |\e[0m\n" $lint
-        printf "\e[0;31m|    Code style must be tidy %b   |\e[0m\n" $tidy
-        printf "\e[0;31m|     Commit must be clean %b     |\e[0m\n" $commit
-        printf "\e[0;31m|       Tests must pass %b        |\e[0m\n" $test
-        printf "\e[0;31m|       Code must build %b        |\e[0m\n" $build
-        printf "\e[0;31m|                                |\e[0m\n"
-        printf "\e[0;31m ================================ \e[0m\n"
-        exit 1
-    else
-        printf "\e[0;32m ============================ \e[0m\n"
-        printf "\e[0;32m| Everything looks good here |\e[0m\n"
-        printf "\e[0;32m|                            |\e[0m\n"
-        printf "\e[0;32m|           (•_•)            |\e[0m\r"
-        sleep .5
-        printf "\e[0;32m|           ( •_•)>⌐▪-▪      |\e[0m\r"
-        sleep .5
-        printf "\e[0;32m|           (⌐▪_▪)           |\e[0m\n"
-        sleep .5
-        printf "\e[0;32m|                            |\e[0m\n"
-        printf "\e[0;32m|      You may commit        |\e[0m\n"
-        printf "\e[0;32m ============================ \e[0m\n"
-        exit 0
-    fi
+  if [ $1 -ne 0 ]
+    then
+    lint="$(print_status $LINT_CAPTURE)"
+    commit="$(print_status $STATUS_CAPTURE)"
+    test="$(print_status $TEST_CAPTURE)"
+    tidy="$(print_status $TIDY_CAPTURE)"
+    build="$(print_status $BUILD_CAPTURE)"
+    printf "\e[0;31m ================================ \e[0m\n"
+    printf "\e[1;31m|        None of this!           |\e[0m\n"
+    printf "\e[1;31m|                                |\e[0m\n"
+    printf "\e[1;31m|        (╯°□ °)╯︵ ┻━┻          |\e[0m\n"
+    printf "\e[1;31m|                                |\e[0m\n"
+    printf "\e[1;31m|      Don't even PUSH!          |\e[0m\n"
+    printf "\e[0;31m ================================ \e[0m\n"
+    printf "\e[0;31m|                                |\e[0m\n"
+    printf "\e[0;31m| Code style must be lint free %b |\e[0m\n" $lint
+    printf "\e[0;31m|    Code style must be tidy %b   |\e[0m\n" $tidy
+    printf "\e[0;31m|     Commit must be clean %b     |\e[0m\n" $commit
+    printf "\e[0;31m|       Tests must pass %b        |\e[0m\n" $test
+    printf "\e[0;31m|       Code must build %b        |\e[0m\n" $build
+    printf "\e[0;31m|                                |\e[0m\n"
+    printf "\e[0;31m ================================ \e[0m\n"
+    exit 1
+  else
+    printf "\e[0;32m ============================ \e[0m\n"
+    printf "\e[0;32m| Everything looks good here |\e[0m\n"
+    printf "\e[0;32m|                            |\e[0m\n"
+    printf "\e[0;32m|           (•_•)            |\e[0m\r"
+    sleep .5
+    printf "\e[0;32m|           ( •_•)>⌐▪-▪      |\e[0m\r"
+    sleep .5
+    printf "\e[0;32m|           (⌐▪_▪)           |\e[0m\n"
+    sleep .5
+    printf "\e[0;32m|                            |\e[0m\n"
+    printf "\e[0;32m|      You may commit        |\e[0m\n"
+    printf "\e[0;32m ============================ \e[0m\n"
+    exit 0
+  fi
 }
 ####################################
 #    Clean Git Repository Check    #
@@ -84,8 +84,9 @@ printf "Checking that all projects build\n\n"
 printf "\e[0;33mBuilding HelloWorld Project\e[0m "
 # Change to the HelloWorld project
 cd "$SJBASE/firmware/HelloWorld"
-# Clean the build and start building from scratch
-make -s clean
+# Purge repository of all application and framework build files and start
+# building from scratch
+SILENCE=$(make purge)
 # Check if the system can build without any warnings!
 SILENCE=$(make -s application WARNINGS_ARE_ERRORS=-Werror)
 # Set build capture to return code from the build
@@ -97,7 +98,7 @@ printf "\e[0;33mBuilding Hyperload Bootloader\e[0m "
 # Change to the Hyperload project
 cd "$SJBASE/firmware/Hyperload"
 # Clean the build and start building from scratch
-make -s clean
+SILENCE=$(make clean)
 # Check if the system can build without any warnings!
 SILENCE=$(make -s bootloader WARNINGS_ARE_ERRORS=-Werror)
 # Set build capture to return code from the build
@@ -114,7 +115,7 @@ cd "$SJBASE/firmware/examples/$d"
 
 printf "\e[0;33mBuilding Example $d\e[0m "
 # Clean the build and start building from scratch
-make -s clean
+SILENCE=$(make clean)
 # Check if the system can build without any warnings!
 SILENCE=$(make -s application WARNINGS_ARE_ERRORS=-Werror)
 # Add the return codes of the previous build capture. None zero means that at
@@ -125,6 +126,8 @@ print_status $SPECIFIC_BUILD_CAPTURE
 echo ""
 
 done
+
+exit
 
 # Return to home project
 cd $SJBASE/firmware/HelloWorld


### PR DESCRIPTION
Added macro definition for making static libraries in makefile (not
documented in comments yet).

Adding static libraries to the repo so that users using this framework
do not need to recompile the static libraries each time they want to
build a project.

Time to run and build all examples projects has gone from 1m25s -> 12s.