### PR TITLE
Add Bit::Mask structure

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,7 +13,7 @@ AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
 AlwaysBreakAfterReturnType: None
 AlwaysBreakTemplateDeclarations: true
-BinPackArguments: true
+BinPackArguments: false
 BreakStringLiterals: true
 CompactNamespaces: true
 ConstructorInitializerAllOnOneLineOrOnePerLine: true

--- a/demos/sjtwo/adc/source/main.cpp
+++ b/demos/sjtwo/adc/source/main.cpp
@@ -11,7 +11,7 @@ int main()
 
   LOG_INFO("Creating Adc object and selecting ADC channel 0");
   LOG_INFO("ADC channel 0 is connected to pin P0.23");
-  sjsu::lpc40xx::Adc adc0(sjsu::lpc40xx::Adc::Channel::kChannel0);
+  sjsu::lpc40xx::Adc adc0(sjsu::lpc40xx::Adc::Channel::kChannel2);
   LOG_INFO("Initializing ADC ...");
   adc0.Initialize();
   LOG_INFO("Initializing ADC Complete!");
@@ -30,8 +30,8 @@ int main()
     uint16_t adc_digital_value = adc0.Read();
     // For the LPC40xx with a 12-bit ADC, lowest and highest values are 0 to
     // 1023, where as the lowest and highest voltages are between 0 and 3.3V
-    float voltage = sjsu::Map(adc_digital_value, 0, 1023, 0.0f, 3.3f);
-    LOG_INFO("Voltage on pin P0.23 = %f, raw value = %u\n",
+    float voltage = sjsu::Map(adc_digital_value, 0, 4095, 0.0f, 3.3f);
+    LOG_INFO("Voltage on pin P0.23 = %f, raw value = %u",
              static_cast<double>(voltage), adc_digital_value);
     sjsu::Delay(250);
   }

--- a/demos/sjtwo/temperature/source/main.cpp
+++ b/demos/sjtwo/temperature/source/main.cpp
@@ -1,6 +1,7 @@
 #include "L1_Peripheral/lpc40xx/i2c.hpp"
 #include "L2_HAL/sensors/environment/temperature/si7060.hpp"
 #include "utility/log.hpp"
+#include "utility/time.hpp"
 
 int main()
 {
@@ -11,22 +12,18 @@ int main()
 
   if (!temperature_sensor_initialized)
   {
-    LOG_INFO("Could not initialize temperature device (Si7060)\n\n");
+    LOG_ERROR("Could not initialize temperature device (Si7060)");
     sjsu::Halt();
   }
 
-  LOG_INFO("Temperature Device is ON.\n");
+  LOG_INFO("Temperature Device is ON.");
 
   while (temperature_sensor_initialized)
   {
-    double temperature_data;
-
-    temperature_data = static_cast<double>(temperature_sensor.GetCelsius());
-    LOG_INFO("Celsius data: %.2g \n", temperature_data);
-
-    // This will only return Fahrenheit.
-    temperature_data = static_cast<double>(temperature_sensor.GetFahrenheit());
-    LOG_INFO("Fahrenheit data: %.2g \n", temperature_data);
+    double temperature_data =
+        static_cast<double>(temperature_sensor.GetCelsius());
+    LOG_INFO("Board Temperature: %.4f C", temperature_data);
+    sjsu::Delay(1000);
   }
   return 0;
 }

--- a/demos/sjtwo/timer/source/main.cpp
+++ b/demos/sjtwo/timer/source/main.cpp
@@ -36,10 +36,11 @@ int main()
   timer2.Initialize(1'000'000, Timer2ISR);
   timer3.Initialize(1'000'000, Timer3ISR);
 
-  timer0.SetTimer(1'000'000, sjsu::lpc40xx::Timer::kInterruptRestart);
-  timer1.SetTimer(3'000'000, sjsu::lpc40xx::Timer::kInterruptRestart);
-  timer2.SetTimer(5'000'000, sjsu::lpc40xx::Timer::kInterruptRestart);
-  timer3.SetTimer(10'000'000, sjsu::lpc40xx::Timer::kInterruptRestart);
+  timer0.SetTimer(1'000'000, sjsu::Timer::TimerIsrCondition::kInterruptRestart);
+  timer1.SetTimer(3'000'000, sjsu::Timer::TimerIsrCondition::kInterruptRestart);
+  timer2.SetTimer(5'000'000, sjsu::Timer::TimerIsrCondition::kInterruptRestart);
+  timer3.SetTimer(10'000'000,
+                  sjsu::Timer::TimerIsrCondition::kInterruptRestart);
 
   sjsu::Halt();
   return 0;

--- a/library/L1_Peripheral/lpc17xx/pin.hpp
+++ b/library/L1_Peripheral/lpc17xx/pin.hpp
@@ -48,9 +48,16 @@ class Pin final : public sjsu::Pin
     return Pin(5, 4);
   }
 
-  constexpr Pin(uint8_t port, uint8_t pin) : sjsu::Pin(port, pin) {}
+  constexpr Pin(uint8_t port, uint8_t pin)
+      : sjsu::Pin(port, pin),
+        kPinMask{
+          .position = static_cast<uint8_t>(pin_ * 2),
+          .width    = 2,
+        }
+  {
+  }
 
