### PR TITLE
Add SystemControl as a ctor parameter for LPC40xx L1

### DIFF
--- a/demos/arm_cortex/system_timer/source/main.cpp
+++ b/demos/arm_cortex/system_timer/source/main.cpp
@@ -11,7 +11,9 @@ void DemoSystemIsr()
 int main()
 {
   LOG_INFO("System Timer Application Starting...");
-  sjsu::cortex::SystemTimer system_timer;
+  sjsu::DefaultSystemController default_system_controller;
+  sjsu::cortex::SystemTimer system_timer(default_system_controller);
+
   system_timer.SetInterrupt(DemoSystemIsr);
   system_timer.SetTickFrequency(10 /* Hz */);
   system_timer.StartTimer();

--- a/demos/sjtwo/spi/source/main.cpp
+++ b/demos/sjtwo/spi/source/main.cpp
@@ -23,15 +23,15 @@ int main()
   sjsu::lpc40xx::Spi spi2(sjsu::lpc40xx::Spi::Bus::kSpi2);
 
   // Set SSP1 as SPI master. Note that the function SetSpiMasterDefault()
-  // could be used instead of SetPeripheralMode() and SetClock().
+  // could be used instead of SetMode() and SetClock().
   LOG_INFO("Set SSP1 as SPI master.");
-  spi2.SetPeripheralMode(sjsu::lpc40xx::Spi::MasterSlaveMode::kMaster,
+  spi2.SetMode(sjsu::lpc40xx::Spi::MasterSlaveMode::kMaster,
                          sjsu::lpc40xx::Spi::DataSize::kEight);
 
   // Set up SPI clock polarity and phase
   LOG_INFO("MOSI will read low when inactive.");
   LOG_INFO("SCK will read high when inactive.");
-  spi2.SetClock(1, 1, 2, 0);
+  spi2.SetClock(1, 1, 1'000'000);
 
   // Initialize SSP
   LOG_INFO("SSP initialization");

--- a/library/L0_Platform/lpc17xx/lpc17xx.cfg
+++ b/library/L0_Platform/lpc17xx/lpc17xx.cfg
@@ -20,9 +20,9 @@ transport select jtag
 # Source the LPC17xx configuration file
 source [find target/lpc17xx.cfg]
 
-# JTAG Clock rate in kHz (max for lpc40xx is 4Mhz)
+# JTAG Clock rate in kHz
 # lower this if you are getting glitches
-adapter_khz 400
+adapter_khz 200
 
 $_TARGETNAME configure -event gdb-attach {
    halt

--- a/library/L0_Platform/lpc17xx/startup.cpp
+++ b/library/L0_Platform/lpc17xx/startup.cpp
@@ -55,7 +55,7 @@ sjsu::lpc17xx::SystemController system_controller;
 // Create timer0 to be used by lower level initialization for uptime calculation
 sjsu::cortex::DwtCounter arm_dwt_counter;
 // Uart port 0 is used to communicate back to the host computer
-sjsu::lpc17xx::Uart uart0(sjsu::lpc17xx::UartPort::kUart0);
+sjsu::lpc17xx::Uart uart0(sjsu::lpc17xx::UartPort::kUart0, system_controller);
 // System timer is used to count milliseconds of time and to run the RTOS
 // scheduler.
 sjsu::cortex::SystemTimer system_timer(system_controller);

--- a/library/L1_Peripheral/cortex/system_timer.hpp
+++ b/library/L1_Peripheral/cortex/system_timer.hpp
@@ -38,13 +38,8 @@ class SystemTimer final : public sjsu::SystemTimer
   /// frequency of the SystemTimer is set to 1kHz, this could be used as a
   /// milliseconds counter.
   inline static uint64_t counter = 0;
-  // If the user does not specify a system controller, the default system
-  // controller will be used. The default system controller does not modify
-  // hardware. It only returns the project's desired system clock rate.
-  inline static DefaultSystemController default_system_controller;
 
-  explicit SystemTimer(
-      const SystemController & system_controller = default_system_controller)
+  explicit SystemTimer(const SystemController & system_controller)
       : system_controller_(system_controller)
   {
   }

--- a/library/L1_Peripheral/lpc17xx/system_controller.hpp
+++ b/library/L1_Peripheral/lpc17xx/system_controller.hpp
@@ -1,12 +1,117 @@
 #pragma once
 
+#include "L0_Platform/lpc17xx/LPC17xx.h"
 #include "L1_Peripheral/lpc40xx/system_controller.hpp"
 
 namespace sjsu
 {
 namespace lpc17xx
 {
-// The LPC40xx driver is compatible with the lpc17xx peripheral
-using ::sjsu::lpc40xx::SystemController;
+class SystemController final : public sjsu::SystemController
+{
+ public:
+  // LPC17xx Peripheral Power On Values:
+  // The kDeviceId of each peripheral corresponds to the peripheral's power on
+  // bit position within the LPC17xx System Controller's PCONP register.
+  class Peripherals
+  {
+   public:
+    static constexpr auto kLcd               = AddPeripheralID<0>();
+    static constexpr auto kTimer0            = AddPeripheralID<1>();
+    static constexpr auto kTimer1            = AddPeripheralID<2>();
+    static constexpr auto kUart0             = AddPeripheralID<3>();
+    static constexpr auto kUart1             = AddPeripheralID<4>();
+    static constexpr auto kPwm0              = AddPeripheralID<5>();
+    static constexpr auto kPwm1              = AddPeripheralID<6>();
+    static constexpr auto kI2c0              = AddPeripheralID<7>();
+    static constexpr auto kUart4             = AddPeripheralID<8>();
+    static constexpr auto kRtc               = AddPeripheralID<9>();
+    static constexpr auto kSsp1              = AddPeripheralID<10>();
+    static constexpr auto kEmc               = AddPeripheralID<11>();
+    static constexpr auto kAdc               = AddPeripheralID<12>();
+    static constexpr auto kCan1              = AddPeripheralID<13>();
+    static constexpr auto kCan2              = AddPeripheralID<14>();
+    static constexpr auto kGpio              = AddPeripheralID<15>();
+    static constexpr auto kSpifi             = AddPeripheralID<16>();
+    static constexpr auto kMotorControlPwm   = AddPeripheralID<17>();
+    static constexpr auto kQuadratureEncoder = AddPeripheralID<18>();
+    static constexpr auto kI2c1              = AddPeripheralID<19>();
+    static constexpr auto kSsp2              = AddPeripheralID<20>();
+    static constexpr auto kSsp0              = AddPeripheralID<21>();
+    static constexpr auto kTimer2            = AddPeripheralID<22>();
+    static constexpr auto kTimer3            = AddPeripheralID<23>();
+    static constexpr auto kUart2             = AddPeripheralID<24>();
+    static constexpr auto kUart3             = AddPeripheralID<25>();
+    static constexpr auto kI2c2              = AddPeripheralID<26>();
+    static constexpr auto kI2s               = AddPeripheralID<27>();
+    static constexpr auto kSdCard            = AddPeripheralID<28>();
+    static constexpr auto kGpdma             = AddPeripheralID<29>();
+    static constexpr auto kEthernet          = AddPeripheralID<30>();
+    static constexpr auto kUsb               = AddPeripheralID<31>();
+  };
+
+  static constexpr uint32_t kDefaultIRCFrequency    = 4'000'000;
+  static constexpr uint32_t kDefaultTimeout         = 1'000;  // ms
+
+  inline static LPC_SC_TypeDef * system_controller = LPC_SC;
+
+  uint32_t SetClockFrequency(uint8_t /* frequency_in_mhz */) const override
+  {
+    return 0;
+  }
+
+  void SetPeripheralClockDivider(
+      uint8_t /* peripheral_divider */) const override
+  {
+    system_controller->PCLKSEL0 = 0x5555'5555;
+    system_controller->PCLKSEL1 = 0x5555'5555;
+  }
+
+  uint32_t GetPeripheralClockDivider() const override
+  {
+    return 1;
+  }
+
+  uint32_t GetSystemFrequency() const override
+  {
+    return speed_in_hertz;
+  }
+
+  uint32_t GetPeripheralFrequency() const override
+  {
+    return speed_in_hertz;
+  }
+  /// Check if a peripheral is powered up by checking the power connection
+  /// register. Should typically only be used for unit testing code and
+  /// debugging.
+  bool IsPeripheralPoweredUp(
+      const PeripheralID & peripheral_select) const override
+  {
+    bool peripheral_is_powered_on =
+        system_controller->PCONP & (1 << peripheral_select.device_id);
+
+    return peripheral_is_powered_on;
+  }
+  void PowerUpPeripheral(
+      const PeripheralID & peripheral_select) const override
+  {
+    auto power_connection_with_enabled_peripheral =
+        system_controller->PCONP | (1 << peripheral_select.device_id);
+
+    system_controller->PCONP = power_connection_with_enabled_peripheral;
+  }
+  void PowerDownPeripheral(
+      const PeripheralID & peripheral_select) const override
+  {
+    auto power_connection_without_enabled_peripheral =
+        system_controller->PCONP & ~(1 << peripheral_select.device_id);
+
+    system_controller->PCONP = power_connection_without_enabled_peripheral;
+  }
+
+ private:
+  inline static uint32_t speed_in_hertz = kDefaultIRCFrequency;
+};
+
 }  // namespace lpc17xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc40xx/dac.hpp
+++ b/library/L1_Peripheral/lpc40xx/dac.hpp
@@ -12,7 +12,7 @@ namespace sjsu
 {
 namespace lpc40xx
 {
-class Dac final : public sjsu::Dac, protected sjsu::lpc40xx::SystemController
+class Dac final : public sjsu::Dac
 {
  public:
   enum Bit : uint8_t
@@ -37,7 +37,7 @@ class Dac final : public sjsu::Dac, protected sjsu::lpc40xx::SystemController
   };
 
   static constexpr sjsu::lpc40xx::Pin kDacPin = Pin::CreatePin<0, 26>();
-  static constexpr float kVref = 3.3f;
+  static constexpr float kVref                = 3.3f;
 
   inline static LPC_DAC_TypeDef * dac_register = LPC_DAC;
 
@@ -48,8 +48,11 @@ class Dac final : public sjsu::Dac, protected sjsu::lpc40xx::SystemController
   {
     static constexpr uint8_t kDacMode = 0b010;
     dac_pin_.SetPinFunction(kDacMode);
-    // Temporally convert
-    reinterpret_cast<const Pin *>(&dac_pin_)->EnableDac();
+    // Temporally convert dac_pin to a lpc40xx::Pin so we can use the
+    // EnableDacs() method featured in the LPC40xx pin object.
+    const sjsu::lpc40xx::Pin & lpc40xx_dac_pin =
+        reinterpret_cast<const sjsu::lpc40xx::Pin &>(dac_pin_);
+    lpc40xx_dac_pin.EnableDac();
     dac_pin_.SetAsAnalogMode();
     dac_pin_.SetMode(Pin::Mode::kInactive);
     // Disable interrupt and DMA

--- a/library/L1_Peripheral/lpc40xx/system_controller.hpp
+++ b/library/L1_Peripheral/lpc40xx/system_controller.hpp
@@ -155,26 +155,12 @@ class SystemController : public sjsu::SystemController
 
   uint32_t GetPeripheralClockDivider() const final override
   {
-    if constexpr (build::kTarget == build::Target::HostTest)
-    {
-      return 1;
-    }
-    else
-    {
-      return system_controller->PCLKSEL;
-    }
+    return system_controller->PCLKSEL;
   }
 
   uint32_t GetSystemFrequency() const final override
   {
-    if constexpr (build::kTarget == build::Target::HostTest)
-    {
-      return config::kSystemClockRate;
-    }
-    else
-    {
-      return speed_in_hertz;
-    }
+    return speed_in_hertz;
   }
 
   uint32_t GetPeripheralFrequency() const final override
@@ -210,7 +196,7 @@ class SystemController : public sjsu::SystemController
       const PeripheralID & peripheral_select) const final override
   {
     auto power_connection_without_enabled_peripheral =
-        system_controller->PCONP & (1 << peripheral_select.device_id);
+        system_controller->PCONP & ~(1 << peripheral_select.device_id);
 
     system_controller->PCONP = power_connection_without_enabled_peripheral;
   }

--- a/library/L1_Peripheral/lpc40xx/test/uart_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/uart_test.cpp
@@ -10,12 +10,14 @@ TEST_CASE("Testing lpc40xx Uart", "[lpc40xx-Uart]")
 {
   // Simulated local version of LPC_UART2 to verify registers
   LPC_UART_TypeDef local_uart;
-  LPC_SC_TypeDef local_sc;
-
   memset(&local_uart, 0, sizeof(local_uart));
-  memset(&local_sc, 0, sizeof(local_sc));
 
-  sjsu::lpc40xx::SystemController::system_controller = &local_sc;
+  // Set mock for sjsu::SystemController
+  constexpr uint32_t kDummySystemControllerClockFrequency = 48'000'000;
+  Mock<sjsu::SystemController> mock_system_controller;
+  Fake(Method(mock_system_controller, PowerUpPeripheral));
+  When(Method(mock_system_controller, GetPeripheralFrequency))
+      .AlwaysReturn(kDummySystemControllerClockFrequency);
 
   Mock<sjsu::Pin> mock_tx;
   Fake(Method(mock_tx, SetPinFunction));
@@ -36,7 +38,7 @@ TEST_CASE("Testing lpc40xx Uart", "[lpc40xx-Uart]")
   };
   constexpr uint32_t kBaudRate = 9600;
 
-  Uart uart_test(kMockUart2);
+  Uart uart_test(kMockUart2, mock_system_controller.get());
   uart_test.Initialize(kBaudRate);
 
   SECTION("Initialize")
@@ -49,8 +51,11 @@ TEST_CASE("Testing lpc40xx Uart", "[lpc40xx-Uart]")
     constexpr uint32_t kExpectedMul       = 2;
     constexpr uint32_t kExpectedFdr = (kExpectedMul << 4) | kExpectedDivAdd;
 
-    CHECK(sjsu::lpc40xx::SystemController().IsPeripheralPoweredUp(
-        sjsu::lpc40xx::SystemController::Peripherals::kUart2));
+    Verify(Method(mock_system_controller, PowerUpPeripheral)
+               .Matching([](sjsu::SystemController::PeripheralID id) {
+                 return sjsu::lpc40xx::SystemController::Peripherals::kUart2
+                            .device_id == id.device_id;
+               }));
 
     Verify(Method(mock_tx, SetMode).Using(sjsu::Pin::Mode::kPullUp)).Once();
     Verify(Method(mock_tx, SetPinFunction).Using(kMockUart2.tx_function_id))

--- a/library/L1_Peripheral/lpc40xx/uart.hpp
+++ b/library/L1_Peripheral/lpc40xx/uart.hpp
@@ -49,14 +49,16 @@ constexpr UartCalibration_t FindClosestFractional(float decimal)
   return result;
 }
 
-constexpr float DividerEstimate(float baud_rate, float fraction_estimate = 1,
+constexpr float DividerEstimate(float baud_rate,
+                                float fraction_estimate       = 1,
                                 uint32_t peripheral_frequency = 1)
 {
   float clock_frequency = static_cast<float>(peripheral_frequency);
   return clock_frequency / (16.0f * baud_rate * fraction_estimate);
 }
 
-constexpr float FractionalEstimate(float baud_rate, float divider,
+constexpr float FractionalEstimate(float baud_rate,
+                                   float divider,
                                    uint32_t peripheral_frequency)
 {
   float clock_frequency = static_cast<float>(peripheral_frequency);
@@ -90,10 +92,11 @@ enum class States
 };
 
 constexpr static UartCalibration_t GenerateUartCalibration(
-    float baud_rate, uint32_t peripheral_frequency)
+    uint32_t baud_rate, uint32_t peripheral_frequency)
 {
   States state = States::kCalculateIntegerDivideLatch;
   UartCalibration_t uart_calibration;
+  float baud_rate_float = static_cast<float>(baud_rate);
   float divide_estimate = 0;
   float decimal         = 1.5;
   float div             = 1;
@@ -104,7 +107,8 @@ constexpr static UartCalibration_t GenerateUartCalibration(
     {
       case States::kCalculateIntegerDivideLatch:
       {
-        divide_estimate = DividerEstimate(baud_rate, 1, peripheral_frequency);
+        divide_estimate =
+            DividerEstimate(baud_rate_float, 1, peripheral_frequency);
 
         if (divide_estimate < 1.0f)
         {
@@ -126,8 +130,8 @@ constexpr static UartCalibration_t GenerateUartCalibration(
       case States::kCalculateDivideLatchWithDecimal:
       {
         divide_estimate = RoundFloat(
-            DividerEstimate(baud_rate, decimal, peripheral_frequency));
-        decimal = FractionalEstimate(baud_rate, divide_estimate,
+            DividerEstimate(baud_rate_float, decimal, peripheral_frequency));
+        decimal = FractionalEstimate(baud_rate_float, divide_estimate,
                                      peripheral_frequency);
         if (1.1f <= decimal && decimal <= 1.9f)
         {
@@ -174,7 +178,7 @@ constexpr static UartCalibration_t GenerateUartCalibration(
 }
 }  // namespace uart
 
-class Uart final : public sjsu::Uart, protected sjsu::lpc40xx::SystemController
+class Uart final : public sjsu::Uart
 {
  public:
   using sjsu::Uart::Read;
@@ -184,23 +188,11 @@ class Uart final : public sjsu::Uart, protected sjsu::lpc40xx::SystemController
   struct Port_t
   {
     LPC_UART_TypeDef * registers;
-    PeripheralID power_on_id;
+    sjsu::SystemController::PeripheralID power_on_id;
     const sjsu::Pin & tx;
     const sjsu::Pin & rx;
     uint8_t tx_function_id : 3;
     uint8_t rx_function_id : 3;
-  };
-
-  static constexpr uart::UartCalibration_t kBaudRateLUT[] = {
-    uart::GenerateUartCalibration(4800, config::kSystemClockRate),
-    uart::GenerateUartCalibration(9600, config::kSystemClockRate),
-    uart::GenerateUartCalibration(19200, config::kSystemClockRate),
-    uart::GenerateUartCalibration(38400, config::kSystemClockRate),
-    uart::GenerateUartCalibration(57600, config::kSystemClockRate),
-    uart::GenerateUartCalibration(115200, config::kSystemClockRate),
-    uart::GenerateUartCalibration(230400, config::kSystemClockRate),
-    uart::GenerateUartCalibration(460800, config::kSystemClockRate),
-    uart::GenerateUartCalibration(921600, config::kSystemClockRate),
   };
 
   struct Port  // NOLINT
@@ -221,7 +213,7 @@ class Uart final : public sjsu::Uart, protected sjsu::lpc40xx::SystemController
    public:
     inline static const Port_t kUart0 = {
       .registers      = LPC_UART0,
-      .power_on_id    = Peripherals::kUart0,
+      .power_on_id    = sjsu::lpc40xx::SystemController::Peripherals::kUart0,
       .tx             = kUart0Tx,
       .rx             = kUart0Rx,
       .tx_function_id = 0b001,
@@ -230,7 +222,7 @@ class Uart final : public sjsu::Uart, protected sjsu::lpc40xx::SystemController
 
     inline static const Port_t kUart2 = {
       .registers      = LPC_UART2,
-      .power_on_id    = Peripherals::kUart2,
+      .power_on_id    = sjsu::lpc40xx::SystemController::Peripherals::kUart2,
       .tx             = kUart2Tx,
       .rx             = kUart2Rx,
       .tx_function_id = 0b010,
@@ -239,7 +231,7 @@ class Uart final : public sjsu::Uart, protected sjsu::lpc40xx::SystemController
 
     inline static const Port_t kUart3 = {
       .registers      = LPC_UART3,
-      .power_on_id    = Peripherals::kUart3,
+      .power_on_id    = sjsu::lpc40xx::SystemController::Peripherals::kUart3,
       .tx             = kUart3Tx,
       .rx             = kUart3Rx,
       .tx_function_id = 0b010,
@@ -248,34 +240,44 @@ class Uart final : public sjsu::Uart, protected sjsu::lpc40xx::SystemController
 
     inline static const Port_t kUart4 = {
       .registers      = reinterpret_cast<LPC_UART_TypeDef *>(LPC_UART4),
-      .power_on_id    = Peripherals::kUart4,
+      .power_on_id    = sjsu::lpc40xx::SystemController::Peripherals::kUart4,
       .tx             = kUart4Tx,
       .rx             = kUart4Rx,
       .tx_function_id = 0b101,
       .rx_function_id = 0b011,
     };
   };
+  static constexpr sjsu::lpc40xx::SystemController kLpc40xxSystemController =
+      sjsu::lpc40xx::SystemController();
 
-  explicit constexpr Uart(const Port_t & port) : port_(port) {}
+  explicit constexpr Uart(const Port_t & port,
+                          const sjsu::SystemController & system_controller =
+                              kLpc40xxSystemController)
+      : port_(port), system_controller_(system_controller)
+  {
+  }
 
-  /// For LPC40xx only supports the following baud rates:
-  ///   4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600
+  Status Initialize(uint32_t baud_rate) const override
+  {
+    constexpr uint8_t kFIFOEnableAndReset = 0b111;
+    // Powering the port
+    system_controller_.PowerUpPeripheral(port_.power_on_id);
+    SetBaudRate(baud_rate);
+    // Setting the pin functions and modes
+    port_.rx.SetPinFunction(port_.rx_function_id);
+    port_.tx.SetPinFunction(port_.tx_function_id);
+    port_.rx.SetMode(sjsu::Pin::Mode::kPullUp);
+    port_.tx.SetMode(sjsu::Pin::Mode::kPullUp);
+    port_.registers->FCR |= kFIFOEnableAndReset;
+
+    return Status::kSuccess;
+  }
+
   bool SetBaudRate(uint32_t baud_rate) const override
   {
-    uart::UartCalibration_t calibration;
-    switch (baud_rate)
-    {
-      case 4800: calibration = kBaudRateLUT[0]; break;
-      case 9600: calibration = kBaudRateLUT[1]; break;
-      case 19200: calibration = kBaudRateLUT[2]; break;
-      case 38400: calibration = kBaudRateLUT[3]; break;
-      case 57600: calibration = kBaudRateLUT[4]; break;
-      case 115200: calibration = kBaudRateLUT[5]; break;
-      case 230400: calibration = kBaudRateLUT[6]; break;
-      case 460800: calibration = kBaudRateLUT[7]; break;
-      case 921600: calibration = kBaudRateLUT[8]; break;
-      default: return false;
-    }
+    uart::UartCalibration_t calibration = uart::GenerateUartCalibration(
+        baud_rate, system_controller_.GetPeripheralFrequency());
+
     constexpr uint8_t kDlabBit = (1 << 7);
 
     uint8_t dlm = static_cast<uint8_t>((calibration.divide_latch >> 8) & 0xFF);
@@ -291,41 +293,6 @@ class Uart final : public sjsu::Uart, protected sjsu::lpc40xx::SystemController
     return true;
   }
 
-  void SetNonStandardBaudRate(uint32_t baud_rate)
-  {
-    constexpr uint8_t kDlabBit = (1 << 7);
-    float baudrate             = static_cast<float>(baud_rate);
-    uart::UartCalibration_t dividers =
-        uart::GenerateUartCalibration(baudrate, GetPeripheralFrequency());
-
-    uint8_t dlm = static_cast<uint8_t>((dividers.divide_latch >> 8) & 0xFF);
-    uint8_t dll = static_cast<uint8_t>(dividers.divide_latch & 0xFF);
-    uint8_t fdr = static_cast<uint8_t>((dividers.multiply & 0xF) << 4 |
-                                       (dividers.divide_add & 0xF));
-
-    port_.registers->LCR = kDlabBit;
-    port_.registers->DLM = dlm;
-    port_.registers->DLL = dll;
-    port_.registers->FDR = fdr;
-    port_.registers->LCR = kStandardUart;
-  }
-
-  Status Initialize(uint32_t baud_rate) const override
-  {
-    constexpr uint8_t kFIFOEnableAndReset = 0b111;
-    // Powering the port
-    PowerUpPeripheral(port_.power_on_id);
-    SetBaudRate(baud_rate);
-    // Setting the pin functions and modes
-    port_.rx.SetPinFunction(port_.rx_function_id);
-    port_.tx.SetPinFunction(port_.tx_function_id);
-    port_.rx.SetMode(sjsu::Pin::Mode::kPullUp);
-    port_.tx.SetMode(sjsu::Pin::Mode::kPullUp);
-    port_.registers->FCR |= kFIFOEnableAndReset;
-
-    return Status::kSuccess;
-  }
-
   void Write(const uint8_t * data, size_t size) const override
   {
     for (size_t i = 0; i < size; i++)
@@ -338,7 +305,8 @@ class Uart final : public sjsu::Uart, protected sjsu::lpc40xx::SystemController
     }
   }
 
-  Status Read(uint8_t * data, size_t size,
+  Status Read(uint8_t * data,
+              size_t size,
               uint32_t timeout = UINT32_MAX) const override
   {
     // NOTE: Consider changing this to using a Wait() call.
@@ -371,6 +339,7 @@ class Uart final : public sjsu::Uart, protected sjsu::lpc40xx::SystemController
   }
 
   const Port_t & port_;
+  const sjsu::SystemController & system_controller_;
 };
 }  // namespace lpc40xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/spi.hpp
+++ b/library/L1_Peripheral/spi.hpp
@@ -34,8 +34,9 @@ class Spi
 
   virtual Status Initialize() const                                         = 0;
   virtual uint16_t Transfer(uint16_t data) const                            = 0;
-  virtual void SetPeripheralMode(MasterSlaveMode mode, DataSize size) const = 0;
-  virtual void SetClock(bool positive_polarity, bool phase, uint8_t prescaler,
-                        uint8_t divider) const                              = 0;
+  virtual void SetMode(MasterSlaveMode mode, DataSize size) const = 0;
+  virtual void SetClock(bool positive_polarity,
+                        bool phase,
+                        uint32_t frequency) const                           = 0;
 };
 }  // namespace sjsu

--- a/library/L2_HAL/displays/oled/ssd1306.hpp
+++ b/library/L2_HAL/displays/oled/ssd1306.hpp
@@ -128,10 +128,10 @@ class Ssd1306 final : public PixelDisplay
     cs_.Set(sjsu::Gpio::State::kHigh);
     dc_.Set(sjsu::Gpio::State::kHigh);
 
-    ssp_.SetPeripheralMode(sjsu::Spi::MasterSlaveMode::kMaster,
+    ssp_.SetMode(sjsu::Spi::MasterSlaveMode::kMaster,
                            sjsu::Spi::DataSize::kEight);
     // Set speed to 1Mhz by dividing by 1 * ClockFrequencyInMHz.
-    ssp_.SetClock(false, false, 1, config::kSystemClockRateMhz / 3);
+    ssp_.SetClock(false, false, 1'000'000);
     ssp_.Initialize();
 
     Clear();

--- a/library/L2_HAL/memory/sd.hpp
+++ b/library/L2_HAL/memory/sd.hpp
@@ -441,10 +441,10 @@ class Sd final : public SdInterface
     chip_select_.Set(Gpio::State::kHigh);
 
     LOG_DEBUG("Setting SSP Clock Speed...");
-    spi_.SetClock(false, false, 14, 2);  // 400kHz
+    spi_.SetClock(false, false, 400'000);
 
     LOG_DEBUG("Setting Peripheral Mode...");
-    spi_.SetPeripheralMode(Spi::MasterSlaveMode::kMaster,
+    spi_.SetMode(Spi::MasterSlaveMode::kMaster,
                            Spi::DataSize::kEight);
 
     LOG_DEBUG("Starting SSP Peripheral...");

--- a/library/L4_Testing/factory_test.hpp
+++ b/library/L4_Testing/factory_test.hpp
@@ -82,9 +82,8 @@ class FactoryTest
     cs.SetAsOutput();
     cs.SetHigh();
 
-    spi2.SetPeripheralMode(Spi::MasterSlaveMode::kMaster,
-                           Spi::DataSize::kEight);
-    spi2.SetClock(false, false, 100, 48);
+    spi2.SetMode(Spi::MasterSlaveMode::kMaster, Spi::DataSize::kEight);
+    spi2.SetClock(false, false, 100'000);
     spi2.Initialize();
 
     uint8_t array[5];
@@ -109,8 +108,10 @@ class FactoryTest
     return result;
   }
 
-  void OnBoardLedTest(bool gesture_test, bool accelerometer_test,
-                      bool temp_test, bool flash_test)
+  void OnBoardLedTest(bool gesture_test,
+                      bool accelerometer_test,
+                      bool temp_test,
+                      bool flash_test)
   {
     // Turn on all LEDs if all tests pass else none.
     // LED Test
@@ -187,7 +188,8 @@ class FactoryTest
     return (id_test_result && temp_test_result);
   }
 
-  bool CheckDeviceId(uint8_t device_address, uint8_t id_register_address,
+  bool CheckDeviceId(uint8_t device_address,
+                     uint8_t id_register_address,
                      uint8_t expected_id)
   {
     uint8_t device_id = 0x00;

--- a/projects/hyperload/source/main.cpp
+++ b/projects/hyperload/source/main.cpp
@@ -232,7 +232,8 @@ void SetFlashAcceleratorSpeed(int32_t clocks_per_flash_access)
 
 int main()
 {
-  sjsu::cortex::SystemTimer system_timer;
+  const sjsu::lpc40xx::SystemController kLpc40xxSystemController;
+  sjsu::cortex::SystemTimer system_timer(kLpc40xxSystemController);
   sjsu::lpc40xx::Gpio button0(1, 19);
   sjsu::lpc40xx::Gpio button1(1, 15);
   sjsu::lpc40xx::Gpio button2(0, 30);


### PR DESCRIPTION
By doing this, the SystemController can be dependency injected for
testing and for cross support with the SJOne board.

Resolves issue #551