### PR TITLE
Improve build system memory usage stats

### DIFF
--- a/library/L0_Platform/lpc40xx/linker.ld
+++ b/library/L0_Platform/lpc40xx/linker.ld
@@ -12,25 +12,25 @@ MEMORY
 {
   /* Define each memory region */
   /* 512kB (alias Flash) */
-  MFlash512 (rx) : ORIGIN = 0, LENGTH = 512K
+  FLASH (rx) : ORIGIN = 0, LENGTH = 512K
   /* 64kB (alias RAM) */
-  RamLoc64 (rwx) : ORIGIN = 0x10000000, LENGTH = 0x10000
+  SRAM (rwx) : ORIGIN = 0x10000000, LENGTH = 0x10000
   /* 32kB (alias RAM2) */
-  RamPeriph32 (rwx) : ORIGIN = 0x20000000, LENGTH = 0x8000
+  SRAM_AHB (rwx) : ORIGIN = 0x20000000, LENGTH = 0x8000
 }
 
   /* Define a symbol for the top of each memory region */
-  __base_MFlash512 = 0x0  ; /* MFlash512 */
+  __base_FLASH = 0x0  ; /* FLASH */
   __base_Flash = 0x0 ; /* Flash */
-  __top_MFlash512 = 0x0 + 0x80000 ; /* 512K bytes */
+  __top_FLASH = 0x0 + 0x80000 ; /* 512K bytes */
   __top_Flash = 0x0 + 0x80000 ; /* 512K bytes */
-  __base_RamLoc64 = 0x10000000  ; /* RamLoc64 */
+  __base_SRAM = 0x10000000  ; /* SRAM */
   __base_RAM = 0x10000000 ; /* RAM */
-  __top_RamLoc64 = 0x10000000 + 0x10000 ; /* 64K bytes */
+  __top_SRAM = 0x10000000 + 0x10000 ; /* 64K bytes */
   __top_RAM = 0x10000000 + 0x10000 ; /* 64K bytes */
-  __base_RamPeriph32 = 0x20000000  ; /* RamPeriph32 */
+  __base_SRAM_AHB = 0x20000000  ; /* SRAM_AHB */
   __base_RAM2 = 0x20000000 ; /* RAM2 */
-  __top_RamPeriph32 = 0x20000000 + 0x8000 ; /* 32K bytes */
+  __top_SRAM_AHB = 0x20000000 + 0x8000 ; /* 32K bytes */
   __top_RAM2 = 0x20000000 + 0x8000 ; /* 32K bytes */
   __user_heap_base = __base_RAM2 ; /* SJSU-Dev2: RAM2 is solely for heap */
 
@@ -103,14 +103,14 @@ SECTIONS
 		KEEP (*(SORT(.dtors.*)))
 		KEEP (*crtend.o(.dtors))
         /* End C++ */
-    } >MFlash512
+    } >FLASH
 
     .text : ALIGN(4)
     {
         *(.text*)
         *(.rodata .rodata.* .constdata .constdata.*)
         . = ALIGN(4);
-    } > MFlash512
+    } > FLASH
     /*
      * for exception handling/unwind - some Newlib functions (in common
      * with C++ and STDC++) use this.
@@ -118,29 +118,29 @@ SECTIONS
     .ARM.extab : ALIGN(4)
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
-    } > MFlash512
+    } > FLASH
     __exidx_start = .;
 
     .ARM.exidx : ALIGN(4)
     {
         *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-    } > MFlash512
+    } > FLASH
     __exidx_end = .;
 
     _etext = .;
 
-    /* DATA section for RamPeriph32 */
+    /* DATA section for SRAM_AHB */
     .data_RAM2 : ALIGN(4)
     {
         FILL(0xff)
         PROVIDE(__start_data_RAM2 = .) ;
         *(.ramfunc.$RAM2)
-        *(.ramfunc.$RamPeriph32)
+        *(.ramfunc.$SRAM_AHB)
         *(.data.$RAM2*)
-        *(.data.$RamPeriph32*)
+        *(.data.$SRAM_AHB*)
         . = ALIGN(4) ;
         PROVIDE(__end_data_RAM2 = .) ;
-     } > RamPeriph32 AT>MFlash512
+     } > SRAM_AHB AT>FLASH
 
     /* MAIN DATA SECTION */
     .uninit_RESERVED : ALIGN(4)
