### PR TITLE
L1 Initialize() methods now return Status enum

### DIFF
--- a/firmware/library/L0_LowLevel/startup.cpp
+++ b/firmware/library/L0_LowLevel/startup.cpp
@@ -94,8 +94,8 @@ void vPortSetupTimerInterrupt(void)  // NOLINT
   // The system_timer keeps the time that the system_clock uses to delay itself.
   system_timer.SetTickFrequency(config::kRtosFrequency);
   system_timer.SetIsrFunction(xPortSysTickHandler);
-  bool timer_started_successfully = system_timer.StartTimer();
-  SJ2_ASSERT_FATAL(timer_started_successfully,
+  Status timer_start_status = system_timer.StartTimer();
+  SJ2_ASSERT_FATAL(timer_start_status == Status::kSuccess,
                     "System Timer (used by FreeRTOS) has FAILED to start!");
 }
 }

--- a/firmware/library/L1_Drivers/adc.hpp
+++ b/firmware/library/L1_Drivers/adc.hpp
@@ -6,11 +6,12 @@
 #include "L0_LowLevel/system_controller.hpp"
 #include "L1_Drivers/pin.hpp"
 #include "utility/log.hpp"
+#include "utility/status.hpp"
 
 class AdcInterface
 {
  public:
-  virtual void Initialize() const            = 0;
+  virtual Status Initialize() const          = 0;
   virtual void Conversion() const            = 0;
   virtual uint16_t Read() const              = 0;
   virtual bool HasConversionFinished() const = 0;
@@ -140,7 +141,7 @@ class Adc final : public AdcInterface, protected Lpc40xxSystemController
   }
 
   explicit constexpr Adc(const Channel_t & channel) : channel_(channel) {}
