### PR TITLE
Adding LPC17xx L1 configuration structures

### DIFF
--- a/library/L1_Peripheral/lpc17xx/adc.hpp
+++ b/library/L1_Peripheral/lpc17xx/adc.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "L1_Peripheral/lpc17xx/pin.hpp"
 #include "L1_Peripheral/lpc40xx/adc.hpp"
 
 namespace sjsu
@@ -8,5 +9,66 @@ namespace lpc17xx
 {
 // The LPC40xx driver is compatible with the lpc17xx peripheral
 using ::sjsu::lpc40xx::Adc;
+
+struct AdcChannel  // NOLINT
+{
+ private:
+  enum AdcMode : uint8_t
+  {
+    kCh0123Pins = 0b01,
+    kCh45Pins   = 0b11,
+    kCh67Pins   = 0b10,
+  };
+  inline static const Pin kAdcPinChannel0 = Pin::CreatePin<0, 23>();
+  inline static const Pin kAdcPinChannel1 = Pin::CreatePin<0, 24>();
+  inline static const Pin kAdcPinChannel2 = Pin::CreatePin<0, 25>();
+  inline static const Pin kAdcPinChannel3 = Pin::CreatePin<0, 26>();
+  inline static const Pin kAdcPinChannel4 = Pin::CreatePin<1, 30>();
+  inline static const Pin kAdcPinChannel5 = Pin::CreatePin<1, 31>();
+  inline static const Pin kAdcPinChannel6 = Pin::CreatePin<0, 3>();
+  inline static const Pin kAdcPinChannel7 = Pin::CreatePin<0, 2>();
+
+ public:
+  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel0 = {
+    .adc_pin      = kAdcPinChannel0,
+    .channel      = 0,
+    .pin_function = AdcMode::kCh0123Pins,
+  };
+  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel1 = {
+    .adc_pin      = kAdcPinChannel1,
+    .channel      = 1,
+    .pin_function = AdcMode::kCh0123Pins,
+  };
+  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel2 = {
+    .adc_pin      = kAdcPinChannel2,
+    .channel      = 2,
+    .pin_function = AdcMode::kCh0123Pins,
+  };
+  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel3 = {
+    .adc_pin      = kAdcPinChannel3,
+    .channel      = 3,
+    .pin_function = AdcMode::kCh0123Pins,
+  };
+  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel4 = {
+    .adc_pin      = kAdcPinChannel4,
+    .channel      = 4,
+    .pin_function = AdcMode::kCh45Pins,
+  };
+  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel5 = {
+    .adc_pin      = kAdcPinChannel5,
+    .channel      = 5,
+    .pin_function = AdcMode::kCh45Pins,
+  };
+  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel6 = {
+    .adc_pin      = kAdcPinChannel6,
+    .channel      = 6,
+    .pin_function = AdcMode::kCh67Pins,
+  };
+  inline static const sjsu::lpc40xx::Adc::Channel_t kChannel7 = {
+    .adc_pin      = kAdcPinChannel7,
+    .channel      = 7,
+    .pin_function = AdcMode::kCh67Pins,
+  };
+};
 }  // namespace lpc17xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc17xx/dac.hpp
+++ b/library/L1_Peripheral/lpc17xx/dac.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "L1_Peripheral/lpc17xx/pin.hpp"
 #include "L1_Peripheral/lpc40xx/dac.hpp"
 
 namespace sjsu
@@ -7,5 +8,10 @@ namespace sjsu
 namespace lpc17xx
 {
 using ::sjsu::lpc40xx::Dac;
+
+struct DacChannel // NOLINT
+{
+  static constexpr Pin kDacPin = Pin::CreatePin<0, 26>();
+};
 }  // namespace lpc17xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc17xx/pwm.hpp
+++ b/library/L1_Peripheral/lpc17xx/pwm.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "L1_Peripheral/lpc17xx/pin.hpp"
+#include "L1_Peripheral/lpc17xx/system_controller.hpp"
 #include "L1_Peripheral/lpc40xx/pwm.hpp"
 
 namespace sjsu