@@ -148,8 +148,8 @@ SECTIONS
         KEEP(*(.bss.$RESERVED*))
         . = ALIGN(4) ;
         _end_uninit_RESERVED = .;
-    } > RamLoc64
-    /* Main DATA section (RamLoc64) */
+    } > SRAM
+    /* Main DATA section (SRAM) */
     .data : ALIGN(4)
     {
        FILL(0xff)
@@ -159,16 +159,16 @@ SECTIONS
        *(.data*)
        . = ALIGN(4) ;
        _edata = . ;
-    } > RamLoc64 AT>MFlash512
-    /* BSS section for RamPeriph32 */
+    } > SRAM AT>FLASH
+    /* BSS section for SRAM_AHB */
     .bss_RAM2 : ALIGN(4)
     {
        PROVIDE(__start_bss_RAM2 = .) ;
        *(.bss.$RAM2*)
-       *(.bss.$RamPeriph32*)
+       *(.bss.$SRAM_AHB*)
        . = ALIGN (. != 0 ? 4 : 1) ; /* avoid empty segment */
        PROVIDE(__end_bss_RAM2 = .) ;
-    } > RamPeriph32
+    } > SRAM_AHB
     /* MAIN BSS SECTION */
     .bss : ALIGN(4)
     {
@@ -178,14 +178,14 @@ SECTIONS
         . = ALIGN(4) ;
         _ebss = .;
         PROVIDE(end = .);
-    } > RamLoc64
-    /* NOINIT section for RamPeriph32 */
+    } > SRAM
+    /* NOINIT section for SRAM_AHB */
     .noinit_RAM2 (NOLOAD) : ALIGN(4)
     {
        *(.noinit.$RAM2*)
-       *(.noinit.$RamPeriph32*)
+       *(.noinit.$SRAM_AHB*)
        . = ALIGN(4) ;
-    } > RamPeriph32
+    } > SRAM_AHB
     /* DEFAULT NOINIT SECTION */
     .noinit (NOLOAD): ALIGN(4)
     {
@@ -193,9 +193,9 @@ SECTIONS
         *(.noinit*)
          . = ALIGN(4) ;
         _end_noinit = .;
-    } > RamLoc64
+    } > SRAM
 
     PROVIDE(heap = DEFINED(__user_heap_base) ? __user_heap_base : .);
     PROVIDE(heap_end = __top_RAM2);
-    PROVIDE(StackTop = DEFINED(__user_stack_top) ? __user_stack_top : __top_RamLoc64 - 0);
+    PROVIDE(StackTop = DEFINED(__user_stack_top) ? __user_stack_top : __top_SRAM - 0);
 }

--- a/makefile
+++ b/makefile
@@ -7,7 +7,9 @@
 YELLOW=$(shell echo "\x1B[33;1m")
 RED=$(shell echo "\x1B[31;1m")
 MAGENTA=$(shell echo "\x1B[35;1m")
+BLUE=$(shell echo "\x1B[34;1m")
 GREEN=$(shell echo "\x1B[32;1m")
+WHITE=$(shell echo "\x1B[37;1m")
 RESET=$(shell echo "\x1B[0m")
 CURRENT_SETUP_VERSION=$(shell cat $(SJSU_DEV2_BASE)/setup_version.txt)
 # ============================
@@ -190,7 +192,7 @@ endif
 BUILD_DIRECTORY_NAME = build
 
 ifeq ($(MAKECMDGOALS), application)
-$(info $(shell printf '$(MAGENTA)Building application firmware...$(RESET)\n'))
+$(info $(shell printf '$(MAGENTA)Building application firmware...$(RESET)'))
 endif
 
 # "make application"'s build directory becomes "build/application"
@@ -262,11 +264,10 @@ $(1)_OBJECTS = $$(addprefix $(OBJECT_DIR)/, $$($(2):=.o))
 
 $(PLATFORM_STATIC_LIBRARY_DIR)/$(1).a: $$($(1)_OBJECTS)
 	@mkdir -p "$(PLATFORM_STATIC_LIBRARY_DIR)"