-  uint32_t PinSelectRegister() const
+  uint32_t PinRegisterLookup() const
   {
     uint32_t odd_register = (pin_ > 15) ? 1 : 0;
     return (port_ * 2) + odd_register;
@@ -58,9 +65,9 @@ class Pin final : public sjsu::Pin
 
   void SetPinFunction(uint8_t function) const override
   {
-    uint32_t pin_reg_select = PinSelectRegister();
+    uint32_t pin_reg_select = PinRegisterLookup();
     function_map->pin[pin_reg_select] =
-        bit::Insert(function_map->pin[pin_reg_select], function, pin_ * 2, 2);
+        bit::Insert(function_map->pin[pin_reg_select], function, kPinMask);
   }
   static constexpr uint8_t kResistorModes[4] = {
     0b10,  // kInactive [0]
@@ -70,10 +77,11 @@ class Pin final : public sjsu::Pin
   };
   void SetMode(Mode mode) const override
   {
-    uint32_t pin_reg_select = PinSelectRegister();
+    uint32_t pin_reg_select = PinRegisterLookup();
     mode_map->pin[pin_reg_select] =
         bit::Insert(mode_map->pin[pin_reg_select],
-                    kResistorModes[util::Value(mode)], pin_ * 2, 2);
+                    kResistorModes[util::Value(mode)],
+                    kPinMask);
   }
   [[deprecated]] void SetAsAnalogMode(
       [[maybe_unused]] bool set_as_analog = true) const override {
@@ -82,9 +90,14 @@ class Pin final : public sjsu::Pin
 
   void SetAsOpenDrain(bool set_as_open_drain = true) const override
   {
-    open_drain_map->pin[port_] =
-        bit::Insert(open_drain_map->pin[port_], set_as_open_drain, pin_, 1);
+    open_drain_map->pin[port_] = bit::Insert(open_drain_map->pin[port_],
+                                             set_as_open_drain,
+                                             {
+                                                 .position = pin_,
+                                                 .width    = 1,
+                                             });
   }
+  const bit::Mask kPinMask;
 };
 }  // namespace lpc17xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc40xx/adc.hpp
+++ b/library/L1_Peripheral/lpc40xx/adc.hpp
@@ -28,33 +28,23 @@ class Adc final : public sjsu::Adc
 
   inline static LPC_ADC_TypeDef * adc_base = LPC_ADC;
 
