### PR TITLE
Clean up extend adc test

### DIFF
--- a/demos/sjtwo/adc/source/main.cpp
+++ b/demos/sjtwo/adc/source/main.cpp
@@ -11,17 +11,21 @@ int main()
 {
   LOG_INFO("Analog-to-Ditial Application Starting...");
 
-  LOG_INFO("Creating Adc object and selecting ADC channel 0");
-  LOG_INFO("ADC channel 0 is connected to pin P0.23");
-  sjsu::lpc40xx::Adc adc0(sjsu::lpc40xx::Adc::Channel::kChannel2);
-  LOG_INFO("Initializing ADC ...");
-  adc0.Initialize();
-  LOG_INFO("Initializing ADC Complete!");
-  LOG_INFO("Enabling ADC to burst mode!");
+  LOG_INFO("Creating ADC object and selecting ADC channel 4 & 5");
+  LOG_INFO("ADC channel 4 is connected to pin P1.30");
+  sjsu::lpc40xx::Adc adc4(sjsu::lpc40xx::Adc::Channel::kChannel4);
+  LOG_INFO("ADC channel 5 is connected to pin P1.31");
+  sjsu::lpc40xx::Adc adc5(sjsu::lpc40xx::Adc::Channel::kChannel5);
+
   LOG_INFO(
-      "Burst mode is useful in that you do not need to turn on conversion. You "
-      "simply need to run the Read() method!");
-  adc0.BurstMode(true);
+      "If you leave a channel disconnected, then the pin will be in a floating "
+      "state, and in this state, the voltage read from this pin will be "
+      "random.");
+
+  LOG_INFO("Initializing ADC ...");
+  adc5.Initialize();
+  adc4.Initialize();
+  LOG_INFO("Initializing ADC Complete!");
 
   LOG_INFO(
       "Apply a voltage from 0 to 3.3V (BE SUPER SURE not to accidently apply "
@@ -29,12 +33,26 @@ int main()
 
   while (true)
   {
-    uint32_t adc_digital_value = adc0.Read();
+    // Now that conversion is complete, read the value like so.
+    uint32_t adc_digital_value[2];
+    float voltage[2];
+
     // For the LPC40xx with a 12-bit ADC, lowest and highest values are 0 to
     // 1023, where as the lowest and highest voltages are between 0 and 3.3V
-    float voltage = sjsu::Map(adc_digital_value, 0, 4095, 0.0f, 3.3f);
-    LOG_INFO("Voltage on pin P0.23 = %f, raw value = %lu",
-             static_cast<double>(voltage), adc_digital_value);
+
+    // Now that conversion is complete, read the value like so.
+    adc_digital_value[0] = adc5.Read();
+    adc_digital_value[1] = adc4.Read();
+    // For the LPC40xx with a 12-bit ADC, lowest and highest values are 0 to
+    // 1023, where as the lowest and highest voltages are between 0 and 3.3V
+    voltage[0] = sjsu::Map(adc_digital_value[0], 0, 4095, 0.0f, 3.3f);
+    voltage[1] = sjsu::Map(adc_digital_value[1], 0, 4095, 0.0f, 3.3f);
+
+    LOG_INFO("voltage[0] = %f V (%lu) :: voltage[1] = %f V (%lu)",
+             static_cast<double>(voltage[0]),
+             adc_digital_value[0],
+             static_cast<double>(voltage[1]),
+             adc_digital_value[1]);
     sjsu::Delay(250ms);
   }
   return 0;

--- a/library/L1_Peripheral/adc.hpp
+++ b/library/L1_Peripheral/adc.hpp
@@ -6,32 +6,20 @@
 
 namespace sjsu
 {
-/// Analog-to-Digital (ADC) Converter Interface
+/// Common abstraction interface for Analog-to-Digital (ADC) Converter. These
+/// peripherals are used to sense a voltage and convert it to a numeric value.
 class Adc
 {
  public:
   /// Initialize and enable hardware. This must be called before any other
   /// method in this interface is called.
   virtual Status Initialize() const = 0;
-  /// Start conversion process and loop until the ADC conversion is complete.
-  /// When this returns, you can read the actual value from the Read() method.
-  ///
-  /// Some implementations of ADC have additional functionality that allows them
-  /// to skip the conversion step. For example the LPC40xx series of chips have
-  /// burst mode, which causes the hardware to continuous perform conversion
-  /// without the need of the user code to run this method. With Burst mode
-  /// enabled, Read() will always return the latest value.
-  virtual void Conversion() const = 0;
   /// Read the analog signal's value.
   /// The number active bits depends on the ADC being used and be known by
   /// running the GetActiveBits().
   ///
   /// @return Returns the digital representation of the analog.
   virtual uint32_t Read() const = 0;
-  /// @return true if a conversion has finished. The exact behaviour of this
-  ///         method is not known if Conversion() was not called before calling
-  ///         this method.
-  virtual bool HasConversionFinished() const = 0;
   /// @return number of active bits for the ADC.
   virtual uint8_t GetActiveBits() const = 0;
 };

--- a/library/L1_Peripheral/inactive.hpp
+++ b/library/L1_Peripheral/inactive.hpp
@@ -62,14 +62,9 @@ const sjsu::Adc & GetInactive<sjsu::Adc>()
     {
       return sjsu::Status::kNotImplemented;
     }
-    void Conversion() const override {}
     uint32_t Read() const override
     {
       return 0;
-    }
-    bool HasConversionFinished() const override
-    {
-      return true;
     }
     uint8_t GetActiveBits() const override
     {

--- a/library/L1_Peripheral/lpc40xx/adc.hpp
+++ b/library/L1_Peripheral/lpc40xx/adc.hpp
@@ -23,9 +23,11 @@ class Adc final : public sjsu::Adc
   /// lpc40xx's ADC Control register.
   struct Control  // NOLINT
   {
-    /// Set which ADC channels are enabled. It bit position represents 1 channel
-    /// with this 8 channel ADC.
-    static constexpr bit::Mask kChannelEnable = bit::CreateMaskFromRange(0, 7);
+    /// In burst mode, sets the ADC channels to be automatically converted.
+    /// It bit position represents 1 channel with this 8 channel ADC.
+    /// In software mode, this should hold only a single 1 for the single
+    /// channel to be converted.
+    static constexpr bit::Mask kChannelSelect = bit::CreateMaskFromRange(0, 7);
     /// Sets the channel's clock divider. Potentially saving power if clock is
     /// reduced further.
     static constexpr bit::Mask kClockDivider = bit::CreateMaskFromRange(8, 15);
@@ -45,7 +47,7 @@ class Adc final : public sjsu::Adc
   };
   /// Namespace containing the bitmask objects that are used to manipulate the
   /// lpc40xx's ADC Global Data register.
-  struct GlobalData  // NOLINT
+  struct DataRegister  // NOLINT
   {
     /// Result mask holds the latest result from the last ADC that was converted
     static constexpr bit::Mask kResult = bit::CreateMaskFromRange(4, 15);
@@ -178,6 +180,10 @@ class Adc final : public sjsu::Adc
   /// largest value it can have is 2^12 = 4096
   static constexpr uint8_t kActiveBits = 12;
   /// Turn on or off burst mode for the whole ADC peripheral.
+  ///
+  /// WARNING: if you are using this mode, call this before intializing any of
+  /// your LPC40xx ADC peripherals.
+  ///
   /// Normally, and ADC conversion must be triggered. After triggering
   /// conversion, one must wait until the conversion is complete before
   /// retrieving the converted analog voltage to digital value.
@@ -192,6 +198,11 @@ class Adc final : public sjsu::Adc
   {
     adc_base->CR =
         bit::Insert(adc_base->CR, turn_burst_mode_on, Control::kBurstEnable);
+  }
+  /// @returns true if burst mode is enabled and false otherwise.
+  static bool BurstModeIsEnabled()
+  {
+    return bit::Read(adc_base->CR, Control::kBurstEnable);
   }
   /// @param channel: Passed channel descriptor object. See Channel_t and
   ///        Channel documentation for more details about how to use this.
@@ -223,42 +234,28 @@ class Adc final : public sjsu::Adc
 
     uint32_t control = adc_base->CR;
 
-    control = bit::Set(control, channel_.channel);
-    control = bit::Set(control, Control::kPowerEnable.position);
+    control = bit::Set(control, Control::kPowerEnable);
     control = bit::Insert(control, clock_divider, Control::kClockDivider);
+
+    // If burst mode is enabled, the bits in the select area of the control
+    // register, are enables for each corrisponding ADC channel. Otherwise, this
+    // field should only hold a single set 1 when using software conversion.
+    if (BurstModeIsEnabled())
+    {
+      control = bit::Set(control, channel_.channel);
+    }
 
     adc_base->CR = control;
 
     return Status::kSuccess;
   }
-  void Conversion() const override
-  {
-    if (bit::Read(adc_base->CR, Control::kBurstEnable.position))
-    {
-      // NOTE: If burst mode is enabled, conversion start must be set 0
-      adc_base->CR = bit::Insert(adc_base->CR, 0, Control::kStartCode);
-    }
-    else
-    {
-      // NOTE: 0x01 = start code for "Start Conversion Now"
-      adc_base->CR = bit::Insert(adc_base->CR, 1, Control::kStartCode);
-    }
-
-    while (!HasConversionFinished())
-    {
-      continue;
-    }
-  }
   uint32_t Read() const override
   {
+    // Convert analog value from analog to a digital value
+    Conversion();
     uint32_t result =
-        bit::Extract(adc_base->DR[channel_.channel], GlobalData::kResult);
+        bit::Extract(adc_base->DR[channel_.channel], DataRegister::kResult);
     return result;
-  }
-  bool HasConversionFinished() const override
-  {
-    return bit::Read(adc_base->DR[channel_.channel],
-                     GlobalData::kDone.position);
   }
   uint8_t GetActiveBits() const override
   {
@@ -266,6 +263,30 @@ class Adc final : public sjsu::Adc
   }
 
  private:
+  bool HasConversionFinished() const
+  {
+    return bit::Read(adc_base->DR[channel_.channel], DataRegister::kDone);
+  }
+  void Conversion() const
+  {
+    if (BurstModeIsEnabled())
+    {
+      // NOTE: If burst mode is enabled, conversion start must be set 0
+      adc_base->CR = bit::Insert(adc_base->CR, 0, Control::kStartCode);
+    }
+    else
+    {
+      uint32_t channel_select = (1 << channel_.channel);
+      adc_base->CR =
+          bit::Insert(adc_base->CR, channel_select, Control::kChannelSelect);
+      // Start ADC conversion with start code 0x01
+      adc_base->CR = bit::Insert(adc_base->CR, 0x01, Control::kStartCode);
+      while (!HasConversionFinished())
+      {
+        continue;
+      }
+    }
+  }
   const Channel_t & channel_;
   const sjsu::SystemController & system_controller_;
 };

--- a/library/L1_Peripheral/lpc40xx/test/adc_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/adc_test.cpp
@@ -1,6 +1,7 @@
 #include "L0_Platform/lpc40xx/LPC40xx.h"
 #include "L1_Peripheral/lpc40xx/adc.hpp"
 #include "L4_Testing/testing_frameworks.hpp"
+#include "utility/bit.hpp"
 
 namespace sjsu::lpc40xx
 {
@@ -28,97 +29,242 @@ TEST_CASE("Testing lpc40xx adc", "[lpc40xx-adc]")
       .AlwaysReturn(1);
 
   // Set mock for sjsu::Pin
-  Mock<sjsu::Pin> mock_adc_pin;
-  Fake(Method(mock_adc_pin, SetAsAnalogMode),
-       Method(mock_adc_pin, SetPull),
-       Method(mock_adc_pin, SetPinFunction));
+  Mock<sjsu::Pin> mock_adc_pin0;
+  Fake(Method(mock_adc_pin0, SetAsAnalogMode),
+       Method(mock_adc_pin0, SetPull),
+       Method(mock_adc_pin0, SetPinFunction));
+
+  Mock<sjsu::Pin> mock_adc_pin1;
+  Fake(Method(mock_adc_pin1, SetAsAnalogMode),
+       Method(mock_adc_pin1, SetPull),
+       Method(mock_adc_pin1, SetPinFunction));
+
+  const Adc::Channel_t kMockChannel0 = {
+    .adc_pin      = mock_adc_pin0.get(),
+    .channel      = 0,
+    .pin_function = 0b101,
+  };
 
   const Adc::Channel_t kMockChannel1 = {
-    .adc_pin      = mock_adc_pin.get(),
+    .adc_pin      = mock_adc_pin1.get(),
     .channel      = 1,
     .pin_function = 0b101,
   };
+
   // Create ports and pins to test and mock
-  Adc channel0_mock(kMockChannel1, mock_system_controller.get());
+  Adc channel0_mock(kMockChannel0, mock_system_controller.get());
+  Adc channel1_mock(kMockChannel1, mock_system_controller.get());
 
-  constexpr uint8_t kBurstBit = 16;
-  SECTION("Initialization")
+  auto setup_adc_channel = [&](Adc::Channel_t channel,
+                               uint32_t expected_value) {
+    local_adc.CR = bit::Insert(local_adc.CR, 0, Adc::Control::kChannelSelect);
+    local_adc.DR[channel.channel] =
+        bit::Set(local_adc.DR[channel.channel], Adc::DataRegister::kDone);
+    // Set done bit so conversion does not loop forever
+    // Set the expected results
+    local_adc.DR[channel.channel] = bit::Insert(local_adc.DR[channel.channel],
+                                                expected_value,
+                                                Adc::DataRegister::kResult);
+  };
+
+  SECTION("Software Initialization")
   {
-    // Source "UM10562 LPC408x/7x User Manual" table 678 page 805
-    constexpr uint8_t kPowerDownBit       = 21;
-    constexpr uint8_t kPowerDown          = 0b1;
-    constexpr uint16_t kChannelClkDivMask = 0b11'1111'1111;
-    constexpr uint8_t kChannelClkDivBit   = 8;
+    // Setup
+    constexpr uint32_t kExpectedDivider =
+        kDummySystemControllerClockFrequency / Adc::kClockFrequency;
 
+    // Exercise
     channel0_mock.Initialize();
+    channel1_mock.Initialize();
 
+    // Verify
+    // Verify that PowerUpPeripheral() was alled with the ADC peripheral id
     Verify(Method(mock_system_controller, PowerUpPeripheral)
                .Matching([](sjsu::SystemController::PeripheralID id) {
-                 return sjsu::lpc40xx::SystemController::Peripherals::kAdc
-                            .device_id == id.device_id;
+                 return SystemController::Peripherals::kAdc.device_id ==
+                        id.device_id;
                }));
+
+    // Verify that the pins were setup correctly
     Verify(
-        Method(mock_adc_pin, SetPinFunction).Using(kMockChannel1.pin_function),
-        Method(mock_adc_pin, SetPull).Using(sjsu::Pin::Resistor::kNone),
-        Method(mock_adc_pin, SetAsAnalogMode).Using(true));
+        Method(mock_adc_pin0, SetPinFunction).Using(kMockChannel0.pin_function),
+        Method(mock_adc_pin0, SetPull).Using(sjsu::Pin::Resistor::kNone),
+        Method(mock_adc_pin0, SetAsAnalogMode).Using(true));
 
-    // Check if any bits in the clock divider are set given a frequency of
-    uint32_t expected_frequency =
-        kDummySystemControllerClockFrequency / Adc::kClockFrequency;
-    uint32_t actual_set_frequency =
-        local_adc.CR >> kChannelClkDivBit & kChannelClkDivMask;
-    CHECK(expected_frequency == actual_set_frequency);
+    Verify(
+        Method(mock_adc_pin1, SetPinFunction).Using(kMockChannel1.pin_function),
+        Method(mock_adc_pin1, SetPull).Using(sjsu::Pin::Resistor::kNone),
+        Method(mock_adc_pin1, SetAsAnalogMode).Using(true));
+
+    CHECK(kExpectedDivider ==
+          bit::Extract(local_adc.CR, Adc::Control::kClockDivider));
+    // If this register was zero before, then it should remain that way. This
+    // register should not be tampered with in software mode.
+    CHECK(0 == bit::Extract(local_adc.CR, Adc::Control::kChannelSelect));
     // Check bit 21 to see if power down bit is set in local_adc.CR
-    CHECK(((local_adc.CR >> kPowerDownBit) & 1) == kPowerDown);
+    CHECK(bit::Read(local_adc.CR, Adc::Control::kPowerEnable));
   }
-  SECTION("Conversion and finished conversion")
+
+  // This test only tests that the channel select lines were enabled. The rest
+  // of the intiailization is tested above.
+  SECTION("Burst Mode Initialization")
   {
-    // Source "UM10562 LPC408x/7x User Manual" table 678 page 805
-    constexpr uint8_t kStartNoBurst = 0b1;
-    constexpr uint8_t kStartBurst   = 0;
-    constexpr uint8_t kStartBit     = 24;
-    constexpr uint8_t kDone         = 0b1;
-    constexpr uint8_t kDoneBit      = 31;
-
-    // Check if bit 24 in local_adc.CR for the start bits is set
-    local_adc.DR[kMockChannel1.channel] |= (1 << kDoneBit);
-    channel0_mock.Conversion();
-    CHECK(((local_adc.CR >> kStartBit) & 1) == kStartNoBurst);
-    channel0_mock.HasConversionFinished();
-    CHECK(((local_adc.DR[kMockChannel1.channel] >> kDoneBit) & 1) == kDone);
-
-    // Check if bits 24 to 26 in local_adc.CR are cleared for burst mode
-    // conversion
-    channel0_mock.BurstMode(true);
-    channel0_mock.Conversion();
-    CHECK(((local_adc.CR >> kStartBit) & 0b111) == kStartBurst);
-
-    // Check if done bit is set after conversion
-    channel0_mock.HasConversionFinished();
-    CHECK(((local_adc.DR[kMockChannel1.channel] >> kDoneBit) & 1) == kDone);
+    // Setup
+    Adc::BurstMode();
+    // Exercise
+    channel0_mock.Initialize();
+    channel1_mock.Initialize();
+    // Check that the channel enable bits (the first 8 bits of the control
+    // register) has been set to 1 (enabled)
+    CHECK(bit::Read(local_adc.CR, kMockChannel0.channel));
+    CHECK(bit::Read(local_adc.CR, kMockChannel1.channel));
+    CHECK(!bit::Read(local_adc.CR, 3));  // make sure channel 3 is not enabled
+    CHECK(!bit::Read(local_adc.CR, 4));  // make sure channel 4 is not enabled
+    CHECK(!bit::Read(local_adc.CR, 5));  // make sure channel 5 is not enabled
+    CHECK(!bit::Read(local_adc.CR, 6));  // make sure channel 6 is not enabled
+    CHECK(!bit::Read(local_adc.CR, 7));  // make sure channel 7 is not enabled
   }
   SECTION("Burst mode")
   {
-    // Source "UM10562 LPC408x/7x User Manual" table 678 page 805
-    constexpr uint8_t kBurstOn  = 0b1;
-    constexpr uint8_t kBurstOff = 0b0;
-
     // Only need to test if burst mode will turn on and off
     // Burst mode applies to all channels that are initialized
-    channel0_mock.BurstMode(true);
-    CHECK(((local_adc.CR >> kBurstBit) & 1) == kBurstOn);
-    channel0_mock.BurstMode(false);
-    CHECK(((local_adc.CR >> kBurstBit) & 1) == kBurstOff);
-  }
-  SECTION("Read result")
-  {
-    constexpr uint16_t kResultMask = 0xfff;
-    constexpr uint8_t kResultBit   = 4;
+    Adc::BurstMode(true);
 
-    // Check if there is any value in the global data reg
-    channel0_mock.Read();
-    CHECK(((local_adc.DR[kMockChannel1.channel] >> kResultBit) & kResultMask) ==
-          0);
+    CHECK(channel0_mock.BurstModeIsEnabled());
+    CHECK(bit::Read(local_adc.CR, Adc::Control::kBurstEnable));
+
+    Adc::BurstMode(false);
+
+    CHECK(!channel0_mock.BurstModeIsEnabled());
+    CHECK(!bit::Read(local_adc.CR, Adc::Control::kBurstEnable));
+
+    constexpr uint8_t kBurstModeStartCode = 0b000;
+    // Check if bits 24 to 26 in local_adc.CR are cleared for burst mode
+    // conversion
+    Adc::BurstMode(true);
+    CHECK(kBurstModeStartCode ==
+          bit::Extract(local_adc.CR, Adc::Control::kStartCode));
+  }
+  SECTION("Read channel 0 using software mode")
+  {
+    // Setup
+    constexpr uint32_t kExpectedAdcValue  = 2425;
+    constexpr uint32_t kSoftwareStartCode = 0b001;
+    setup_adc_channel(kMockChannel0, kExpectedAdcValue);
+    Adc::BurstMode(false);
+    channel0_mock.Initialize();
+    // Exercise
+    uint32_t adc_raw = channel0_mock.Read();
+    // Verify
+    CHECK(adc_raw == bit::Extract(local_adc.DR[0], Adc::DataRegister::kResult));
+    CHECK(kSoftwareStartCode ==
+          bit::Extract(local_adc.CR, Adc::Control::kStartCode));
+    CHECK(1 << kMockChannel0.channel ==
+          bit::Extract(local_adc.CR, Adc::Control::kChannelSelect));
+  }
+  SECTION("Read channel 1 using software mode")
+  {
+    // Setup
+    constexpr uint32_t kExpectedAdcValue  = 3341;
+    constexpr uint32_t kSoftwareStartCode = 0b001;
+    setup_adc_channel(kMockChannel1, kExpectedAdcValue);
+    Adc::BurstMode(false);
+    channel1_mock.Initialize();
+    // Exercise
+    uint32_t adc_raw = channel1_mock.Read();
+    // Verify
+    CHECK(adc_raw == bit::Extract(local_adc.DR[1], Adc::DataRegister::kResult));
+    CHECK(kSoftwareStartCode ==
+          bit::Extract(local_adc.CR, Adc::Control::kStartCode));
+    CHECK(1 << kMockChannel1.channel ==
+          bit::Extract(local_adc.CR, Adc::Control::kChannelSelect));
+  }
+  SECTION("Read using burst mode")
+  {
+    // Setup
+    constexpr uint32_t kExpectedAdcValue = 1555;
+    constexpr uint32_t kBurstStartCode   = 0b000;
+    setup_adc_channel(kMockChannel0, kExpectedAdcValue);
+    Adc::BurstMode(true);
+    channel0_mock.Initialize();
+    // Exercise
+    uint32_t adc_raw = channel0_mock.Read();
+    // Verify
+    CHECK(1 << kMockChannel0.channel ==
+          bit::Extract(local_adc.CR, Adc::Control::kChannelSelect));
+    CHECK(adc_raw == bit::Extract(local_adc.DR[0], Adc::DataRegister::kResult));
+    CHECK(kBurstStartCode ==
+          bit::Extract(local_adc.CR, Adc::Control::kStartCode));
+  }
+  SECTION("Read Result from two different channels")
+  {
+    constexpr uint32_t kExpectedAdcValue[3] = { 0, 125, 4000 };
+    uint32_t adc_read_result[2]             = { 0 };
+
+    // Source "UM10562 LPC408x/7x User Manual" table 678 page 805
+    constexpr uint8_t kSoftwareStartCode = 0b001;
+
+    // Setup
+    // Set done flag so the functions do not loop forever. Only need to do this
+    // once since the driver should not be modifying these flags.
+    local_adc.DR[kMockChannel0.channel] =
+        bit::Set(local_adc.DR[kMockChannel0.channel], Adc::DataRegister::kDone);
+    local_adc.DR[kMockChannel1.channel] =
+        bit::Set(local_adc.DR[kMockChannel1.channel], Adc::DataRegister::kDone);
+    // Set done bit so conversion does not loop forever
+    // Set the expected results
+    local_adc.DR[kMockChannel0.channel] =
+        bit::Insert(local_adc.DR[kMockChannel0.channel],
+                    kExpectedAdcValue[0],
+                    Adc::DataRegister::kResult);
+    local_adc.DR[kMockChannel1.channel] =
+        bit::Insert(local_adc.DR[kMockChannel1.channel],
+                    kExpectedAdcValue[2],
+                    Adc::DataRegister::kResult);
+    // Exercise
+    adc_read_result[0] = channel0_mock.Read();
+    adc_read_result[1] = channel1_mock.Read();
+    // Verify
+    CHECK(kExpectedAdcValue[0] == adc_read_result[0]);
+    CHECK(kExpectedAdcValue[2] == adc_read_result[1]);
+    CHECK(kSoftwareStartCode ==
+          bit::Extract(local_adc.CR, Adc::Control::kStartCode));
+
+    // Setup
+    local_adc.DR[kMockChannel0.channel] =
+        bit::Insert(local_adc.DR[kMockChannel0.channel],
+                    kExpectedAdcValue[2],
+                    Adc::DataRegister::kResult);
+    local_adc.DR[kMockChannel1.channel] =
+        bit::Insert(local_adc.DR[kMockChannel1.channel],
+                    kExpectedAdcValue[1],
+                    Adc::DataRegister::kResult);
+    // Exercise
+    adc_read_result[0] = channel0_mock.Read();
+    adc_read_result[1] = channel1_mock.Read();
+    // Verify
+    CHECK(kExpectedAdcValue[2] == adc_read_result[0]);
+    CHECK(kExpectedAdcValue[1] == adc_read_result[1]);
+    CHECK(kSoftwareStartCode ==
+          bit::Extract(local_adc.CR, Adc::Control::kStartCode));
+
+    // Setup
+    local_adc.DR[kMockChannel0.channel] =
+        bit::Insert(local_adc.DR[kMockChannel0.channel],
+                    kExpectedAdcValue[1],
+                    Adc::DataRegister::kResult);
+    local_adc.DR[kMockChannel1.channel] =
+        bit::Insert(local_adc.DR[kMockChannel1.channel],
+                    kExpectedAdcValue[0],
+                    Adc::DataRegister::kResult);
+    // Exercise
+    adc_read_result[0] = channel0_mock.Read();
+    adc_read_result[1] = channel1_mock.Read();
+    // Verify
+    CHECK(kExpectedAdcValue[1] == adc_read_result[0]);
+    CHECK(kExpectedAdcValue[0] == adc_read_result[1]);
+    CHECK(kSoftwareStartCode ==
+          bit::Extract(local_adc.CR, Adc::Control::kStartCode));
   }
   SECTION("Get Active Bits")
   {
@@ -126,7 +272,7 @@ TEST_CASE("Testing lpc40xx adc", "[lpc40xx-adc]")
     CHECK(kExpectedActiveBits == channel0_mock.GetActiveBits());
   }
 
-  sjsu::lpc40xx::SystemController::system_controller = LPC_SC;
-  Adc::adc_base                                      = LPC_ADC;
+  SystemController::system_controller = LPC_SC;
+  Adc::adc_base                       = LPC_ADC;
 }
 }  // namespace sjsu::lpc40xx

