### PR TITLE
No longer use PATH env variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 firmware/*
 firmware/**/build
-firmware/**/makefile
 firmware/library/static_libraries
 
 !firmware/library

--- a/firmware/HelloWorld/makefile
+++ b/firmware/HelloWorld/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/Hyperload/makefile
+++ b/firmware/Hyperload/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/arm_cortex/SystemTimer/makefile
+++ b/firmware/examples/arm_cortex/SystemTimer/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/multiplatform/Backtrace/makefile
+++ b/firmware/examples/multiplatform/Backtrace/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/multiplatform/Delay/makefile
+++ b/firmware/examples/multiplatform/Delay/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/multiplatform/FileIO/makefile
+++ b/firmware/examples/multiplatform/FileIO/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/multiplatform/LogLevelPrint/makefile
+++ b/firmware/examples/multiplatform/LogLevelPrint/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/multiplatform/PeriodicScheduler/makefile
+++ b/firmware/examples/multiplatform/PeriodicScheduler/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/multiplatform/SystemClock/makefile
+++ b/firmware/examples/multiplatform/SystemClock/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/multiplatform/TaskScheduler/makefile
+++ b/firmware/examples/multiplatform/TaskScheduler/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/Adc/makefile
+++ b/firmware/examples/sjtwo/Adc/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/Button/makefile
+++ b/firmware/examples/sjtwo/Button/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/Buzzer/makefile
+++ b/firmware/examples/sjtwo/Buzzer/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/CommandLine/makefile
+++ b/firmware/examples/sjtwo/CommandLine/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/Dac/makefile
+++ b/firmware/examples/sjtwo/Dac/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/FactoryTest/makefile
+++ b/firmware/examples/sjtwo/FactoryTest/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/FreeRTOS_Blinker/makefile
+++ b/firmware/examples/sjtwo/FreeRTOS_Blinker/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/Gpio/makefile
+++ b/firmware/examples/sjtwo/Gpio/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/GpioInterrupts/makefile
+++ b/firmware/examples/sjtwo/GpioInterrupts/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/I2c/makefile
+++ b/firmware/examples/sjtwo/I2c/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/I2cDevice/makefile
+++ b/firmware/examples/sjtwo/I2cDevice/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/Oled/makefile
+++ b/firmware/examples/sjtwo/Oled/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/OledPrintf/makefile
+++ b/firmware/examples/sjtwo/OledPrintf/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/Parallel_LCD/makefile
+++ b/firmware/examples/sjtwo/Parallel_LCD/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/PinConfigure/makefile
+++ b/firmware/examples/sjtwo/PinConfigure/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/Pwm/makefile
+++ b/firmware/examples/sjtwo/Pwm/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/SdCard/makefile
+++ b/firmware/examples/sjtwo/SdCard/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/Spi/makefile
+++ b/firmware/examples/sjtwo/Spi/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/SystemClock/makefile
+++ b/firmware/examples/sjtwo/SystemClock/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/Temperature/makefile
+++ b/firmware/examples/sjtwo/Temperature/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/Timer/makefile
+++ b/firmware/examples/sjtwo/Timer/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/firmware/examples/sjtwo/Uart/makefile
+++ b/firmware/examples/sjtwo/Uart/makefile
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/project_makefile.mk
+++ b/project_makefile.mk
@@ -1,0 +1,5 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/setup
+++ b/setup
@@ -234,34 +234,9 @@ cd "$BASE"
 echo " ───────────────────────────────────────────────────┐"
 echo "        Generating Environment Variables File        "
 echo "└─────────────────────────────────────────────────── "
-cat > env.mk <<EOL
-#!/bin/bash
-# Setup a base directory:
-SJBASE = $BASE
-
-# Board Settings:
-SJBAUD = 38400
-
-# Project Target Settings:
-# Sets the binary name, defaults to "firmware" (Optional)
-SJPROJ = firmware
-
-# Sets which DBC to generate, defaults to "DBG"
-ENTITY = DBG
-
-# Path to CLANG compiler
-SJCLANG = \$(SJBASE)/tools/$CLANG_PATH/bin
-# Path to ARM GCC compiler
-SJARMGCC = \$(SJBASE)/tools/gcc-arm-none-eabi-7-2017-q4-major/bin
-# Path to Openocd compiler
-SJOPENOCD = \$(SJBASE)/tools/openocd/bin
-
-# Compiler and library settings:
-# Selects compiler version to use
-PATH := \$(shell printf "%s" "\$(PATH):\$(SJARMGCC)")
-PATH := \$(shell printf "%s" "\$(PATH):\$(SJCLANG)")
-PATH := \$(shell printf "%s" "\$(PATH):\$(SJOPENOCD)")
-SJLIBDIR = "\$(SJBASE)/firmware/library"
+cat > ~/.sjsu_dev2.mk << EOL
+# Location of SJSU-Dev2 folder
+SJSU_DEV2_BASE    = $BASE
 EOL
 echo " ───────────────────────────────────────────────────┐"
 echo "      Linking Files to Firmware Project Folder       "

--- a/tools/link_projects.sh
+++ b/tools/link_projects.sh
@@ -11,12 +11,9 @@ PROJECTS=(\
 
 for PROJECT in ${PROJECTS[@]}
 do
-    echo "Creating link for: $PROJECT/env.mk"
     echo "Creating link for: $PROJECT/makefile"
     # Place env.sh link into project folder
-    rm -f "$PROJECT/env.mk"
-    ln -s -f "${SJBASE}/env.mk" "$PROJECT/env.mk"
     # Place makefile link into project folder
     rm -f "$PROJECT/makefile"
-    ln -s -f "${SJBASE}/makefile" "$PROJECT/makefile"
+    cp "${SJBASE}/project_makefile.mk" "$PROJECT/makefile"
 done

--- a/tools/presubmit.sh
+++ b/tools/presubmit.sh
@@ -109,7 +109,8 @@ echo ""
 
 # Build all example projects
 cd $SJBASE/firmware/examples/
-for d in $(dirname $(find ./ -name "makefile")); do
+LIST_OF_PROJECT=$(find ./ -name "makefile")
+for d in $(dirname $LIST_OF_PROJECT); do
 
 cd "$SJBASE/firmware/examples/$d"
 


### PR DESCRIPTION
makefile, env.sh, and setup no longer use the PATH environemnt variable.
This is helpful in that, there are cases where a user has a globally
installed version of arm-gcc or clang that may get selected rather than
the SJSU-Dev2 installed versions. If the versions are not the same the
behaviour may be different and cause the user problems.

Resolves #390