### PR TITLE
Fixed usage of dirname in Mac OSX presubmit

### DIFF
--- a/tools/presubmit.sh
+++ b/tools/presubmit.sh
@@ -113,9 +113,10 @@ echo ""
 cd $SJBASE/demos/
 
 LIST_OF_PROJECT=$(find ./ -name "makefile")
-for d in $(dirname $LIST_OF_PROJECT)
+for d in $LIST_OF_PROJECT
 do
-cd "$SJBASE/demos/$d"
+PROJECT_PATH=$(dirname $d)
+cd "$SJBASE/demos/$PROJECT_PATH"
 printf "\e[0;33mBuilding Example $d \e[0m "
 # Clean the build and start building from scratch
 SILENCE=$(make clean)


### PR DESCRIPTION
`dirname` can take multiple arguments on linux but only takes 1 on OSX.
By using the results from find directly, we can use the single path with
`dirname` and use that to change into those directories.

Resolves #474