@@ -8,5 +10,58 @@ namespace lpc17xx
 {
 // The LPC40xx driver is compatible with the lpc17xx peripheral
 using ::sjsu::lpc40xx::Pwm;
+
+struct PwmChannel  // NOLINT
+{
+ private:
+  inline static const lpc40xx::Pwm::Peripheral_t kPwm1PeripheralCommon = {
+    .registers   = reinterpret_cast<lpc40xx::LPC_PWM_TypeDef *>(LPC_PWM1),
+    .power_on_id = SystemController::Peripherals::kPwm1,
+  };
+  inline static const Pin kPwmPin0 = Pin::CreatePin<2, 0>();
+  inline static const Pin kPwmPin1 = Pin::CreatePin<2, 1>();
+  inline static const Pin kPwmPin2 = Pin::CreatePin<2, 2>();
+  inline static const Pin kPwmPin3 = Pin::CreatePin<2, 3>();
+  inline static const Pin kPwmPin4 = Pin::CreatePin<2, 4>();
+  inline static const Pin kPwmPin5 = Pin::CreatePin<2, 5>();
+
+ public:
+  inline static const lpc40xx::Pwm::Channel_t kPwm0 = {
+    .peripheral      = kPwm1PeripheralCommon,
+    .pin             = kPwmPin0,
+    .channel         = 1,
+    .pin_function_id = 0b01,
+  };
+  inline static const lpc40xx::Pwm::Channel_t kPwm1 = {
+    .peripheral      = kPwm1PeripheralCommon,
+    .pin             = kPwmPin1,
+    .channel         = 2,
+    .pin_function_id = 0b01,
+  };
+  inline static const lpc40xx::Pwm::Channel_t kPwm2 = {
+    .peripheral      = kPwm1PeripheralCommon,
+    .pin             = kPwmPin2,
+    .channel         = 3,
+    .pin_function_id = 0b01,
+  };
+  inline static const lpc40xx::Pwm::Channel_t kPwm3 = {
+    .peripheral      = kPwm1PeripheralCommon,
+    .pin             = kPwmPin3,
+    .channel         = 4,
+    .pin_function_id = 0b01,
+  };
+  inline static const lpc40xx::Pwm::Channel_t kPwm4 = {
+    .peripheral      = kPwm1PeripheralCommon,
+    .pin             = kPwmPin4,
+    .channel         = 5,
+    .pin_function_id = 0b01,
+  };
+  inline static const lpc40xx::Pwm::Channel_t kPwm5 = {
+    .peripheral      = kPwm1PeripheralCommon,
+    .pin             = kPwmPin5,
+    .channel         = 6,
+    .pin_function_id = 0b01,
+  };
+};
 }  // namespace lpc17xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc17xx/timer.hpp
+++ b/library/L1_Peripheral/lpc17xx/timer.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "L1_Peripheral/lpc17xx/pin.hpp"
+#include "L1_Peripheral/lpc17xx/system_controller.hpp"
 #include "L1_Peripheral/lpc40xx/timer.hpp"
 
 namespace sjsu
@@ -8,5 +10,56 @@ namespace lpc17xx
 {
 // The LPC40xx driver is compatible with the lpc17xx peripheral
 using ::sjsu::lpc40xx::Timer;
+
+struct TimerChannel  // NOLINT
+{
+ private:
+  inline static IsrPointer timer0_isr                                 = nullptr;
+  inline static const lpc40xx::Timer::ChannelPartial_t kTimerPartial0 = {
+    .timer_register = reinterpret_cast<lpc40xx::LPC_TIM_TypeDef *>(LPC_TIM0),
+    .power_id       = SystemController::Peripherals::kTimer0,
+    .irq            = static_cast<lpc40xx::IRQn>(IRQn::TIMER0_IRQn),
+    .user_callback  = &timer0_isr,
+  };
+  inline static IsrPointer timer1_isr                                 = nullptr;
+  inline static const lpc40xx::Timer::ChannelPartial_t kTimerPartial1 = {
+    .timer_register = reinterpret_cast<lpc40xx::LPC_TIM_TypeDef *>(LPC_TIM1),
+    .power_id       = SystemController::Peripherals::kTimer1,
+    .irq            = static_cast<lpc40xx::IRQn>(IRQn::TIMER1_IRQn),
+    .user_callback  = &timer1_isr,
+  };
+  inline static IsrPointer timer2_isr                                 = nullptr;
+  inline static const lpc40xx::Timer::ChannelPartial_t kTimerPartial2 = {
+    .timer_register = reinterpret_cast<lpc40xx::LPC_TIM_TypeDef *>(LPC_TIM2),
+    .power_id       = SystemController::Peripherals::kTimer2,
+    .irq            = static_cast<lpc40xx::IRQn>(IRQn::TIMER2_IRQn),
+    .user_callback  = &timer2_isr,
+  };
+  inline static IsrPointer timer3_isr                                 = nullptr;
+  inline static const lpc40xx::Timer::ChannelPartial_t kTimerPartial3 = {
+    .timer_register = reinterpret_cast<lpc40xx::LPC_TIM_TypeDef *>(LPC_TIM3),
+    .power_id       = SystemController::Peripherals::kTimer3,
+    .irq            = static_cast<lpc40xx::IRQn>(IRQn::TIMER3_IRQn),
+    .user_callback  = &timer3_isr,
+  };
+
+ public:
+  inline static const lpc40xx::Timer::Channel_t kTimer0 = {
+    .channel = kTimerPartial0,
+    .isr     = lpc40xx::Timer::TimerHandler<kTimerPartial0>,
+  };
+  inline static const lpc40xx::Timer::Channel_t kTimer1 = {
+    .channel = kTimerPartial1,
+    .isr     = lpc40xx::Timer::TimerHandler<kTimerPartial1>,
+  };
+  inline static const lpc40xx::Timer::Channel_t kTimer2 = {
+    .channel = kTimerPartial2,
+    .isr     = lpc40xx::Timer::TimerHandler<kTimerPartial2>,
+  };
+  inline static const lpc40xx::Timer::Channel_t kTimer3 = {
+    .channel = kTimerPartial3,
+    .isr     = lpc40xx::Timer::TimerHandler<kTimerPartial3>,
+  };
+};
 }  // namespace lpc17xx
 }  // namespace sjsu


### PR DESCRIPTION
- Added configuration structures for the following peripherals:
  - ADC
  - DAC
  - PWM
  - Timer

Resolves: #561, #562, #566, #567