### PR TITLE
Add make target "format-code"

### DIFF
--- a/makefile
+++ b/makefile
@@ -498,6 +498,12 @@ purge: clean
 telemetry:
 	google-chrome https://kammce.github.io/Telemetry
 # ====================================================================
+# Format Code
+# ====================================================================
+format-code:
+	@$(SJCLANG)/bin/git-clang-format --binary="$(SJCLANG)/bin/clang-format" \
+	  --force
+# ====================================================================
 # Build Test Executable, Run test and generate code coverage
 # ====================================================================
 # In reference to issue #374, we need to remove the old gcda files otherwise


### PR DESCRIPTION
This will check the staged and unstaged files in the commit and format
them without needing to integrate clang-format with VSCode, Eclipse or
running it directly from the command line.

Resolves #651