-	@printf '$(YELLOW)Library  file ( A ) $(RESET): $$@ '
 	@rm -f "$@"
 	@$$(DEVICE_AR) rcs "$$@" $$^
 	@$$(DEVICE_RANLIB) "$$@"
-	@printf '$(GREEN)DONE!$(RESET)\n'
+	@echo -e '$(YELLOW)Library file ( A )$(RESET)  : $$@ '
 
 endef
 # Set of ALL compilable test files in the current library.
@@ -408,7 +409,8 @@ TEST_EXEC  = $(BUILD_DIRECTORY_NAME)/tests.exe
 .DEFAULT_GOAL := default
 # Tell make that these recipes don't have a end product
 .PHONY: default build cleaninstall telemetry monitor show-lists clean flash \
-        telemetry presubmit openocd debug library-clean purge test library-test
+        telemetry presubmit openocd debug library-clean purge test \
+        library-test $(SIZE)
 print-%  : ; @echo $* = $($*)
 # ====================================================================
 # When the user types just "make" or "help" this should appear to them
@@ -425,7 +427,7 @@ help:
 	@echo "  clean        - deletes build folder contents"
 	@echo "  cleaninstall - cleans, builds, and installs application firmware on "
 	@echo "                 device."
-	@echo " library-clean - cleans static libraries files"
+	@echo "  library-clean - cleans static libraries files"
 	@echo "  purge        - remove local build files and static libraries "
 	@echo "  telemetry    - Launch telemetry web interface on platform"
 	@echo
@@ -587,50 +589,49 @@ show-lists:
 # ====================================================================
 
 $(HEX): $(EXECUTABLE)
-	@printf '$(YELLOW)Generating Hex Image $(RESET)   : $@ '
 	@$(OBJCOPY) -O ihex "$<" "$@"
-	@printf '$(GREEN)Hex Generated!$(RESET)\n'
+	@echo -e '$(YELLOW)Generated Hex Image $(RESET)   : $@'
 
 $(BINARY): $(EXECUTABLE)
-	@printf '$(YELLOW)Generating Binary Image $(RESET): $@ '
 	@$(OBJCOPY) -O binary "$<" "$@"
-	@printf '$(GREEN)Binary Generated!$(RESET)\n'
+	@echo -e '$(YELLOW)Generated Binary Image $(RESET): $@'
+
 
 $(SIZE): $(EXECUTABLE)
-	@echo ' '
-	@echo 'Showing Image Size Information: '
+	@echo
+	@echo -e '$(WHITE)   Memory region:     Used Size  Region Size  %age Used'
+	@echo -ne '$(RESET)'
+	@export GREP_COLOR='1;34' ; cat '$(SIZE)' | grep --color=always ".*: " || true
+	@echo
+	@echo -e '$(WHITE)Section Memory Usage$(RESET)'
 	@$(SIZEC) --format=berkeley "$<"
-	@echo ' '
+	@echo
 
 $(LIST): $(EXECUTABLE)
-	@printf '$(YELLOW)Generating Disassembly$(RESET)  : $@ '
 	@$(OBJDUMP) --disassemble --all-headers --source --demangle --wide "$<" > "$@"
-	@printf '$(GREEN)Disassembly Generated!$(RESET)\n'
+	@echo -e '$(YELLOW)Disassembly Generated!$(RESET)  : $@'
 
 $(CORE_STATIC_LIBRARY): $(LIBRARIES)
-	@printf '$(YELLOW)Final Library file ( A ) $(RESET): $@ '
 	@rm -f "$@"
 	@$(DEVICE_AR) -rcT "$@" $^
 	@$(DEVICE_RANLIB) "$@"
-	@printf '$(GREEN)DONE!$(RESET)\n'
+	@echo -e '$(YELLOW)Final Library file ( A ) $(RESET): $@'
 
 $(EXECUTABLE): $(OBJECTS) $(CORE_STATIC_LIBRARY)
-	@printf '$(YELLOW)Linking Executable $(RESET)     : $@ '
+	@echo -e '$(YELLOW)Linking Executable$(RESET)    : $@'
 	@mkdir -p "$(dir $@)"