-  void Initialize() const override
+  Status Initialize() const override
   {
     PowerUpPeripheral(Lpc40xxSystemController::Peripherals::kAdc);
 
@@ -158,6 +159,8 @@ class Adc final : public AdcInterface, protected Lpc40xxSystemController
         (GetPeripheralFrequency() / kClockFrequency) & 0xFF;
 
     adc_base->CR = control.data;
+
+    return Status::kSuccess;
   }
   void Conversion() const override
   {

--- a/firmware/library/L1_Drivers/can.hpp
+++ b/firmware/library/L1_Drivers/can.hpp
@@ -10,6 +10,7 @@
 #include "L0_LowLevel/system_controller.hpp"
 #include "L1_Drivers/pin.hpp"
 #include "utility/macros.hpp"
+#include "utility/status.hpp"
 
 class CanInterface
 {
@@ -72,7 +73,7 @@ class CanInterface
     Data_t data;  // CAN message data payload
   };
 
-  virtual bool Initialize() const                                        = 0;
+  virtual Status Initialize() const                                      = 0;
   virtual bool Send(TxMessage_t * const kMessage, uint32_t id,
                     const uint8_t * const kPayload, size_t length) const = 0;
   virtual bool Receive(RxMessage_t * const kMessage) const               = 0;
@@ -374,12 +375,12 @@ class Can final : public CanInterface, protected Lpc40xxSystemController
   {
   }
 
-  bool Initialize() const override
+  Status Initialize() const override
   {
-    bool success = true;
+    Status status = Status::kSuccess;
     if (controller_ > kNumberOfControllers)
     {
-      success = false;
+      status = Status::kDeviceNotFound;
     }
     else
     {
@@ -405,7 +406,7 @@ class Can final : public CanInterface, protected Lpc40xxSystemController
       is_controller_initialized[controller_] = true;
     }
 
-    return success;
+    return status;
   }
 
   // TODO(#344):

--- a/firmware/library/L1_Drivers/example_driver.hpp
+++ b/firmware/library/L1_Drivers/example_driver.hpp
@@ -68,7 +68,7 @@ class ExampleInterface
   // Only put in methods that you know each Example driver should have. If you
   // are not sure, put them all in and it can be figured out during code
   // review.
-  virtual void Initialize()                                             = 0;
+  virtual Status Initialize()                                             = 0;
   virtual void DoSomeAction()                                           = 0;
   virtual void SendData(const uint8_t * payload, bool readback = false) = 0;
   virtual void SetMode(InterfaceModes mode)                             = 0;
@@ -162,7 +162,7 @@ class Example final : public ExampleInterface, protected Lpc40xxSystemController
   // You must put "override" for methods that you override from the interface.
   // If you don't expect someone to inherit and override this class's
   // implementation declare it "final".
-  void Initialize() override
+  Status Initialize() override
   {
     // Typically you will need to power up your peripheral. Use the inherited
     // method rather than directly using the LPC_SC register.

--- a/firmware/library/L1_Drivers/gpio.hpp
+++ b/firmware/library/L1_Drivers/gpio.hpp
@@ -7,6 +7,7 @@
 #include "L1_Drivers/pin.hpp"
 #include "utility/enum.hpp"
 #include "utility/log.hpp"
+#include "utility/status.hpp"
 
 class GpioInterface
 {

--- a/firmware/library/L1_Drivers/i2c.hpp
+++ b/firmware/library/L1_Drivers/i2c.hpp
@@ -54,7 +54,7 @@ class I2cInterface
     bool busy                = false;
   };
 
-  virtual void Initialize() const                                           = 0;
+  virtual Status Initialize() const                                         = 0;
   virtual Status Read(uint8_t address, uint8_t * destination, size_t length,
                       uint32_t timeout = kI2cTimeout) const                 = 0;
   virtual Status Write(uint8_t address, const uint8_t * destination,
@@ -354,7 +354,7 @@ class I2c final : public I2cInterface, protected Lpc40xxSystemController
   // This defaults to I2C port 2
   explicit constexpr I2c(const Bus_t & bus) : i2c_(bus) {}
 
-  void Initialize() const override
+  Status Initialize() const override
   {
     i2c_.bus.sda_pin.SetPinFunction(i2c_.bus.pin_function_id);
     i2c_.bus.scl_pin.SetPinFunction(i2c_.bus.pin_function_id);
@@ -377,6 +377,8 @@ class I2c final : public I2cInterface, protected Lpc40xxSystemController
     i2c_.bus.registers->CONSET = Control::kInterfaceEnable;
 
     RegisterIsr(i2c_.bus.irq_number, i2c_.handler, true);
+
+    return Status::kSuccess;
   }
 
   Status Read(uint8_t address, uint8_t * data, size_t length,

--- a/firmware/library/L1_Drivers/pwm.hpp
+++ b/firmware/library/L1_Drivers/pwm.hpp
@@ -14,16 +14,18 @@
 #include "L0_LowLevel/system_controller.hpp"
 #include "L1_Drivers/pin.hpp"
 #include "utility/log.hpp"
+#include "utility/status.hpp"
 
 class PwmInterface
 {
  public:
   static constexpr uint32_t kDefaultFrequency = 1'000;
 
-  virtual void Initialize(uint32_t frequency_hz = kDefaultFrequency) const = 0;
-  virtual void SetDutyCycle(float duty_cycle) const                        = 0;
-  virtual float GetDutyCycle() const                                       = 0;
-  virtual void SetFrequency(uint32_t frequency_hz) const                   = 0;
+  virtual Status Initialize(
+      uint32_t frequency_hz = kDefaultFrequency) const   = 0;
+  virtual void SetDutyCycle(float duty_cycle) const      = 0;
+  virtual float GetDutyCycle() const                     = 0;
+  virtual void SetFrequency(uint32_t frequency_hz) const = 0;
 };
 
 class Pwm final : public PwmInterface, protected Lpc40xxSystemController
@@ -148,7 +150,7 @@ class Pwm final : public PwmInterface, protected Lpc40xxSystemController
   explicit constexpr Pwm(const Channel_t & channel) : channel_(channel) {}
 
   /// @param frequency_hz - Pulse width modulation frequency
-  void Initialize(uint32_t frequency_hz = kDefaultFrequency) const override
+  Status Initialize(uint32_t frequency_hz = kDefaultFrequency) const override
   {
     SJ2_ASSERT_FATAL(1 <= channel_.channel && channel_.channel <= 6,
                      "Channel must be between 1 and 6 on LPC40xx platforms.");
@@ -185,6 +187,8 @@ class Pwm final : public PwmInterface, protected Lpc40xxSystemController
         0b11'1111;
 
     channel_.pin.SetPinFunction(channel_.peripheral.pin_function_id);
+
+    return Status::kSuccess;
   }
 
   void SetDutyCycle(float duty_cycle) const override

--- a/firmware/library/L1_Drivers/spi.hpp
+++ b/firmware/library/L1_Drivers/spi.hpp
@@ -25,6 +25,7 @@
 #include "L1_Drivers/pin.hpp"
 #include "utility/bit.hpp"
 #include "utility/enum.hpp"
+#include "utility/status.hpp"
 
 class SpiInterface
 {
@@ -53,7 +54,7 @@ class SpiInterface
     kSixteen,  // The largest standard frame sized allowed for SJSU-Dev2
   };
 
-  virtual void Initialize() const                                           = 0;
+  virtual Status Initialize() const                                         = 0;
   virtual uint16_t Transfer(uint16_t data) const                            = 0;
   virtual void SetPeripheralMode(MasterSlaveMode mode, DataSize size) const = 0;
   virtual void SetClock(bool positive_polarity, bool phase, uint8_t prescaler,
@@ -152,7 +153,7 @@ class Spi final : public SpiInterface, protected Lpc40xxSystemController
   /// Powers on the peripheral, activates the SSP pins and enables the SSP
   /// peripheral.
   /// See page 601 of user manual UM10562 LPC408x/407x for more details.
-  void Initialize() const override
+  Status Initialize() const override
   {
     // Power up peripheral
     PowerUpPeripheral(bus_.power_on_bit);
@@ -162,6 +163,8 @@ class Spi final : public SpiInterface, protected Lpc40xxSystemController
     bus_.sck.SetPinFunction(bus_.pin_function_id);
     // Enable SSP
     bus_.registers->CR1 = bit::Set(bus_.registers->CR1, kSpiEnable);
+
+    return Status::kSuccess;
   }
 
   /// An easy way to sets up an SPI peripheral as SPI master with default clock

--- a/firmware/library/L1_Drivers/test/system_timer_test.cpp
+++ b/firmware/library/L1_Drivers/test/system_timer_test.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Testing SystemTimer", "[system_timer]")
     local_systick.VAL        = 0xBEEF;
     local_systick.LOAD       = 1000;
 
-    CHECK(true == test_subject.StartTimer());
+    CHECK(Status::kSuccess == test_subject.StartTimer());
     CHECK(kMask == local_systick.CTRL);
     CHECK(0 == local_systick.VAL);
   }
@@ -65,7 +65,7 @@ TEST_CASE("Testing SystemTimer", "[system_timer]")
     local_systick.LOAD = 0;
     local_systick.VAL  = 0xBEEF;
 
-    CHECK(false == test_subject.StartTimer());
+    CHECK(Status::kInvalidSettings == test_subject.StartTimer());
     CHECK(kClkSourceMask == local_systick.CTRL);
     CHECK(0xBEEF == local_systick.VAL);
   }

--- a/firmware/library/L1_Drivers/uart.hpp
+++ b/firmware/library/L1_Drivers/uart.hpp
@@ -7,15 +7,16 @@
 #include "L0_LowLevel/LPC40xx.h"
 #include "L0_LowLevel/system_controller.hpp"
 #include "L1_Drivers/pin.hpp"
+#include "utility/status.hpp"
 #include "utility/time.hpp"
 
 class UartInterface
 {
-  virtual bool Initialize(uint32_t baud_rate)  const = 0;
-  virtual bool SetBaudRate(uint32_t baud_rate) const = 0;
-  virtual void Send(uint8_t out)               const = 0;
+  virtual Status Initialize(uint32_t baud_rate) const = 0;
+  virtual bool SetBaudRate(uint32_t baud_rate) const  = 0;
+  virtual void Send(uint8_t out) const                = 0;
   // TODO(#442): Add an IsAvailable function to check if a byte has been receive
-  virtual uint8_t Receive(uint32_t timeout)    const = 0;
+  virtual uint8_t Receive(uint32_t timeout) const = 0;
 };
 
 namespace uart
@@ -310,7 +311,7 @@ class Uart final : public UartInterface, protected Lpc40xxSystemController
     port_.registers->LCR = kStandardUart;
   }
 
-  bool Initialize(uint32_t baud_rate) const override
+  Status Initialize(uint32_t baud_rate) const override
   {
     constexpr uint8_t kFIFOEnableAndReset = 0b111;
     // Powering the port
@@ -322,7 +323,8 @@ class Uart final : public UartInterface, protected Lpc40xxSystemController
     port_.rx.SetMode(PinInterface::Mode::kPullUp);
     port_.tx.SetMode(PinInterface::Mode::kPullUp);
     port_.registers->FCR |= kFIFOEnableAndReset;
-    return true;
+
+    return Status::kSuccess;
   }
 
   void Send(uint8_t data) const override

--- a/firmware/library/utility/status.hpp
+++ b/firmware/library/utility/status.hpp
@@ -5,7 +5,8 @@ enum class Status
   kSuccess,
   kTimedOut,
   kBusError,
-  kDeviceNotFound
+  kDeviceNotFound,
+  kInvalidSettings
 };
 
 constexpr const char * Stringify(Status status)


### PR DESCRIPTION
This will make it easier in the future for drivers to return useful
information about the intialization state of the driver.

Resolves #439 .