-  union ControlRegister_t {
-    uint32_t data;
-    struct
-    {
-      unsigned channel_enable : 8;
-      unsigned clock_divider : 8;
-      unsigned enable_burst : 1;
-      unsigned reserved0 : 4;
-      unsigned power_enable : 1;
-      unsigned reserved1 : 2;
-      unsigned start_conversion_code : 3;
-      unsigned start_conversion_on_falling_edge : 1;
-    } bits;
+  struct Control  // NOLINT
+  {
+    static constexpr bit::Mask kChannelEnable = bit::CreateMaskFromRange(0, 7);
+    static constexpr bit::Mask kClockDivider  = bit::CreateMaskFromRange(8, 15);
+    static constexpr bit::Mask kBurstEnable   = bit::CreateMaskFromRange(16);
+    static constexpr bit::Mask kPowerEnable   = bit::CreateMaskFromRange(21);
+    static constexpr bit::Mask kStartCode = bit::CreateMaskFromRange(24, 26);
+    static constexpr bit::Mask kStartEdge = bit::CreateMaskFromRange(27);
   };
 
-  union GlobalDataRegister_t {
-    uint32_t data;
-    struct
-    {
-      unsigned reserved0 : 4;
-      unsigned result : 12;
-      unsigned reserved1 : 8;
-      unsigned converted_channel : 3;
-      unsigned reserved2 : 3;
-      unsigned overrun : 1;
-      unsigned done : 1;
-    } bits;
+  struct GlobalData  // NOLINT
+  {
+    static constexpr bit::Mask kResult = bit::CreateMaskFromRange(4, 15);
+    static constexpr bit::Mask kConvertedChannel =
+        bit::CreateMaskFromRange(24, 26);
+    static constexpr bit::Mask kOverrun = bit::CreateMaskFromRange(30);
+    static constexpr bit::Mask kDone    = bit::CreateMaskFromRange(31);
   };
 
   struct Channel_t
@@ -127,17 +117,10 @@ class Adc final : public sjsu::Adc
   static constexpr sjsu::lpc40xx::SystemController kLpc40xxSystemController =
       sjsu::lpc40xx::SystemController();
 
-  static volatile ControlRegister_t * GetControlRegister()
-  {
-    return reinterpret_cast<volatile ControlRegister_t *>(&adc_base->CR);
-  }
-  static volatile GlobalDataRegister_t * GetGlobalDataRegister()
-  {
-    return reinterpret_cast<volatile GlobalDataRegister_t *>(&adc_base->GDR);
-  }
   static void BurstMode(bool burst_mode_is_on = true)
   {
-    GetControlRegister()->bits.enable_burst = burst_mode_is_on;
+    adc_base->CR =
+        bit::Insert(adc_base->CR, burst_mode_is_on, Control::kBurstEnable);
   }
 
   explicit constexpr Adc(const Channel_t & channel,
@@ -155,44 +138,47 @@ class Adc final : public sjsu::Adc
     channel_.adc_pin.SetMode(sjsu::Pin::Mode::kInactive);
     channel_.adc_pin.SetAsAnalogMode(true);
 
-    ControlRegister_t control;
+    uint32_t clock_divider =
+        system_controller_.GetPeripheralFrequency() / kClockFrequency;
 
-    control.data = adc_base->CR;
-    control.bits.channel_enable =
-        (control.bits.channel_enable | (1 << channel_.channel)) & 0xFF;
-    control.bits.power_enable = true;
-    control.bits.clock_divider =
-        (system_controller_.GetPeripheralFrequency() / kClockFrequency) & 0xFF;
+    uint32_t control = adc_base->CR;
 
-    adc_base->CR = control.data;
+    control = bit::Set(control, channel_.channel);
+    control = bit::Set(control, Control::kPowerEnable.position);
+    control = bit::Insert(control, clock_divider, Control::kClockDivider);
+
+    adc_base->CR = control;
 
     return Status::kSuccess;
   }
   void Conversion() const override
   {
-    volatile ControlRegister_t * control = GetControlRegister();
-    if (control->bits.enable_burst)
+    if (bit::Read(adc_base->CR, Control::kBurstEnable.position))
     {
-      control->bits.start_conversion_code = 0;
+      // NOTE: If burst mode is enabled, conversion start must be set 0
+      adc_base->CR = bit::Insert(adc_base->CR, 0, Control::kStartCode);
     }
     else
     {
-      // 0x01 = start code for "Start Conversion Now"
-      control->bits.start_conversion_code = 0x01;
+      // NOTE: 0x01 = start code for "Start Conversion Now"
+      adc_base->CR = bit::Insert(adc_base->CR, 1, Control::kStartCode);
     }
 
-    while (!(GetGlobalDataRegister()->bits.done))
+    while (!HasConversionFinished())
     {
       continue;
     }
   }
   uint16_t Read() const override
   {
-    return GetGlobalDataRegister()->bits.result;
+    uint32_t result =
+        bit::Extract(adc_base->DR[channel_.channel], GlobalData::kResult);
+    return static_cast<uint16_t>(result);
   }
   bool HasConversionFinished() const override
   {
-    return GetGlobalDataRegister()->bits.done;
+    return bit::Read(adc_base->DR[channel_.channel],
+                     GlobalData::kDone.position);
   }
 
  private:

--- a/library/L1_Peripheral/lpc40xx/pin.hpp
+++ b/library/L1_Peripheral/lpc40xx/pin.hpp
@@ -23,20 +23,17 @@ class Pin final : public sjsu::Pin
 {
  public:
   // Source: "UM10562 LPC408x/407x User manual" table 83 page 132
-  enum PinBitMap : uint8_t
-  {
-    kFunction            = 0,
-    kMode                = 3,
-    kHysteresis          = 5,
-    kInputInvert         = 6,
-    kAnalogDigitalMode   = 7,
-    kDigitalFilter       = 8,
-    kI2cHighSpeed        = 8,
-    kSlew                = 9,
-    kI2cHighCurrentDrive = 9,
-    kOpenDrain           = 10,
-    kDacEnable           = 16
-  };
+  static constexpr bit::Mask kFunction    = bit::CreateMaskFromRange(0, 2);
+  static constexpr bit::Mask kMode        = bit::CreateMaskFromRange(3, 4);
+  static constexpr bit::Mask kHysteresis  = bit::CreateMaskFromRange(5);
+  static constexpr bit::Mask kInputInvert = bit::CreateMaskFromRange(6);
+  static constexpr bit::Mask kAnalogDigitalMode   = bit::CreateMaskFromRange(7);
+  static constexpr bit::Mask kDigitalFilter       = bit::CreateMaskFromRange(8);
+  static constexpr bit::Mask kI2cHighSpeed        = bit::CreateMaskFromRange(8);
+  static constexpr bit::Mask kSlew                = bit::CreateMaskFromRange(9);
+  static constexpr bit::Mask kI2cHighCurrentDrive = bit::CreateMaskFromRange(9);
+  static constexpr bit::Mask kOpenDrain = bit::CreateMaskFromRange(10);
+  static constexpr bit::Mask kDacEnable = bit::CreateMaskFromRange(16);
 
   struct [[gnu::packed]] PinMap_t
   {
@@ -63,72 +60,63 @@ class Pin final : public sjsu::Pin
     return Pin(5, 4);
   }
   constexpr Pin(uint8_t port, uint8_t pin) : sjsu::Pin(port, pin) {}
+
   void SetPinFunction(uint8_t function) const override
   {
-    *GetPinRegister() = bit::Insert(*GetPinRegister(), function,
-                                    util::Value(PinBitMap::kFunction), 3);
+    SetPinRegister(function, kFunction);
   }
   void SetMode(sjsu::Pin::Mode mode) const override
   {
-    uint8_t ui_mode   = static_cast<uint8_t>(mode);
-    *GetPinRegister() = bit::Insert(*GetPinRegister(), ui_mode,
-                                    util::Value(PinBitMap::kMode), 2);
+    SetPinRegister(static_cast<uint8_t>(mode), kMode);
   }
   // Set bit to 0 to enable analog mode
   void SetAsAnalogMode(bool set_as_analog = true) const override
   {
-    *GetPinRegister() =
-        bit::Insert(*GetPinRegister(), !set_as_analog,
-                    util::Value(PinBitMap::kAnalogDigitalMode), 1);
+    SetPinRegister(!set_as_analog, kAnalogDigitalMode);
   }
 
   void SetAsOpenDrain(bool set_as_open_drain = true) const override
   {
-    *GetPinRegister() = bit::Insert(*GetPinRegister(), set_as_open_drain,
-                                    util::Value(PinBitMap::kOpenDrain), 1);
+    SetPinRegister(set_as_open_drain, kOpenDrain);
   }
 
   void EnableHysteresis(bool enable_hysteresis = true) const
   {
-    *GetPinRegister() = bit::Insert(*GetPinRegister(), enable_hysteresis,
-                                    util::Value(PinBitMap::kHysteresis), 1);
+    SetPinRegister(enable_hysteresis, kHysteresis);
   }
   void SetAsActiveLow(bool set_as_active_low = true) const
   {
-    *GetPinRegister() = bit::Insert(*GetPinRegister(), set_as_active_low,
-                                    util::Value(PinBitMap::kInputInvert), 1);
+    SetPinRegister(set_as_active_low, kInputInvert);
   }
   // Enable by setting bit to 0 to enable digital filter.
   void EnableDigitalFilter(bool enable_digital_filter = true) const
   {
-    *GetPinRegister() = bit::Insert(*GetPinRegister(), !enable_digital_filter,
-                                    util::Value(PinBitMap::kDigitalFilter), 1);
+    SetPinRegister(!enable_digital_filter, kDigitalFilter);
   }
   void EnableFastMode(bool enable_fast_mode = true) const
   {
-    *GetPinRegister() = bit::Insert(*GetPinRegister(), enable_fast_mode,
-                                    util::Value(PinBitMap::kSlew), 1);
+    SetPinRegister(enable_fast_mode, kSlew);
   }
   // Enable by setting bit to 0 for i2c high speed mode
   void EnableI2cHighSpeedMode(bool enable_high_speed = true) const
   {
-    *GetPinRegister() = bit::Insert(*GetPinRegister(), !enable_high_speed,
-                                    util::Value(PinBitMap::kI2cHighSpeed), 1);
+    SetPinRegister(!enable_high_speed, kI2cHighSpeed);
   }
   void EnableI2cHighCurrentDrive(bool enable_high_current = true) const
   {
-    *GetPinRegister() =
-        bit::Insert(*GetPinRegister(), enable_high_current,
-                    util::Value(PinBitMap::kI2cHighCurrentDrive), 1);
+    SetPinRegister(enable_high_current, kI2cHighCurrentDrive);
   }
   void EnableDac(bool enable_dac = true) const
   {
-    *GetPinRegister() = bit::Insert(*GetPinRegister(), enable_dac,
-                                    util::Value(PinBitMap::kDacEnable), 1);
+    SetPinRegister(enable_dac, kDacEnable);
   }
 
  protected:
-  [[gnu::always_inline]] volatile uint32_t * GetPinRegister() const
+  void SetPinRegister(uint8_t data, bit::Mask mask) const
+  {
+    *PinRegister() = bit::Insert(*PinRegister(), data, mask);
+  }
+  [[gnu::always_inline]] volatile uint32_t * PinRegister() const
   {
     return &pin_map->_register[GetPort()][GetPin()];
   }

--- a/library/L1_Peripheral/lpc40xx/system_controller.hpp
+++ b/library/L1_Peripheral/lpc40xx/system_controller.hpp
@@ -7,6 +7,7 @@
 
 #include "L0_Platform/lpc40xx/LPC40xx.h"
 #include "L1_Peripheral/system_controller.hpp"
+#include "utility/bit.hpp"
 #include "utility/build_info.hpp"
 #include "utility/enum.hpp"
 #include "utility/log.hpp"
@@ -21,28 +22,28 @@ class SystemController : public sjsu::SystemController
  public:
   enum class UsbSource : uint16_t
   {
-    kBaseClock         = (0b00 << 8),
-    kMainPllClock      = (0b01 << 8),
-    kALternatePllClock = (0b10 << 8)
+    kBaseClock         = 0b00,
+    kMainPllClock      = 0b01,
+    kALternatePllClock = 0b10,
   };
 
   enum class SpifiSource : uint16_t
   {
-    kBaseClock         = (0b00 << 8),
-    kMainPllClock      = (0b01 << 8),
-    kALternatePllClock = (0b10 << 8)
+    kBaseClock         = 0b00,
+    kMainPllClock      = 0b01,
+    kALternatePllClock = 0b10,
   };
 
   enum class OscillatorSource : uint16_t
   {
     kIrc  = 0b0,
-    kMain = 0b1
+    kMain = 0b1,
   };
 
   enum class MainClockSource : uint16_t
   {
-    kBaseClock = (0b0 << 8),
-    kPllClock  = (0b1 << 8)
+    kBaseClock = 0b0,
+    kPllClock  = 0b1,
   };
 
   enum class PllInput : uint16_t
@@ -50,13 +51,13 @@ class SystemController : public sjsu::SystemController
     kIrc    = 12,
     kF12MHz = 12,
     kF16MHz = 16,
-    kF24MHz = 24
+    kF24MHz = 24,
   };
 
   enum class EmcDivider : uint8_t
   {
-    kSameSpeedAsCpu,
-    kHalfTheSpeedOfCpu
+    kSameSpeedAsCpu    = 0,
+    kHalfTheSpeedOfCpu = 1,
   };
 
   enum class UsbDivider : uint8_t
@@ -64,7 +65,7 @@ class SystemController : public sjsu::SystemController
     kDivideBy1 = 0,
     kDivideBy2,
     kDivideBy3,
-    kDivideBy4
+    kDivideBy4,
   };
 
   // LPC40xx Peripheral Power On Values:
@@ -107,21 +108,46 @@ class SystemController : public sjsu::SystemController
     static constexpr auto kUsb               = AddPeripheralID<31>();
   };
 