-	@$(CPPC) $(LINKFLAGS) -o "$@" $(OBJECTS) $(CORE_STATIC_LIBRARY)
-	@printf '$(GREEN)Executable Generated!$(RESET)\n'
+	@$(CPPC) -Wl,--print-memory-usage $(LINKFLAGS) -o "$@" \
+			$(OBJECTS) $(CORE_STATIC_LIBRARY) 1> "$(SIZE)"
 
 $(OBJECT_DIR)/%.c.o: %.c
-	@printf '$(YELLOW)Building file ( C ) $(RESET): $< '
 	@mkdir -p "$(dir $@)"
 	@$(CC) $(CFLAGS) -std=gnu11 -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
-	@printf '$(GREEN)DONE!$(RESET)\n'
+	@echo -e '$(YELLOW)Built file ( C ) $(RESET): $<'
 
 $(OBJECT_DIR)/%.o: %
-	@printf '$(YELLOW)Building file (C++) $(RESET): $< '
 	@mkdir -p "$(dir $@)"
 	@$(CPPC) $(CPPFLAGS) -std=c++17 -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
-	@printf '$(GREEN)DONE!$(RESET)\n'
+	@echo -e '$(YELLOW)Built file (C++) $(RESET): $<'
 
 $(DBC_BUILD):
 	@mkdir -p "$(dir $@)"
@@ -638,7 +639,7 @@ $(DBC_BUILD):
 		-i "$(LIBRARY_DIR)/$(DBC_DIR)/243.dbc" -s $(ENTITY) > $(DBC_BUILD)
 
 $(TEST_EXEC): $(OBJECTS)
-	@printf '$(YELLOW)Linking Test Executable $(RESET) : $@ '
+	@echo -e '$(YELLOW)Linking Test Executable $(RESET) : $@'
 	@mkdir -p "$(dir $@)"
 	@$(CPPC) -fprofile-arcs -fPIC -fexceptions -fno-inline \
 					 -fno-inline-small-functions -fno-default-inline \
@@ -646,14 +647,13 @@ $(TEST_EXEC): $(OBJECTS)
 					 -ftest-coverage -O0 -fsanitize=address \
 					 -std=c++17 -stdlib=libc++ -lc++ -lc++abi \
 					 -o $(TEST_EXEC) $(OBJECTS)
-	@printf '$(GREEN)Test Executable Generated!$(RESET)\n'
+	@echo -e '$(GREEN)Test Executable Generated!$(RESET)'
 
 $(OBJECT_DIR)/%.tidy: %
-	@printf '$(YELLOW)Evaluating file: $(RESET)$< '
 	@mkdir -p "$(dir $@)"
 	@$(CLANG_TIDY) $(if $(or $(findstring .hpp,$<), $(findstring .cpp,$<)), \
 		-extra-arg="-std=c++17") "$<"  -- \
 		-D TARGET=HostTest -D HOST_TEST=1 \
 		-isystem"$(SJCLANG)/include/c++/v1/" \
 		-stdlib=libc++ $(INCLUDES) $(SYSTEM_INCLUDES) 2> $@
-	@printf '$(GREEN)DONE!$(RESET)\n'
+	@echo -e '$(GREEN)Evaluated file: $(RESET)$< '

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -31,7 +31,7 @@ function print_divider
   printf "$BOLD_YELLOW"
   printf "_____________________________________________________________________"
   printf "\n\n"
-  printf "$1\n"
+  printf "$BOLD_WHITE $1\n"
   printf "_____________________________________________________________________"
   printf "\n"
   printf "$RESET\n"

--- a/tools/presubmit.sh
+++ b/tools/presubmit.sh
@@ -45,7 +45,7 @@ function check
     printf "\e[0;32m|           (⌐▪_▪)           |\e[0m\n"
     sleep .5
     printf "\e[0;32m|                            |\e[0m\n"
-    printf "\e[0;32m|      You may commit        |\e[0m\n"
+    printf "\e[0;32m|       You may commit       |\e[0m\n"
     printf "\e[0;32m ============================ \e[0m\n"
     exit 0
   fi


### PR DESCRIPTION
Added --print-memory-usage to linking flag and storing output into the
$(SIZE) file which will describe the space utilization of each memory
region in the linker script.

This is shown along side the gnu size output for specific code sections.