--- a/library/L2_HAL/sensors/environment/light/temt6000x01.hpp
+++ b/library/L2_HAL/sensors/environment/light/temt6000x01.hpp
@@ -30,7 +30,6 @@ class Temt6000x01 final : public LightSensor
   /// @returns The illuminance in units of lux ranging from 1 - 1'000.
   units::illuminance::lux_t GetIlluminance() const override
   {
-    adc_.Conversion();
     // voltage = adc_output * (adc_reference_voltage / adc_resolution)
     const units::voltage::microvolt_t kVoltage(
         adc_.Read() * kAdcReferenceVoltage / adc_resolution_);

--- a/library/L2_HAL/sensors/environment/light/test/temt6000x01_test.cpp
+++ b/library/L2_HAL/sensors/environment/light/test/temt6000x01_test.cpp
@@ -22,9 +22,7 @@ TEST_CASE("Testing TEMP6000X01 Light Sensor", "[temt6000x01]")
   constexpr units::illuminance::lux_t kExpectedMaxLux(1'000_lx);
 
   Mock<Adc> mock_adc;
-  Fake(Method(mock_adc, GetActiveBits),
-       Method(mock_adc, Conversion),
-       Method(mock_adc, HasConversionFinished));
+  Fake(Method(mock_adc, GetActiveBits));
   When(Method(mock_adc, Initialize)).AlwaysReturn(Status::kSuccess);
   When(Method(mock_adc, GetActiveBits)).AlwaysReturn(kAdcActiveBits);
   When(Method(mock_adc, Read)).AlwaysReturn(kAdcTestOutput);
@@ -45,7 +43,7 @@ TEST_CASE("Testing TEMP6000X01 Light Sensor", "[temt6000x01]")
     const units::illuminance::lux_t kLux = light_sensor.GetIlluminance();
     const float kFloatError = fabs(kLux.to<float>() - kExpectedLux.to<float>());
 
-    Verify(Method(mock_adc, Conversion), Method(mock_adc, Read)).Once();
+    Verify(Method(mock_adc, Read)).Once();
     CHECK(0.0f <= kFloatError);
     CHECK(kFloatError < 0.001f);
   }
@@ -67,7 +65,7 @@ TEST_CASE("Testing TEMP6000X01 Light Sensor", "[temt6000x01]")
     const float kPercentage = light_sensor.GetPercentageBrightness();
     const float kFloatError = fabs(kPercentage - kExpectedPercentage);
 
-    Verify(Method(mock_adc, Conversion), Method(mock_adc, Read)).Once();
+    Verify(Method(mock_adc, Read)).Once();
     CHECK(0.0f <= kFloatError);
     CHECK(kFloatError < 0.1f);
   }

