### PR TITLE
Added Coulomb Counting for Battery Percentages

### DIFF
--- a/library/L1_Peripheral/gpio.hpp
+++ b/library/L1_Peripheral/gpio.hpp
@@ -57,7 +57,7 @@ class Gpio
   /// @param function - the function to execute when the interrupt condition
   ///        occurs
   /// @param edge - the pin condition that will trigger the interrupt
-  virtual void AttachInterrupt(IsrPointer function, Edge edge) const = 0;
+  virtual void AttachInterrupt(IsrPointer function, Edge edge) = 0;
   /// Remove interrupt call from pin and deactivate interrupts for this pin
   virtual void DetachInterrupt() const = 0;
 

--- a/library/L1_Peripheral/inactive.hpp
+++ b/library/L1_Peripheral/inactive.hpp
@@ -122,7 +122,7 @@ const sjsu::Gpio & GetInactive<sjsu::Gpio>()
     {
       return GetInactive<sjsu::Pin>();
     }
-    void AttachInterrupt(IsrPointer, Edge) const override {}
+    void AttachInterrupt(IsrPointer, Edge) override {}
     void DetachInterrupt() const override {}
   };
 

--- a/library/L1_Peripheral/lpc17xx/gpio.hpp
+++ b/library/L1_Peripheral/lpc17xx/gpio.hpp
@@ -212,8 +212,9 @@ class Gpio final : public sjsu::Gpio
   }
   /// Assign the developer's ISR and sets the selected edge that the gpio
   /// interrupt will be triggered on.