-  static constexpr uint32_t kOscillatorSelect       = (1 << 0);
-  static constexpr uint32_t kBaseClockSelect        = (1 << 8);
-  static constexpr uint32_t kUsbClockSource         = (0b11 << 8);
-  static constexpr uint32_t kSpifiClockSource       = (0b11 << 8);
   static constexpr uint32_t kEnablePll              = (0b1 << 0);
   static constexpr uint32_t kPlock                  = 10;
-  static constexpr uint32_t kDivideInputBy1         = 1;
   static constexpr uint32_t kClearPllMultiplier     = (0x1f << 0);
   static constexpr uint32_t kClearPllDivider        = (0b11 << 5);
-  static constexpr uint32_t kClearCpuDivider        = (0x1F << 0);
-  static constexpr uint32_t kClearEmcDivider        = (1 << 0);
   static constexpr uint32_t kClearPeripheralDivider = (0b1'1111);
-  static constexpr uint32_t kClearUsbDivider        = (0x1F << 0);
   static constexpr uint32_t kDefaultIRCFrequency    = 12'000'000;
   static constexpr uint32_t kDefaultTimeout         = 1'000;  // ms
+
+  struct Oscillator  // NOLINT
+  {
+    static constexpr bit::Mask kSelect = bit::CreateMaskFromRange(0);
+  };
+
+  struct EmcClock  // NOLINT
+  {
+    static constexpr bit::Mask kDivider = bit::CreateMaskFromRange(0);
+  };
+
+  struct CpuClock  // NOLINT
+  {
+    static constexpr bit::Mask kDivider = bit::CreateMaskFromRange(0, 4);
+    static constexpr bit::Mask kSelect  = bit::CreateMaskFromRange(8);
+  };
+
+  struct UsbClock  // NOLINT
+  {
+    static constexpr bit::Mask kDivider = bit::CreateMaskFromRange(0, 4);
+    static constexpr bit::Mask kSelect  = bit::CreateMaskFromRange(8, 9);
+  };
+
+  struct PeripheralClock  // NOLINT
+  {
+    static constexpr bit::Mask kDivider = bit::CreateMaskFromRange(0, 4);
+  };
+
+  struct SpiFiClock  // NOLINT
+  {
+    static constexpr bit::Mask kDivider = bit::CreateMaskFromRange(0, 4);
+    static constexpr bit::Mask kSelect  = bit::CreateMaskFromRange(8, 9);
+  };
 
   inline static LPC_SC_TypeDef * system_controller = LPC_SC;
 
@@ -140,8 +166,8 @@ class SystemController : public sjsu::SystemController
       SelectMainClockSource(MainClockSource::kBaseClock);
       speed_in_hertz = kDefaultIRCFrequency;
     }
