### PR TITLE
Migrate LOG_CRITICAL -> LOG_ERROR

### DIFF
--- a/demos/multiplatform/dual_platforms/source/main.cpp
+++ b/demos/multiplatform/dual_platforms/source/main.cpp
@@ -35,7 +35,7 @@ int main()
   }
   else
   {
-    LOG_CRITICAL("Invalid platform for this application!");
+    LOG_ERROR("Invalid platform for this application!");
     sjsu::Halt();
   }
   // Phase #3:

--- a/demos/multiplatform/log_level_print/source/main.cpp
+++ b/demos/multiplatform/log_level_print/source/main.cpp
@@ -21,7 +21,7 @@ void PrintLogDescription(int a)
       "something possibly going wrong in the program.");
   LOG_ERROR(
       "Error messages should alert the user or developer of a possible error.");
-  LOG_CRITICAL(
+  LOG_ERROR(
       "Critical messages should always be shown and typically occur when a "
       "fatal error has occurred during the runtime of the program.");
 }
@@ -34,7 +34,7 @@ int main()
   LOG_INFO("This is an info message.");
   LOG_WARNING("This is an warning message.");
   LOG_ERROR("This is an error message.");
-  LOG_CRITICAL("This is an critical message.");
+  LOG_ERROR("This is an critical message.");
 
   PrintLogDescription(5);
   return 0;

--- a/documentation/guides/multi_platform.md
+++ b/documentation/guides/multi_platform.md
@@ -81,7 +81,7 @@ else if constexpr (sjsu::build::kPlatform == sjsu::build::Platform::linux)
 }
 else
 {
-  LOG_CRITICAL("Invalid platform for this application!");
+  LOG_ERROR("Invalid platform for this application!");
   sjsu::Halt();
 }
 ```

--- a/library/L0_Platform/example/startup.cpp
+++ b/library/L0_Platform/example/startup.cpp
@@ -104,7 +104,7 @@ extern "C" void ResetHandler()
 #pragma GCC diagnostic pop
   // main() shouldn't return, but if it does, we'll just enter an infinite
   // loop
-  LOG_CRITICAL("main() returned with value %" PRId32, result);
+  LOG_ERROR("main() returned with value %" PRId32, result);
   sjsu::Halt();
 }
 // Add section variables. Typically this includes checksums or security lock

--- a/library/config.hpp
+++ b/library/config.hpp
@@ -130,8 +130,7 @@ static_assert(kLogLevel == SJ2_LOG_LEVEL_NONESET ||
                   kLogLevel == SJ2_LOG_LEVEL_DEBUG ||
                   kLogLevel == SJ2_LOG_LEVEL_INFO ||
                   kLogLevel == SJ2_LOG_LEVEL_WARNING ||
-                  kLogLevel == SJ2_LOG_LEVEL_ERROR ||
-                  kLogLevel == SJ2_LOG_LEVEL_CRITICAL,
+                  kLogLevel == SJ2_LOG_LEVEL_ERROR,
               "SJ2_LOG_LEVEL must equal to one of the predefined log levels "
               "such as SJ2_LOG_LEVEL_INFO.");
 

--- a/library/log_levels.hpp
+++ b/library/log_levels.hpp
@@ -6,4 +6,3 @@
 #define SJ2_LOG_LEVEL_INFO       20
 #define SJ2_LOG_LEVEL_WARNING    30
 #define SJ2_LOG_LEVEL_ERROR      40
-#define SJ2_LOG_LEVEL_CRITICAL   50

--- a/library/utility/log.hpp
+++ b/library/utility/log.hpp
@@ -55,13 +55,6 @@
 #define LOG_ERROR(format, ...)
 #endif  // SJ2_LOG_LEVEL <= SJ2_LOG_LEVEL_ERROR
 
-#if SJ2_LOG_LEVEL <= SJ2_LOG_LEVEL_CRITICAL
-#define LOG_CRITICAL(format, ...) \
-  _LOG_PRINT(SJ2_BACKGROUND_RED "CRITICAL", format, ##__VA_ARGS__)
-#else
-#define LOG_CRITICAL(format, ...)
-#endif  // SJ2_LOG_LEVEL <= SJ2_LOG_LEVEL_CRITICAL
-
 // When the condition is false, issue a warning to the user with a warning
 // message. Warning message format acts like printf.
 #define SJ2_ASSERT_WARNING(condition, warning_message, ...)        \
@@ -80,7 +73,7 @@
   {                                                                          \
     if (!(condition))                                                        \
     {                                                                        \
-      LOG_CRITICAL("Assertion Failure, Condition Tested: " #condition        \
+      LOG_ERROR("Assertion Failure, Condition Tested: " #condition        \
                    "\n          " fatal_message SJ2_COLOR_RESET,             \
                    ##__VA_ARGS__);                                           \
       if ((with_dump))                                                       \

--- a/tools/launch_openocd_gdb.sh
+++ b/tools/launch_openocd_gdb.sh
@@ -20,7 +20,7 @@ else # For all other platforms
   # Capture the pid of the background OpenOCD process
   OPENOCD_PID=$(echo $!)
   # Wait for OpenOCD to continue or quit
-  sleep .25
+  sleep 2
   # Use kill to check if OpenOCD is running
   kill -0 $OPENOCD_PID &> /dev/null
   # Capture success or failure of check above
@@ -34,7 +34,6 @@ else # For all other platforms
     echo
     exit 1
   fi
-
   # When the GDB session closes, kill openocd below
   $DEVICE_GDB $EXECUTABLE -ex "target remote :3333" $GDB_ARGS
 


### PR DESCRIPTION
Choosing between LOG_CRITICAL and LOG_ERROR is really confusing. It is
not exactly clear why anyone would want ot log critical and not simply
just error. So removing log crit for log error and replacing it in code
that uses log crit.

Resolves #914