-  void AttachInterrupt(IsrPointer function, Edge edge) const override
+  void AttachInterrupt(IsrPointer function, Edge edge) override
   {
+    EnableInterrupts();
     ValidPortCheck();
     SetInterruptRoutine(function);
     SetInterruptEdge(edge);

--- a/library/L1_Peripheral/lpc40xx/gpio.hpp
+++ b/library/L1_Peripheral/lpc40xx/gpio.hpp
@@ -207,8 +207,9 @@ class Gpio final : public sjsu::Gpio
 
   /// Assign the developer's ISR and sets the selected edge that the gpio
   /// interrupt will be triggered on.
-  void AttachInterrupt(IsrPointer function, Edge edge) const override
+  void AttachInterrupt(IsrPointer function, Edge edge) override
   {
+    EnableInterrupts();
     ValidPortCheck();
     SetInterruptRoutine(function);
     SetInterruptEdge(edge);

--- a/library/L2_HAL/L2.mk
+++ b/library/L2_HAL/L2.mk
@@ -59,3 +59,7 @@ TESTS += $(LIBRARY_DIR)/L2_HAL/memory/test/sd_test.cpp
 # Actuators
 # ==============================================================================
 TESTS += $(LIBRARY_DIR)/L2_HAL/actuators/servo/test/servo_test.cpp
+# ==============================================================================
+# Battery
+# ==============================================================================
+TESTS += $(LIBRARY_DIR)/L2_HAL/sensors/battery/test/ltc4150_test.cpp

--- a/library/L2_HAL/sensors/battery/coulomb_counter.hpp
+++ b/library/L2_HAL/sensors/battery/coulomb_counter.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace sjsu
+{
+/// Abstraction Interface for a coulomb counter. This device can give us
+/// information about a connected battery's power level.
+class CoulombCounter
+{
+ public:
+  /// Initialize and enable hardware. This must be called before any other
+  /// method in this interface is called.
+  virtual void Initialize() const = 0;
+  /// Returns the battery's milliamp hours at a given ppint in time.
+  virtual float GetBatterymAh() const = 0;
+};
+}  // namespace sjsu

--- a/library/L2_HAL/sensors/battery/ltc4150.hpp
+++ b/library/L2_HAL/sensors/battery/ltc4150.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <cstdint>
+
+#include "L2_HAL/sensors/battery/coulomb_counter.hpp"
+#include "L1_Peripheral/gpio.hpp"
+
+namespace sjsu
+{
+/// Represents the default Rsense value from calculating the mAh for a given
+/// number of ticks.
+constexpr float kRsense = 0.00005f;
+/// Represents the voltage to frequency gain in millivolts.
+constexpr float kGvf = 32.55f;
+
+/// LTC4150 control driver for the LPC40xx and LPC17xx microcontrollers. It
+/// keeps track of a connected battery's current milliamp hours.
+class Ltc4150 : public CoulombCounter
+{
+ public:
+  /// struct for holding the number of times an ISR invoked for a coulomb
+  /// counter
+  struct Battery_t
+  {
+    /// int variable holding the number of times an ISR invoked for a coulomb
+    /// counter
+    int num_ticks;
+  };
+
+  /// Class that handles the ticks from the LTC4150. The class uses a template
+  /// so there can be different handlers for different LTC4150s connected to a
+  /// board.
+  template <int id>
+  class TickHandler
+  {
+   public:
+    /// This member variable will hold the number of ticks sent from the
+    /// LTC4150. The interrupt handler increments this value by one every time
+    /// it is invoked.
+    inline static Battery_t battery_info;
+
+    /// handles the ISR by incrementing the num_ticks variable of TickHandler's
+    /// Battery_t
+    static void IsrHandler()
+    {
+      battery_info.num_ticks += 1;
+    }
+
+    /// @return the calculated milliamp hours based on the number of ticks.
+    /// 3600 is X 32.55 is kGvF and 0.00005 is kRsense
+    static float GetBatterymAh()
+    {
+      return static_cast<float>(static_cast<float>(battery_info.num_ticks) /
+                                (3600 * kGvf * kRsense));
+    }
+  };
+
+  /// @param isr - handler for coulomb counter ticks.
+  /// @param int_pin - gpio pin for handling handling interrupts from the
+  /// LTC4150
+  /// @param pol - gpio pin to determine the polarity output of the LTC4150.
+  template <int id>
+  explicit constexpr Ltc4150(const TickHandler<id> & isr,
+                             Gpio & int_pin,
+                             Gpio & pol)
+      : int_pin_(int_pin),
+        pol_(pol),
+        get_mah_(isr.GetBatterymAh),
+        isr_handler_(isr.IsrHandler)
+  {
+  }
+
+  /// Initialize hardware, setting pins as inputs and attaching ISR handlers to
+  /// the interrupt pin.
+  void Initialize() const override
+  {
+    pol_.SetAsInput();
+    int_pin_.SetAsInput();
+    int_pin_.AttachInterrupt(isr_handler_, Gpio::Edge::kEdgeFalling);
+  }
+
+  /// @return the calculated mAh from the TickHandler instance
+  float GetBatterymAh() const override
+  {
+    return get_mah_();
+  }
+
+ private:
+  /// Gpio pin to recieve tick interrupts from the LTC4150.
+  sjsu::Gpio & int_pin_;
+  /// Gpio pin to check polarity output from the LTC4150.
+  sjsu::Gpio & pol_;
+  /// function pointer to grab current battery mAh
+  float (*get_mah_)(void) = nullptr;
+  /// function pointer to isr handler
+  void (*isr_handler_)(void) = nullptr;
+};
+}  // namespace sjsu

--- a/library/L2_HAL/sensors/battery/test/ltc4150_test.cpp
+++ b/library/L2_HAL/sensors/battery/test/ltc4150_test.cpp
@@ -1,0 +1,73 @@
+#include "L2_HAL/sensors/battery/ltc4150.hpp"
+#include "L4_Testing/testing_frameworks.hpp"
+
+namespace sjsu
+{
+#define APPROX_EQUALITY(expected, actual, resolution) \
+  CHECK(-resolution < (actual - expected));           \
+  CHECK((actual - expected) < resolution);
+
+EMIT_ALL_METHODS(Ltc4150);
+TEST_CASE("Test LTC4150 Coulomb Counter/ Battery Gas Gauge", "[ltc4150]")
+{
+  constexpr float kResolution = 0.001f;
+
+  Ltc4150::TickHandler<0> primary_isr;
+  Ltc4150::TickHandler<1> backup_isr;
+
+  Mock<Gpio> mock_primary_input_pin;
+  Mock<Gpio> mock_primary_pol_pin;
+  Mock<Gpio> mock_backup_input_pin;
+  Mock<Gpio> mock_backup_pol_pin;
+
+  Fake(Method(mock_primary_input_pin, AttachInterrupt));
+  Fake(Method(mock_primary_input_pin, SetDirection));
+  Fake(Method(mock_primary_pol_pin, SetDirection));
+  Fake(Method(mock_backup_input_pin, AttachInterrupt));
+  Fake(Method(mock_backup_input_pin, SetDirection));
+  Fake(Method(mock_backup_pol_pin, SetDirection));
+
+  SECTION("LTC4150 Initialization")
+  {
+    Ltc4150 primary_counter = Ltc4150(
+        primary_isr, mock_primary_input_pin.get(), mock_primary_pol_pin.get());
+    Ltc4150 backup_counter = Ltc4150(
+        backup_isr, mock_backup_input_pin.get(), mock_backup_pol_pin.get());
+
+    primary_counter.Initialize();
+    backup_counter.Initialize();
+
+    Verify(Method(mock_primary_input_pin, SetDirection)
+               .Using(Gpio::Direction::kInput));
+    Verify(Method(mock_backup_input_pin, SetDirection)
+               .Using(Gpio::Direction::kInput));
+    Verify(Method(mock_primary_pol_pin, SetDirection)
+               .Using(Gpio::Direction::kInput));
+    Verify(Method(mock_backup_pol_pin, SetDirection)
+               .Using(Gpio::Direction::kInput));
+    Verify(Method(mock_primary_input_pin, AttachInterrupt)).Exactly(1);
+    Verify(Method(mock_backup_input_pin, AttachInterrupt)).Exactly(1);
+  }
+
+  SECTION("Count Ticks and Calculate mAh")
+  {
+    Ltc4150 primary_counter = Ltc4150(
+        primary_isr, mock_primary_input_pin.get(), mock_primary_pol_pin.get());
+    Ltc4150 backup_counter = Ltc4150(
+        backup_isr, mock_backup_input_pin.get(), mock_backup_pol_pin.get());
+    primary_isr.IsrHandler();
+    primary_isr.IsrHandler();
+    primary_isr.IsrHandler();
+    primary_isr.IsrHandler();
+    APPROX_EQUALITY(primary_counter.GetBatterymAh(), 0.68271f, kResolution);
+
+    backup_isr.IsrHandler();
+    backup_isr.IsrHandler();
+    backup_isr.IsrHandler();
+    backup_isr.IsrHandler();
+    backup_isr.IsrHandler();
+    backup_isr.IsrHandler();
+    APPROX_EQUALITY(backup_counter.GetBatterymAh(), 1.02407f, kResolution);
+  }
+}
+}  // namespace sjsu

--- a/tools/doxygen_warning_patterns.txt
+++ b/tools/doxygen_warning_patterns.txt
@@ -1,0 +1,9 @@
+adc.hpp
+pin.hpp
+gpio.hpp
+spi.hpp
+i2c.hpp
+pwm.hpp
+uart.hpp
+system_timer.hpp
+ltc4150.hpp


### PR DESCRIPTION
Using a CoulombCounter interface, the Ltc4150 class reads ticks from a Sparkfun LTC4150 Coulomb
Counter.