-    SetCpuClockDivider(kDivideInputBy1);
-    SetPeripheralClockDivider(kDivideInputBy1);
+    SetCpuClockDivider(1);
+    SetPeripheralClockDivider(1);
     SetEmcClockDivider(EmcDivider::kSameSpeedAsCpu);
     return offset;
   }
@@ -187,49 +213,42 @@ class SystemController : public sjsu::SystemController
   void PowerUpPeripheral(
       const PeripheralID & peripheral_select) const final override
   {
-    auto power_connection_with_enabled_peripheral =
-        system_controller->PCONP | (1 << peripheral_select.device_id);
-
-    system_controller->PCONP = power_connection_with_enabled_peripheral;
+    system_controller->PCONP =
+        bit::Set(system_controller->PCONP, peripheral_select.device_id);
   }
   void PowerDownPeripheral(
       const PeripheralID & peripheral_select) const final override
   {
-    auto power_connection_without_enabled_peripheral =
-        system_controller->PCONP & ~(1 << peripheral_select.device_id);
-
-    system_controller->PCONP = power_connection_without_enabled_peripheral;
+    system_controller->PCONP =
+        bit::Clear(system_controller->PCONP, peripheral_select.device_id);
   }
 
  private:
   void SelectOscillatorSource(OscillatorSource source) const
   {
-    uint32_t source_bit = static_cast<uint32_t>(source);
-    system_controller->CLKSRCSEL =
-        (system_controller->CLKSRCSEL & ~(kOscillatorSelect)) | source_bit;
+    system_controller->CLKSRCSEL = bit::Insert(system_controller->CLKSRCSEL,
+                                               static_cast<uint32_t>(source),
+                                               Oscillator::kSelect);
   }
-
   void SelectMainClockSource(MainClockSource source) const
   {
-    system_controller->CCLKSEL =
-        (system_controller->CCLKSEL & ~(kBaseClockSelect)) |
-        static_cast<uint32_t>(source);
+    system_controller->CCLKSEL = bit::Insert(system_controller->CCLKSEL,
+                                             static_cast<uint32_t>(source),
+                                             CpuClock::kSelect);
   }
-
   void SelectUsbClockSource(UsbSource usb_clock) const
   {
-    system_controller->USBCLKSEL =
-        (system_controller->USBCLKSEL & ~(kUsbClockSource)) |
-        static_cast<uint32_t>(usb_clock);
+    system_controller->USBCLKSEL = bit::Insert(system_controller->USBCLKSEL,
+                                               static_cast<uint32_t>(usb_clock),
+                                               UsbClock::kSelect);
   }
-
   void SelectSpifiClockSource(SpifiSource spifi_clock) const
   {
     system_controller->SPIFISEL =
-        (system_controller->SPIFISEL & ~(kSpifiClockSource)) |
-        static_cast<uint32_t>(spifi_clock);
+        bit::Insert(system_controller->SPIFISEL,
+                    static_cast<uint32_t>(spifi_clock),
+                    SpiFiClock::kSelect);
   }
