### PR TITLE
Alert user if project directory has been moved

### DIFF
--- a/demos/arm_cortex/dwt_counter/makefile
+++ b/demos/arm_cortex/dwt_counter/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/arm_cortex/system_timer/makefile
+++ b/demos/arm_cortex/system_timer/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/multiplatform/backtrace/makefile
+++ b/demos/multiplatform/backtrace/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/multiplatform/delay/makefile
+++ b/demos/multiplatform/delay/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/multiplatform/examples/makefile
+++ b/demos/multiplatform/examples/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/multiplatform/file_io/makefile
+++ b/demos/multiplatform/file_io/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/multiplatform/log_level_print/makefile
+++ b/demos/multiplatform/log_level_print/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/multiplatform/periodic_scheduler/makefile
+++ b/demos/multiplatform/periodic_scheduler/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/multiplatform/print_return_codes/makefile
+++ b/demos/multiplatform/print_return_codes/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/multiplatform/stdin/makefile
+++ b/demos/multiplatform/stdin/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/multiplatform/task_scheduler/makefile
+++ b/demos/multiplatform/task_scheduler/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjone/system_controller/makefile
+++ b/demos/sjone/system_controller/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/Servo/makefile
+++ b/demos/sjtwo/Servo/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/adc/makefile
+++ b/demos/sjtwo/adc/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/button/makefile
+++ b/demos/sjtwo/button/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/buzzer/makefile
+++ b/demos/sjtwo/buzzer/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/command_line/makefile
+++ b/demos/sjtwo/command_line/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/dac/makefile
+++ b/demos/sjtwo/dac/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/factory_test/makefile
+++ b/demos/sjtwo/factory_test/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/freertos_blinker/makefile
+++ b/demos/sjtwo/freertos_blinker/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/gpio/makefile
+++ b/demos/sjtwo/gpio/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/gpio_interrupts/makefile
+++ b/demos/sjtwo/gpio_interrupts/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/i2c/makefile
+++ b/demos/sjtwo/i2c/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/i2c_device/makefile
+++ b/demos/sjtwo/i2c_device/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/oled/makefile
+++ b/demos/sjtwo/oled/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/oled_printf/makefile
+++ b/demos/sjtwo/oled_printf/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/parallel_lcd/makefile
+++ b/demos/sjtwo/parallel_lcd/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/pin_configuration/makefile
+++ b/demos/sjtwo/pin_configuration/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/pwm/makefile
+++ b/demos/sjtwo/pwm/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/sd_card/makefile
+++ b/demos/sjtwo/sd_card/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/spi/makefile
+++ b/demos/sjtwo/spi/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/system_clock/makefile
+++ b/demos/sjtwo/system_clock/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/temperature/makefile
+++ b/demos/sjtwo/temperature/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/timer/makefile
+++ b/demos/sjtwo/timer/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/uart/makefile
+++ b/demos/sjtwo/uart/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/project_makefile.mk
+++ b/project_makefile.mk
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/projects/hello_world/makefile
+++ b/projects/hello_world/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/projects/hyperload/makefile
+++ b/projects/hyperload/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/projects/starter/makefile
+++ b/projects/starter/makefile
@@ -1,5 +1,15 @@
 # sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
 # the SJSU-Dev2 folder.
 include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
 # Using the directory location, include the project makefile
 include $(SJSU_DEV2_BASE)/makefile

--- a/setup
+++ b/setup
@@ -187,8 +187,18 @@ function generate_location_file()
   echo "         Generating SJSU-Dev2 Location File          "
   echo "└─────────────────────────────────────────────────── "
   cat >~/.sjsu_dev2.mk <<EOL
-  # Location of SJSU-Dev2 folder
-  SJSU_DEV2_BASE    = $BASE
+# Location of SJSU-Dev2 folder
+SJSU_DEV2_BASE    = $BASE
+
+ifeq (,\$(wildcard \$(SJSU_DEV2_BASE)))
+\$(info +-------------- SJSU-Dev2 Folder Not Found Error ---------------+)
+\$(info |                                                               |)
+\$(info | To update the location of SJSU-Dev2's folder run ./setup      |)
+\$(info |                                                               |)
+\$(info +---------------------------------------------------------------+)
+\$(error )
+endif
+
 EOL
   return $?
 }


### PR DESCRIPTION
Rather than giving an error that simply says, file not found alert the
user to what they need to do when this happens. And in this case simply
running setup again should do the trick.

Resolves: #391