### PR TITLE
Changing PeriodicScheduler to use FreeRTOS software timers

### DIFF
--- a/library/L0_Platform/freertos/FreeRTOSConfig.h
+++ b/library/L0_Platform/freertos/FreeRTOSConfig.h
@@ -79,6 +79,12 @@ to exclude the API function. */
 #define INCLUDE_uxTaskGetStackHighWaterMark 1
 #define INCLUDE_xTaskGetSchedulerState 1
 
+/* FreeRTOS Timer or daemon task configuration */
+#define configUSE_TIMERS 1
+#define configTIMER_TASK_PRIORITY (configMAX_PRIORITIES - 1)
+#define configTIMER_QUEUE_LENGTH 10
+#define configTIMER_TASK_STACK_DEPTH (512)
+
 /* This demo makes use of one or more example stats formatting functions.  These
 format the raw data provided by the uxTaskGetSystemState() function in to human
 readable ASCII form.  See the notes in the implementation of vTaskList() within

--- a/library/L0_Platform/freertos/freertos_common.cpp
+++ b/library/L0_Platform/freertos/freertos_common.cpp
@@ -15,3 +15,19 @@ extern "C" void vApplicationGetIdleTaskMemory(  // NOLINT
   *ppx_idle_task_stack_buffer = idle_task_stack;
   *pul_idle_task_stack_size   = std::size(idle_task_stack);
 }
+// Implementation of vApplicationGetTimerTaskMemory is required for
+// the use of timers when configSUPPORT_STATIC_ALLOCATION == 1.
+// The function is called to statically create the FreeRTOS timer task
+// responsible for handling all created timers.
+// see: https://www.freertos.org/a00110.html#configSUPPORT_STATIC_ALLOCATION
+static StaticTask_t timer_task_tcb;
+static StackType_t timer_task_stack[configTIMER_TASK_STACK_DEPTH];
+extern "C" void vApplicationGetTimerTaskMemory( // NOLINT
+    StaticTask_t ** ppx_timer_task_tcb_buffer,
+    StackType_t ** ppx_timer_task_stack_buffer,
+    uint32_t * pul_timer_task_stack_size)
+{
+    *ppx_timer_task_tcb_buffer = &timer_task_tcb;
+    *ppx_timer_task_stack_buffer = timer_task_stack;
+    *pul_timer_task_stack_size = std::size(timer_task_stack);
+}

--- a/library/L4_Testing/freertos_mocks.cpp
+++ b/library/L4_Testing/freertos_mocks.cpp
@@ -26,4 +26,12 @@ DEFINE_FAKE_VALUE_FUNC(BaseType_t, xQueueGenericSend, QueueHandle_t,
                        const void *, TickType_t, BaseType_t);
 DEFINE_FAKE_VALUE_FUNC(BaseType_t, xQueueSemaphoreTake, QueueHandle_t,
                        TickType_t);
+
+DEFINE_FAKE_VALUE_FUNC(TimerHandle_t, xTimerCreateStatic, const char *,
+                       TickType_t, UBaseType_t, void *, TimerCallbackFunction_t,
+                       StaticTimer_t *);
+DEFINE_FAKE_VALUE_FUNC(BaseType_t, xTimerGenericCommand, TimerHandle_t,
+                       BaseType_t, TickType_t, BaseType_t *, TickType_t);
+DEFINE_FAKE_VALUE_FUNC(void *, pvTimerGetTimerID, TimerHandle_t);
+DEFINE_FAKE_VOID_FUNC(vTimerSetTimerID, TimerHandle_t, void *);
 #endif  // HOST_TEST

--- a/library/utility/rtos.hpp
+++ b/library/utility/rtos.hpp
@@ -12,6 +12,7 @@
 
 #include "event_groups.h"
 #include "semphr.h"
+#include "timers.h"
 
 DECLARE_FAKE_VOID_FUNC(vTaskStartScheduler);
 DECLARE_FAKE_VOID_FUNC(vTaskSuspend, TaskHandle_t);
@@ -37,6 +38,14 @@ DECLARE_FAKE_VALUE_FUNC(BaseType_t, xQueueGenericSend, QueueHandle_t,
                         const void *, TickType_t, BaseType_t);
 DECLARE_FAKE_VALUE_FUNC(BaseType_t, xQueueSemaphoreTake, QueueHandle_t,
                         TickType_t);
+
+DECLARE_FAKE_VALUE_FUNC(TimerHandle_t, xTimerCreateStatic, const char *,
+                        TickType_t, UBaseType_t, void *,
+                        TimerCallbackFunction_t, StaticTimer_t *);
+DECLARE_FAKE_VALUE_FUNC(BaseType_t, xTimerGenericCommand, TimerHandle_t,
+                        BaseType_t, TickType_t, BaseType_t *, TickType_t);
+DECLARE_FAKE_VALUE_FUNC(void *, pvTimerGetTimerID, TimerHandle_t);
+DECLARE_FAKE_VOID_FUNC(vTimerSetTimerID, TimerHandle_t, void *);
 #endif  // HOST_TEST
 
 namespace sjsu


### PR DESCRIPTION
- Added vApplicationGetTimerTaskMemory() to startup.cpp.
- Configured FreeRTOSConfig.h to enable the use of software timers.
- Updated Unit Tests for PeriodicScheduler
   - Added fake functions for xTimerCreateStatic, xTimerGenericCommand,
     and vTimerGetTimerID, vTimerSetTimerID.