### PR TITLE
Change optimization level for presubmit to Os

### DIFF
--- a/firmware/library/L1_Drivers/pin.hpp
+++ b/firmware/library/L1_Drivers/pin.hpp
@@ -44,7 +44,7 @@ class PinInterface
   uint8_t pin_;
 };
 
-class Pin : public PinInterface
+class Pin final : public PinInterface
 {
  public:
   // Source: "UM10562 LPC408x/407x User manual" table 83 page 132

--- a/firmware/library/L1_Drivers/spi.hpp
+++ b/firmware/library/L1_Drivers/spi.hpp
@@ -98,9 +98,9 @@ class Spi final : public SpiInterface, protected Lpc40xxSystemController
   {
     LPC_SSP_TypeDef * registers;
     PeripheralID power_on_bit;
-    const Pin & mosi;
-    const Pin & miso;
-    const Pin & sck;
+    const PinInterface & mosi;
+    const PinInterface & miso;
+    const PinInterface & sck;
     uint8_t pin_function_id;
   };
 

--- a/firmware/library/L1_Drivers/test/pwm_test.cpp
+++ b/firmware/library/L1_Drivers/test/pwm_test.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Testing PWM instantiation", "[pwm]")
   Lpc40xxSystemController::system_controller = &local_sc;
 
   // Creating mock of Pin class
-  Mock<Pin> mock_pwm_pin;
+  Mock<PinInterface> mock_pwm_pin;
   // Make sure mock Pin doesn't call real SetPinFunction() method
   Fake(Method(mock_pwm_pin, SetPinFunction));
 

--- a/firmware/library/L1_Drivers/test/spi_test.cpp
+++ b/firmware/library/L1_Drivers/test/spi_test.cpp
@@ -19,9 +19,9 @@ TEST_CASE("Testing SPI", "[Spi]")
   memset(&local_sc, 0, sizeof(local_sc));
 
   // Set up Mock for PinCongiure
-  Mock<Pin> mock_mosi;
-  Mock<Pin> mock_miso;
-  Mock<Pin> mock_sck;
+  Mock<PinInterface> mock_mosi;
+  Mock<PinInterface> mock_miso;
+  Mock<PinInterface> mock_sck;
 
   Fake(Method(mock_mosi, SetPinFunction));
   Fake(Method(mock_miso, SetPinFunction));

--- a/firmware/library/L2_HAL/displays/led/onboard_led.hpp
+++ b/firmware/library/L2_HAL/displays/led/onboard_led.hpp
@@ -28,7 +28,7 @@ class OnBoardLedInterface
   virtual uint8_t GetStates(void)                        = 0;
 };
 
-class OnBoardLed : public OnBoardLedInterface
+class OnBoardLed final : public OnBoardLedInterface
 {
  public:
   // Initialize takes the array of Gpios, sets each one to an output, and

--- a/firmware/library/L2_HAL/memory/sd.hpp
+++ b/firmware/library/L2_HAL/memory/sd.hpp
@@ -405,7 +405,7 @@ class SdInterface
   virtual uint16_t GetCrc16(uint8_t message[], uint16_t length) = 0;
 };
 
-class Sd : public SdInterface
+class Sd final : public SdInterface
 {
  public:
   // This value was found through experimentation. The suggested value (found

--- a/tools/presubmit.sh
+++ b/tools/presubmit.sh
@@ -99,7 +99,7 @@ cd "$SJBASE/firmware/Hyperload"
 # Clean the build and start building from scratch
 make -s clean
 # Check if the system can build without any warnings!
-SILENCE=$(make -s bootloader WARNINGS_ARE_ERRORS=-Werror)
+SILENCE=$(make -s bootloader OPT=s WARNINGS_ARE_ERRORS=-Werror)
 # Set build capture to return code from the build
 SPECIFIC_BUILD_CAPTURE=$?
 BUILD_CAPTURE=$(($BUILD_CAPTURE + $SPECIFIC_BUILD_CAPTURE))


### PR DESCRIPTION
This will ensure that warnings produced by code that can be further
optimized will show up during presubmit. This will keep the code from
being submitted if it can be optimized for size further.

Resolves #418