--- a/library/utility/bit.hpp
+++ b/library/utility/bit.hpp
@@ -1,8 +1,3 @@
-// @ingroup SJSU-Dev2
-// @defgroup Bit manipulation library
-// @brief This library contains helper methods for manipulating or extracting
-// bits from a numeric values.
-// @{
 #pragma once
 
 #include <cstdint>
@@ -18,6 +13,7 @@ struct Mask  // NOLINT
   uint8_t position;
   uint8_t width;
 };
+
 constexpr Mask CreateMaskFromRange(uint8_t low_bit_position,
                                    uint8_t high_bit_position)
 {
@@ -191,7 +187,6 @@ template <typename T>
                 "Toggle only accepts intergers.");
   return static_cast<T>(target ^ (1 << position));
 }
-
 /// Read a bit from the target value at the position specifed.
 /// If the bit is 1 at the position given, return true.
 /// If the bit is 0 at the position given, return false.
@@ -214,6 +209,36 @@ template <typename T>
                 "Read only accepts intergers.");
   return static_cast<bool>(target & (1 << position));
 }
+
+/// @returns a value that is the target value with the bit set to a 1 at the bit
+/// position within the bitmask. For exmaple if your bitmask has field position
+/// set to 5, then this function will return the target value with the 5th bits
+/// set to a 1.
+template <typename T>
+[[nodiscard]] constexpr T Set(T target, Mask bitmask)
+{
+  return Set(target, bitmask.position);
+}
+/// Operates the same way as the Set(T target, Mask bitmask) function except it
+/// clears the bit.
+template <typename T>
+[[nodiscard]] constexpr T Clear(T target, Mask bitmask)
+{
+  return Clear(target, bitmask.position);
+}
+/// Operates the same way as the Set() function except it toggles the bit.
+template <typename T>
+[[nodiscard]] constexpr bool Toggle(T target, Mask bitmask)
+{
+  return Toggle(target, bitmask.position);
+}
+/// @returns the bit in the value at the "position" field of the bitmask. For
+/// exmaple, if the passed bitmask has position set to 5, then this function
+/// will return the 5th bits value, regardless of the "width" field is.
+template <typename T>
+[[nodiscard]] constexpr bool Read(T target, Mask bitmask)
+{
+  return Read(target, bitmask.position);
+}
 }  // namespace bit
 }  // namespace sjsu
-// @}


### PR DESCRIPTION
Fixup, clean up, and extend ADC test

Also add helper utility functions to bit.hpp to remove the need to
access the "position" field of the bit::Mask object.

Resolves #877