### PR TITLE
Integrate 3P tool GDB Dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ tools/**/*
 !tools/generate_doxygen_docs.sh
 !tools/doxygen_warning_patterns.txt
 !tools/common.sh
+!tools/gdb_dashboard
 
 api/doxygen_stderr.txt
 

--- a/library/L0_Platform/linux/linux.mk
+++ b/library/L0_Platform/linux/linux.mk
@@ -12,7 +12,7 @@ DEVICE_NM        ?= nm
 DEVICE_AR        ?= ar
 DEVICE_RANLIB    ?= ranlib
 DEVICE_ADDR2LINE ?= addr2line
-DEVICE_GDB       ?= gdb-py
+DEVICE_GDB       ?= gdb
 
 COMMON_FLAGS += -m32
 

--- a/makefile
+++ b/makefile
@@ -54,6 +54,7 @@ MAKEFLAGS += --jobs=$(NPROCS)
 endif
 
 ifeq ($(MAKECMDGOALS), $(filter $(MAKECMDGOALS), debug jtag-flash))
+ifneq ($(PLATFORM), linux)
 ifndef DEBUG_DEVICE
 $(info $(shell printf '$(RED)'))
 $(info +--------------- Missing command line arguments ----------------+)
@@ -74,6 +75,7 @@ $(info $(shell printf '$(RESET)'))
 $(error )
 endif
 endif
+endif
 
 ifneq ($(MAKECMDGOALS), presubmit)
 endif
@@ -83,15 +85,17 @@ endif
 # SJSU-Dev2 Toolchain Paths
 # ============================
 # Path to CLANG compiler
-SJCLANG_PATH   = $(SJSU_DEV2_BASE)/tools/clang+llvm-*/
-SJCLANG        = $(shell cd $(SJCLANG_PATH) ; pwd)
+SJCLANG_PATH      = $(SJSU_DEV2_BASE)/tools/clang+llvm-*/
+SJCLANG           = $(shell cd $(SJCLANG_PATH) ; pwd)
 # Path to ARM GCC compiler
-SJARMGCC_PATH  = $(SJSU_DEV2_BASE)/tools/gcc-arm-none-eabi-*/
-SJARMGCC       = $(shell cd $(SJARMGCC_PATH) ; pwd)
+SJARMGCC_PATH     = $(SJSU_DEV2_BASE)/tools/gcc-arm-none-eabi-*/
+SJARMGCC          = $(shell cd $(SJARMGCC_PATH) ; pwd)
 # Path to Openocd compiler
-OPENOCD_DIR = $(SJSU_DEV2_BASE)/tools/openocd
+OPENOCD_DIR       = $(SJSU_DEV2_BASE)/tools/openocd
+# Path to Openocd compiler
+GDBINIT_PATH      = $(SJSU_DEV2_BASE)/tools/gdb_dashboard/gdbinit
 # Compiler and library settings:
-SJLIBDIR  = $(SJSU_DEV2_BASE)/firmware/library
+SJLIBDIR          = $(SJSU_DEV2_BASE)/firmware/library
 
 # =================================
 # Updating the LD_LIBRARY_PATH
@@ -539,9 +543,15 @@ stacktrace-application:
 # Start gdb and connect to openocd jtag debugging session
 
 debug:
-	$(info $(shell printf '$(MAGENTA)Starting firmware debug...$(RESET)\n'))
-	$(TOOLS_DIR)/launch_openocd_gdb.sh $(OPENOCD_DIR) $(DEBUG_DEVICE) \
-	  $(OPENOCD_CONFIG) $(DEVICE_GDB) $(CURRENT_DIRECTORY)/$(EXECUTABLE)
+	@$(info $(shell printf '$(MAGENTA)Starting firmware debug...$(RESET)\n'))
+	@$(TOOLS_DIR)/launch_openocd_gdb.sh \
+			$(DEVICE_GDB) \
+			$(GDBINIT_PATH) \
+			$(PLATFORM) \
+			$(CURRENT_DIRECTORY)/$(EXECUTABLE) \
+			$(OPENOCD_DIR) \
+			$(DEBUG_DEVICE) \
+			$(OPENOCD_CONFIG)
 
 debug-test:
 	export LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) && gdb build/tests.exe

--- a/tools/launch_openocd_gdb.sh
+++ b/tools/launch_openocd_gdb.sh
@@ -1,37 +1,41 @@
 #!/bin/bash
 
-OPENOCD=$1
-DEBUG_DEVICE=$2
-OPENOCD_CONFIG=$3
-DEVICE_GDB=$4
-EXECUTABLE=$5
+DEVICE_GDB=$1
+GDBINIT_PATH=$2
+PLATFORM=$3
+EXECUTABLE=$4
+OPENOCD=$5
+DEBUG_DEVICE=$6
+OPENOCD_CONFIG=$7
 
-## Uncomment the line below to get a bit of debug information
-# echo "$OPENOCD/bin/openocd  -s $OPENOCD/scripts/ \
-#-c \"source [find interface/$DEBUG_DEVICE.cfg]\" -f $OPENOCD_CONFIG &"
+GDB_ARGS=""
 
-$OPENOCD/bin/openocd  -s $OPENOCD/scripts/ \
--c "source [find interface/$DEBUG_DEVICE.cfg]" -f $OPENOCD_CONFIG &
-
-# Capture the pid of the background OpenOCD process
-OPENOCD_PID=$(echo $!)
-# Wait for OpenOCD to continue or quit
-sleep .25
-# Use kill to check if OpenOCD is running
-kill -0 $OPENOCD_PID &> /dev/null
-# Capture success or failure of check above
-OPENOCD_IS_RUNNING=$?
-if [ $OPENOCD_IS_RUNNING -ne 0 ]
+if [ $PLATFORM == "linux" ]
 then
-RED="\x1B[31;1m"
-RESET="\x1B[0m"
-echo
-echo -e "$RED OpenOCD failed to start, exiting $RESET"
-echo
-exit 1
+$DEVICE_GDB $EXECUTABLE -ex "source $GDBINIT_PATH"
+else # For all other platforms
+  $OPENOCD/bin/openocd  -s $OPENOCD/scripts/ \
+  -c "source [find interface/$DEBUG_DEVICE.cfg]" -f $OPENOCD_CONFIG &
+
+  # Capture the pid of the background OpenOCD process
+  OPENOCD_PID=$(echo $!)
+  # Wait for OpenOCD to continue or quit
+  sleep .25
+  # Use kill to check if OpenOCD is running
+  kill -0 $OPENOCD_PID &> /dev/null
+  # Capture success or failure of check above
+  OPENOCD_IS_RUNNING=$?
+  if [ $OPENOCD_IS_RUNNING -ne 0 ]
+  then
+    RED="\x1B[31;1m"
+    RESET="\x1B[0m"
+    echo
+    echo -e "$RED OpenOCD failed to start, exiting $RESET"
+    echo
+    exit 1
+  fi
+  GDB_ARGS="$GDB_ARGS -ex \"target remote :3333\""
+
+  echo "Killing OpenOCD PID: $OPENOCD_PID"
+  kill $OPENOCD_PID
 fi
-
-$DEVICE_GDB -ex "target remote :3333" $EXECUTABLE
-
-echo "Killing OpenOCD PID: $OPENOCD_PID"
-kill $OPENOCD_PID


### PR DESCRIPTION
With GDB Dashboard, debugging firmware using GDB on the commandline
becomes an absolute breeze. Its is borderline unusable without this
plugin, so each time you run GDB, the local file will be sourced and
used.

Resolves #894