-
   uint32_t CalculatePll(PllInput input_frequency,
                         uint16_t desired_speed_in_mhz) const
   {
@@ -349,15 +368,17 @@ class SystemController : public sjsu::SystemController
   void SetCpuClockDivider(uint8_t cpu_divider) const
   {
     SJ2_ASSERT_FATAL(cpu_divider < 32, "Divider mustn't exceed 32");
-    system_controller->CCLKSEL =
-        (system_controller->CCLKSEL & ~kClearCpuDivider) | cpu_divider;
+
+    system_controller->CCLKSEL = bit::Insert(
+        system_controller->CCLKSEL, cpu_divider, CpuClock::kDivider);
   }
 
   void SetEmcClockDivider(EmcDivider emc_divider) const
   {
     system_controller->EMCCLKSEL =
-        (system_controller->EMCCLKSEL & ~kClearEmcDivider) |
-        static_cast<uint8_t>(emc_divider);
+        bit::Insert(system_controller->EMCCLKSEL,
+                    static_cast<uint32_t>(emc_divider),
+                    EmcClock::kDivider);
   }
   // TODO(#181): Set USB and Spifi clock rates
   inline static uint32_t speed_in_hertz = kDefaultIRCFrequency;

--- a/library/L1_Peripheral/lpc40xx/test/adc_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/adc_test.cpp
@@ -26,7 +26,8 @@ TEST_CASE("Testing lpc40xx adc", "[lpc40xx-adc]")
 
   // Set mock for sjsu::Pin
   Mock<sjsu::Pin> mock_adc_pin;
-  Fake(Method(mock_adc_pin, SetAsAnalogMode), Method(mock_adc_pin, SetMode),
+  Fake(Method(mock_adc_pin, SetAsAnalogMode),
+       Method(mock_adc_pin, SetMode),
        Method(mock_adc_pin, SetPinFunction));
 
   const Adc::Channel_t kMockChannel1 = {
@@ -77,11 +78,11 @@ TEST_CASE("Testing lpc40xx adc", "[lpc40xx-adc]")
     constexpr uint8_t kDoneBit      = 31;
 
     // Check if bit 24 in local_adc.CR for the start bits is set
-    local_adc.GDR |= (1 << kDoneBit);
+    local_adc.DR[kMockChannel1.channel] |= (1 << kDoneBit);
     channel0_mock.Conversion();
     CHECK(((local_adc.CR >> kStartBit) & 1) == kStartNoBurst);
     channel0_mock.HasConversionFinished();
-    CHECK(((local_adc.GDR >> kDoneBit) & 1) == kDone);
+    CHECK(((local_adc.DR[kMockChannel1.channel] >> kDoneBit) & 1) == kDone);
 
     // Check if bits 24 to 26 in local_adc.CR are cleared for burst mode
     // conversion
@@ -91,7 +92,7 @@ TEST_CASE("Testing lpc40xx adc", "[lpc40xx-adc]")
 
     // Check if done bit is set after conversion
     channel0_mock.HasConversionFinished();
-    CHECK(((local_adc.GDR >> kDoneBit) & 1) == kDone);
+    CHECK(((local_adc.DR[kMockChannel1.channel] >> kDoneBit) & 1) == kDone);
   }
   SECTION("Burst mode")
   {
@@ -113,7 +114,8 @@ TEST_CASE("Testing lpc40xx adc", "[lpc40xx-adc]")
 
     // Check if there is any value in the global data reg
     channel0_mock.Read();
-    CHECK(((local_adc.GDR >> kResultBit) & kResultMask) == 0);
+    CHECK(((local_adc.DR[kMockChannel1.channel] >> kResultBit) & kResultMask) ==
+          0);
   }
 
   sjsu::lpc40xx::SystemController::system_controller = LPC_SC;

--- a/library/L1_Peripheral/lpc40xx/timer.hpp
+++ b/library/L1_Peripheral/lpc40xx/timer.hpp
@@ -7,6 +7,7 @@
 #include "L1_Peripheral/lpc40xx/pin.hpp"
 #include "L1_Peripheral/lpc40xx/system_controller.hpp"
 #include "L1_Peripheral/timer.hpp"
+#include "utility/bit.hpp"
 #include "utility/enum.hpp"
 #include "utility/log.hpp"
 #include "utility/status.hpp"
@@ -18,16 +19,6 @@ namespace lpc40xx
 class Timer final : public sjsu::Timer
 {
  public:
-  enum RegisterChoice : uint8_t
-  {
-    kRegMR0 = 0,
-    kRegMR1 = 1,
-    kRegMR2 = 2,
-    kRegMR3 = 3,
-    kRegCR0 = 4,
-    kRegCR1 = 5
-  };
-
   struct ChannelPartial_t
   {
     LPC_TIM_TypeDef * timer_register;
@@ -111,8 +102,8 @@ class Timer final : public sjsu::Timer
     {
       (*channel.user_callback)();
     }
-    channel.timer_register->IR |=
-        (1 << kRegMR0) | (1 << kRegMR1) | (1 << kRegMR2) | (1 << kRegMR3);
+    // Clear interrupts for all 4 match register interrupt flag
+    channel.timer_register->IR |= 0b1111;
   }
 
   static constexpr sjsu::lpc40xx::SystemController kLpc40xxSystemController =
@@ -136,7 +127,6 @@ class Timer final : public sjsu::Timer
                     IsrPointer isr   = nullptr,
                     int32_t priority = -1) const override
   {
-    constexpr uint32_t kClear = std::numeric_limits<uint32_t>::max();
     system_controller_.PowerUpPeripheral(timer_.channel.power_id);
     SJ2_ASSERT_FATAL(
         frequency != 0,
@@ -144,8 +134,7 @@ class Timer final : public sjsu::Timer
     // Set Prescale register for Prescale Counter to milliseconds
     uint32_t prescaler =
         system_controller_.GetPeripheralFrequency() / frequency;
-    timer_.channel.timer_register->PR &= ~(kClear << 1);
-    timer_.channel.timer_register->PR |= (prescaler << 1);
+    timer_.channel.timer_register->PR = prescaler;
     timer_.channel.timer_register->TCR |= (1 << 0);
     *timer_.channel.user_callback = isr;
     RegisterIsr(timer_.channel.irq, timer_.isr, true, priority);
@@ -166,15 +155,19 @@ class Timer final : public sjsu::Timer
                 TimerIsrCondition condition,
                 uint8_t match_register = 0) const override
   {
-    SJ2_ASSERT_FATAL(match_register > 3,
+    SJ2_ASSERT_FATAL(match_register < 3,
                      "The LPC40xx can only has 3 match registers. An attempt "
                      "to set match register %d was attempted.",
                      match_register);
 
-    static constexpr uint8_t kClearMode = 0b0111;
+    timer_.channel.timer_register->MCR =
+        bit::Insert(timer_.channel.timer_register->MCR,
+                    static_cast<uint32_t>(condition),
+                    {
+                        .position = static_cast<uint8_t>(match_register * 3),
+                        .width    = 3,
+                    });
 
-    timer_.channel.timer_register->MCR &= ~(kClearMode << match_register);
-    timer_.channel.timer_register->MCR |= condition << match_register;
     // MR0, MR1, MR2, and MR3 are contiguous, so we can point to the first
     // match register and index from there to get the other match registers.
     volatile uint32_t * match_register_ptr =

--- a/library/L1_Peripheral/lpc40xx/uart.hpp
+++ b/library/L1_Peripheral/lpc40xx/uart.hpp
@@ -329,13 +329,13 @@ class Uart final : public sjsu::Uart
   }
   bool HasData() const override
   {
-    return port_.registers->LSR & (1 << 0);
+    return bit::Read(port_.registers->LSR, 0);
   }
 
  private:
   bool TransmissionComplete() const
   {
-    return (port_.registers->LSR & (1 << 5));
+    return bit::Read(port_.registers->LSR, 5);
   }
 
   const Port_t & port_;

--- a/library/L1_Peripheral/system_controller.hpp
+++ b/library/L1_Peripheral/system_controller.hpp
@@ -13,7 +13,7 @@ class SystemController
   class PeripheralID
   {
    public:
-    size_t device_id = -1;
+    uint8_t device_id = -1;
   };
   template <size_t kDeviceId>
   class AddPeripheralID : public PeripheralID

--- a/library/L1_Peripheral/timer.hpp
+++ b/library/L1_Peripheral/timer.hpp
@@ -13,7 +13,7 @@ class Timer
   // Modes for each match register that when match register matches timer
   // system can trigger an Interrupt, Stop Counter, or Restart and in any
   // mixture of those commands.
-  enum TimerIsrCondition : uint8_t
+  enum class TimerIsrCondition : uint8_t
   {
     kInterrupt            = 0b001,
     kRestart              = 0b010,

--- a/library/L2_HAL/sensors/environment/temperature/si7060.hpp
+++ b/library/L2_HAL/sensors/environment/temperature/si7060.hpp
@@ -13,7 +13,7 @@ class Si7060 final : public Temperature
   static constexpr uint8_t kIdRegister              = 0xC0;
   static constexpr uint8_t kExpectedSensorId        = 0x14;
   static constexpr uint8_t kOneBurstRegister        = 0xC4;
-  static constexpr uint8_t kAutonicBitRegister      = 0xC5;
+  static constexpr uint8_t kAutomaticBitRegister    = 0xC5;
   static constexpr uint8_t kMostSignificantRegister = 0xC1;
 
   explicit Si7060(I2c & i2c, uint8_t address = kDefaultAddress)
@@ -26,42 +26,42 @@ class Si7060 final : public Temperature
     i2c_.Initialize();
     uint8_t temperature_sensor_id_register;
     // is the same as the Base ID (0x14).
-    i2c_.WriteThenRead(address_, { kIdRegister },
-                       &temperature_sensor_id_register, 1);
+    i2c_.WriteThenRead(
+        address_, { kIdRegister }, &temperature_sensor_id_register, 1);
     return (temperature_sensor_id_register == kExpectedSensorId);
   }
 
   float GetCelsius() override
   {
+    // Note that: 1 << 14 = 2^14 = 16384
+    constexpr int32_t kSubtractTemperatureData = 1 << 14;
+
     uint8_t most_significant_register;
     uint8_t least_significant_register;
     // The register will enable the device to collect data once
     // and automatically sets the stop bit to 0 (2nd bit).
     i2c_.Write(address_, { kOneBurstRegister, 0x04 }, 2);
     // Auto increments I2c register address pointer.
-    i2c_.Write(address_, { kAutonicBitRegister, 0x01 }, 2);
-    i2c_.WriteThenRead(address_, { kMostSignificantRegister },
-                       &most_significant_register, 1);
+    i2c_.Write(address_, { kAutomaticBitRegister, 0x01 }, 2);
+    i2c_.WriteThenRead(
+        address_, { kMostSignificantRegister }, &most_significant_register, 1);
     i2c_.Read(address_, &least_significant_register, 1);
 
-    uint32_t temperature_data = 0;
-    // Shift all bits to the 15th bit.
-    temperature_data =
-        bit::Insert(temperature_data, most_significant_register, 8, 16);
     // The write and read operation sets the most significant bit to one,
     // telling the register that the data has been read.
     // Therefore must clear the most significant bit from above.
-    temperature_data = bit::Clear(temperature_data, 15);
-    temperature_data =
-        bit::Insert(temperature_data, least_significant_register, 0, 8);
+    most_significant_register = bit::Clear(most_significant_register, 7);
+    // Combine temperature register data
+    int32_t temperature_data =
+        (most_significant_register << 8) | least_significant_register;
     // The required computation after bit shifting.
     // Formula can be found below, see page 4:
     // datasheets/Temperature-Sensor/si7060-datasheets.pdf
-    // Note that: 1 << 14 = 2^14 = 16384
-    uint16_t new_temperature_data = static_cast<uint16_t>(temperature_data);
-    constexpr float kSubtractTemperatureData = static_cast<float>(1 << 14);
-    return (((new_temperature_data - kSubtractTemperatureData) / 160.0f) +
-            55.0f);
+    float temperature =
+        static_cast<float>(temperature_data - kSubtractTemperatureData);
+    temperature = (temperature / 160.0f) + 55.0f;
+
+    return temperature;
   }
 
   float GetFahrenheit() override

--- a/library/utility/test/bit_test.cpp
+++ b/library/utility/test/bit_test.cpp
@@ -70,6 +70,112 @@ TEST_CASE("Testing Bit Manipulations", "[bit manipulation]")
     CHECK(0xAAAA'BCDB == bit::Insert(target, value_to_insert, 4, 8));
   }
 
+  SECTION("Insert with Mask")
+  {
+    CHECK(0b0110'0000 == bit::Insert(0,
+                                     0b11,
+                                     {
+                                         .position = 5,
+                                         .width    = 2,
+                                     }));
+    static_assert(0b0110'0000 == bit::Insert(0,
+                                             0b11,
+                                             {
+                                                 .position = 5,
+                                                 .width    = 2,
+                                             }));
+
+    CHECK(0b0000'1110 == bit::Insert(0,
+                                     0b111,
+                                     {
+                                         .position = 1,
+                                         .width    = 3,
+                                     }));
+    static_assert(0b0000'1110 == bit::Insert(0,
+                                             0b111,
+                                             {
+                                                 .position = 1,
+                                                 .width    = 3,
+                                             }));
+
+    CHECK(0b0000'1111 == bit::Insert(0,
+                                     0b1111,
+                                     {
+                                         .position = 0,
+                                         .width    = 4,
+                                     }));
+    static_assert(0b0000'1111 == bit::Insert(0,
+                                             0b1111,
+                                             {
+                                                 .position = 0,
+                                                 .width    = 4,
+                                             }));
+
+    CHECK(0xAB00'0000 == bit::Insert(0,
+                                     0xAB,
+                                     {
+                                         .position = 24,
+                                         .width    = 8,
+                                     }));
+    static_assert(0xAB00'0000 == bit::Insert(0,
+                                             0xAB,
+                                             {
+                                                 .position = 24,
+                                                 .width    = 8,
+                                             }));
+
+    CHECK(0xDEAD'BEEF == bit::Insert(0xD00D'BEEF,
+                                     0xEA,
+                                     {
+                                         .position = 20,
+                                         .width    = 8,
+                                     }));
+    static_assert(0xDEAD'BEEF == bit::Insert(0xD00D'BEEF,
+                                             0xEA,
+                                             {
+                                                 .position = 20,
+                                                 .width    = 8,
+                                             }));
+
+    // Shows replacement of DEAD -> BEEF
+    CHECK(0xDEAD'BEEF == bit::Insert(0xDEAD'DEAD,
+                                     0xBEEF,
+                                     {
+                                         .position = 0,
+                                         .width    = 16,
+                                     }));
+    static_assert(0xDEAD'BEEF == bit::Insert(0xDEAD'DEAD,
+                                             0xBEEF,
+                                             {
+                                                 .position = 0,
+                                                 .width    = 16,
+                                             }));
+
+    // Shows replacement of 0101 -> 1111 in the middle of byte
+    CHECK(0b1011'1101 == bit::Insert(0b1010'0101,
+                                     0b1111,
+                                     {
+                                         .position = 2,
+                                         .width    = 4,
+                                     }));
+    static_assert(0b1011'1101 == bit::Insert(0b1010'0101,
+                                             0b1111,
+                                             {
+                                                 .position = 2,
+                                                 .width    = 4,
+                                             }));
+
+    uint32_t target        = 0xAAAA'BBBB;
+    int8_t value_to_insert = 0xCD;
+    // Shows replacement of 0101 -> 1111 in the middle of byte
+    CHECK(0xAAAA'BCDB == bit::Insert(target,
+                                     value_to_insert,
+                                     {
+                                         .position = 4,
+                                         .width    = 8,
+                                     }));
+  }
+
   SECTION("Set")
   {
     CHECK(0b0001'1111 == bit::Set(0b1111, 4));


### PR DESCRIPTION
Along with adding the bit::Mask structure, the codebase has been
refactored to use static constexpr bit::Mask objects when manipulating
bits using bit::Insert or bit::Extract