### PR TITLE
Add Semihosting Printf to all ARM builds

### DIFF
--- a/library/L0_Platform/arm_cortex/exceptions.cpp
+++ b/library/L0_Platform/arm_cortex/exceptions.cpp
@@ -4,9 +4,11 @@
 
 #include "L0_Platform/ram.hpp"
 #include "L0_Platform/startup.hpp"
+#include "L0_Platform/arm_cortex/m4/core_cm4.h"
 #include "L1_Peripheral/cortex/interrupt.hpp"
 #include "utility/log.hpp"
 #include "utility/time.hpp"
+#include "third_party/semihost/trace.h"
 
 extern "C"
 {
@@ -81,6 +83,14 @@ extern "C"
     sjsu::cortex::__set_MSP(kTopOfStack);
 
     sjsu::SystemInitialize();
+    // Check if Debugger is connected
+    {
+      using sjsu::cortex::CoreDebug_Type;
+      if (CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk)
+      {
+          trace_initialize();  // Enable debug tracing
+      }
+    }
     sjsu::InitializePlatform();
 // #pragma ignored "-Wpedantic" to suppress main function call warning
 #pragma GCC diagnostic push ignored "-Wpedantic"

--- a/library/L1_Peripheral/cortex/dwt_counter.hpp
+++ b/library/L1_Peripheral/cortex/dwt_counter.hpp
@@ -2,9 +2,6 @@
 
 #include "L0_Platform/lpc40xx/LPC40xx.h"
 
-// using ::sjsu::lpc40xx::DWT_Type;
-// using ::sjsu::lpc40xx::CoreDebug_Type;
-
 namespace sjsu
 {
 namespace cortex

--- a/library/third_party/printf/printf.cpp
+++ b/library/third_party/printf/printf.cpp
@@ -34,6 +34,7 @@
 // PRINTF_SUPPORT_LONG_LONG, PRINTF_SUPPORT_PTRDIFF_T
 #include <stdbool.h>
 #include <stdint.h>
+#include <unistd.h>
 #include "printf.h"
 #include "config.hpp"
 
@@ -54,6 +55,9 @@
 // one converted float number including padded zeros (dynamically created on stack)
 // 32 byte is a good default
 #define PRINTF_FTOA_BUFFER_SIZE    32U
+
+// Temperary buffer used by vsnprintf in order to
+#define PRINTF_BUFFER_CHUNK_SIZE    256U
 
 // SJSU-Dev2: Added define check to suppress redefinition warning
 // define this to support floating point (%f)
@@ -106,6 +110,29 @@ static inline void _out_buffer(char character, void* buffer, size_t idx, size_t 
 {
   if (idx < maxlen) {
     ((char*)buffer)[idx] = character;
+  }
+}
+
+// SJSU-Dev2: Adding _out_chunk to make usage of the write function more more
+// efficient vs using the out() with individual characters.
+extern "C" int _write(int file, char * ptr, int length);
+// internal chunk output
+
+void _out_chunk(char character, void* buffer, size_t idx, size_t)
+{
+  size_t string_limit = PRINTF_BUFFER_CHUNK_SIZE - 2;
+  size_t proper_index = idx % (string_limit);
+  ((char*)buffer)[proper_index] = character;
+  // if character == '\0', flush the buffer.
+  if (character == '\0') {
+    _write(STDOUT_FILENO, (char*)buffer, proper_index);
+  } else if (proper_index + 1 == string_limit) {
+    // Add null character to the end of the array to make _write(), which uses
+    // trace_write faster.
+    size_t last_character = string_limit + 1;
+    ((char*)buffer)[last_character] = '\0';
+    // At the end of the buffer, flush buffer.
+    _write(STDOUT_FILENO, (char*)buffer, last_character);
   }
 }
 
@@ -721,10 +748,17 @@ int printf(const char* format, ...)
 {
   va_list va;
   va_start(va, format);
-  char buffer[1];
-  const int ret = _vsnprintf(_out_char, buffer, (size_t)-1, format, va);
+  char buffer[PRINTF_BUFFER_CHUNK_SIZE];
+  const int ret = _vsnprintf(_out_chunk, buffer, (size_t)-1, format, va);
   va_end(va);
   return ret;
+
+  // va_list va;
+  // va_start(va, format);
+  // char buffer[1];
+  // const int ret = _vsnprintf(_out_char, buffer, (size_t)-1, format, va);
+  // va_end(va);
+  // return ret;
 }
 
 

--- a/library/third_party/semihost/LICENSE.txt
+++ b/library/third_party/semihost/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright (c) 2014 Liviu Ionescu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/library/third_party/semihost/README.md
+++ b/library/third_party/semihost/README.md
@@ -1,0 +1,60 @@
+# Simple semihosting output functions for Cortex-M devices
+
+For printf, puts and putchar functions that output directly through the debugging interface using semihosting.
+They implement semihosting calls directly so have few dependencies, and they may produce a smaller code size than when using their equivalent built-in functions (particularly trace_puts and trace_putchar).
+
+These files are taken directly from the µOS++ project by Liviu Ionescu, which is MIT-licensed.
+They are also used in the excellent GNU ARM Eclipse plugins suite by the same author.
+
+They are provided here to ease their use in other projects that are not based on µOS++.
+
+Details on µOS++:
+https://sourceforge.net/p/micro-os-plus/
+
+Details on GNU ARM Eclipse:
+https://sourceforge.net/p/gnuarmeclipse/
+
+## Functions
+Provides the following functions:
+```c
+int trace_printf(const char* format, ...);
+int trace_puts(const char *s);
+int trace_putchar(int c);
+```
+
+The semihosting integration is performed in the function call_host called by the above functions.
+
+## Usage
+Add inc/ to your include paths and src/ to your build path.
+
+Add `#include "trace.h"` to any files you wish to use the functions in.
+
+
+
+Two macros must be defined, `TRACE` and one of the following be determine output method:
+* `OS_USE_TRACE_ITM` - ARM's Instrumentation Trace Macrocell (not yet supported by OpenOCD)
+* `OS_USE_TRACE_SEMIHOSTING_DEBUG` - Semihosting debug (unbuffered)
+* `OS_USE_TRACE_SEMIHOSTING_STDOUT` - Semihosting stdout (buffered)
+
+These can be passed to compilers like gcc directly, for example `-DTRACE -DOS_USE_TRACE_SEMIHOSTING_DEBUG`
+
+If using gcc-arm-embedded toolchain you should add the linker option `--specs=rdimon.specs`
+
+trace_printf uses vsnprintf from stdio.h, so this must be available, and this function will have a larger code size as a result.
+
+### OpenOCD
+To enable semihosting in OpenOCD issue the command `arm semihosting enable` or via gdb with `mon arm semihosting enable`.
+
+For example, after successfully connecting to your target with OpenOCD, connect the debugger:
+```
+arm-none-eabi-gdb -ex "target ext localhost:3333" -ex "mon reset halt" -ex "mon arm semihosting enable" myproject.elf
+```
+
+## Disclaimer
+This repository was created to make it easier for me to integrate these functions into my own projects for debugging purposes.
+I hope they may be useful to others, but there is no guarantee that they will work outside of my own specific setup.
+
+They have been tested on an STM32F0 platform using the STM32F0xx_HAL drivers, and the gcc-arm-embedded toolchain with newlib-nano:
+https://launchpad.net/gcc-arm-embedded. I've found them to produce a smaller code size than the built-in output functions used in conjunction with semihosting.
+
+Many thanks to Liviu Ionescu for his great work.

--- a/library/third_party/semihost/semihost.mk
+++ b/library/third_party/semihost/semihost.mk
@@ -1,0 +1,8 @@
+INCLUDES +=
+
+SYSTEM_INCLUDES += $(LIBRARY_DIR)/third_party/semihost/
+
+LIBRARY_SEMIHOST += $(LIBRARY_DIR)/third_party/semihost/trace.cpp
+LIBRARY_SEMIHOST += $(LIBRARY_DIR)/third_party/semihost/trace_impl.cpp
+
+$(eval $(call BUILD_LIRBARY,libsemihost,LIBRARY_SEMIHOST))

--- a/library/third_party/semihost/semihosting.h
+++ b/library/third_party/semihost/semihosting.h
@@ -1,0 +1,107 @@
+//
+// This file is part of the µOS++ III distribution.
+// Copyright (c) 2014 Liviu Ionescu.
+//
+
+#ifndef ARM_SEMIHOSTING_H_
+#define ARM_SEMIHOSTING_H_
+
+// ----------------------------------------------------------------------------
+
+// Semihosting operations.
+enum OperationNumber
+{
+  // Regular operations
+  SEMIHOSTING_EnterSVC = 0x17,
+  SEMIHOSTING_ReportException = 0x18,
+  SEMIHOSTING_SYS_CLOSE = 0x02,
+  SEMIHOSTING_SYS_CLOCK = 0x10,
+  SEMIHOSTING_SYS_ELAPSED = 0x30,
+  SEMIHOSTING_SYS_ERRNO = 0x13,
+  SEMIHOSTING_SYS_FLEN = 0x0C,
+  SEMIHOSTING_SYS_GET_CMDLINE = 0x15,
+  SEMIHOSTING_SYS_HEAPINFO = 0x16,
+  SEMIHOSTING_SYS_ISERROR = 0x08,
+  SEMIHOSTING_SYS_ISTTY = 0x09,
+  SEMIHOSTING_SYS_OPEN = 0x01,
+  SEMIHOSTING_SYS_READ = 0x06,
+  SEMIHOSTING_SYS_READC = 0x07,
+  SEMIHOSTING_SYS_REMOVE = 0x0E,
+  SEMIHOSTING_SYS_RENAME = 0x0F,
+  SEMIHOSTING_SYS_SEEK = 0x0A,
+  SEMIHOSTING_SYS_SYSTEM = 0x12,
+  SEMIHOSTING_SYS_TICKFREQ = 0x31,
+  SEMIHOSTING_SYS_TIME = 0x11,
+  SEMIHOSTING_SYS_TMPNAM = 0x0D,
+  SEMIHOSTING_SYS_WRITE = 0x05,
+  SEMIHOSTING_SYS_WRITEC = 0x03,
+  SEMIHOSTING_SYS_WRITE0 = 0x04,
+
+  // Codes returned by SEMIHOSTING_ReportException
+  ADP_Stopped_ApplicationExit = ((2 << 16) + 38),
+  ADP_Stopped_RunTimeError = ((2 << 16) + 35),
+
+};
+
+// ----------------------------------------------------------------------------
+
+// SWI numbers and reason codes for RDI (Angel) monitors.
+#define AngelSWI_ARM 			0x123456
+#ifdef __thumb__
+#define AngelSWI 			0xAB
+#else
+#define AngelSWI 			AngelSWI_ARM
+#endif
+// For thumb only architectures use the BKPT instruction instead of SWI.
+#if defined(__ARM_ARCH_7M__)     \
+    || defined(__ARM_ARCH_7EM__) \
+    || defined(__ARM_ARCH_6M__)
+#define AngelSWIInsn			"bkpt"
+#define AngelSWIAsm			bkpt
+#else
+#define AngelSWIInsn			"swi"
+#define AngelSWIAsm			swi
+#endif
+
+static inline int
+__attribute__ ((always_inline))
+call_host (int reason, void* arg)
+{
+  int value;
+  asm volatile (
+
+      " mov r0, %[rsn]  \n"
+      " mov r1, %[arg]  \n"
+      " " AngelSWIInsn " %[swi] \n"
+      " mov %[val], r0"
+
+      : [val] "=r" (value) /* Outputs */
+      : [rsn] "r" (reason), [arg] "r" (arg), [swi] "i" (AngelSWI) /* Inputs */
+      : "r0", "r1", "r2", "r3", "ip", "lr", "memory", "cc"
+      // Clobbers r0 and r1, and lr if in supervisor mode
+  );
+
+  // Accordingly to page 13-77 of ARM DUI 0040D other registers
+  // can also be clobbered. Some memory positions may also be
+  // changed by a system call, so they should not be kept in
+  // registers. Note: we are assuming the manual is right and
+  // Angel is respecting the APCS.
+  return value;
+}
+
+// ----------------------------------------------------------------------------
+
+// Function used in _exit() to return the status code as Angel exception.
+static inline void
+__attribute__ ((always_inline,noreturn))
+report_exception (int reason)
+{
+  call_host (SEMIHOSTING_ReportException, (void*) reason);
+
+  for (;;)
+    ;
+}
+
+// ----------------------------------------------------------------------------
+
+#endif // ARM_SEMIHOSTING_H_

--- a/library/third_party/semihost/trace.cpp
+++ b/library/third_party/semihost/trace.cpp
@@ -1,0 +1,85 @@
+//
+// This file is part of the µOS++ III distribution.
+// Copyright (c) 2014 Liviu Ionescu.
+//
+
+// ----------------------------------------------------------------------------
+
+#if defined(TRACE)
+
+#include <stdio.h>
+#include <stdarg.h>
+#include "trace.h"
+#include "string.h"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+
+#ifndef OS_INTEGER_TRACE_PRINTF_TMP_ARRAY_SIZE
+#define OS_INTEGER_TRACE_PRINTF_TMP_ARRAY_SIZE (256)
+#endif
+
+// ----------------------------------------------------------------------------
+
+int
+trace_printf(const char* format, ...)
+{
+  int ret;
+  va_list ap;
+
+  va_start (ap, format);
+
+  // TODO: rewrite it to no longer use newlib, it is way too heavy
+
+  static char buf[OS_INTEGER_TRACE_PRINTF_TMP_ARRAY_SIZE];
+
+  // Print to the local buffer
+  ret = vsnprintf (buf, sizeof(buf), format, ap);
+  if (ret > 0)
+    {
+      // Transfer the buffer to the device
+      ret = trace_write (buf, (size_t)ret);
+    }
+
+  va_end (ap);
+  return ret;
+}
+
+int
+trace_puts(const char *s)
+{
+  trace_write(s, strlen(s));
+  return trace_write("\n", 1);
+}
+
+int
+trace_putchar(int c)
+{
+  trace_write((const char*)&c, 1);
+  return c;
+}
+
+void
+trace_dump_args(int argc, char* argv[])
+{
+  trace_printf("main(argc=%d, argv=[", argc);
+  for (int i = 0; i < argc; ++i)
+    {
+      if (i != 0)
+        {
+          trace_printf(", ");
+        }
+      trace_printf("\"%s\"", argv[i]);
+    }
+  trace_printf("]);\n");
+}
+
+#pragma GCC diagnostic pop
+// ----------------------------------------------------------------------------
+
+#endif // TRACE

--- a/library/third_party/semihost/trace.h
+++ b/library/third_party/semihost/trace.h
@@ -1,0 +1,146 @@
+//
+// This file is part of the µOS++ III distribution.
+// Copyright (c) 2014 Liviu Ionescu.
+//
+
+#ifndef DIAG_TRACE_H_
+#define DIAG_TRACE_H_
+
+// ----------------------------------------------------------------------------
+
+#include <unistd.h>
+
+// ----------------------------------------------------------------------------
+
+// The trace device is an independent output channel, intended for debug
+// purposes.
+//
+// The API is simple, and mimics the standard output calls:
+// - trace_printf()
+// - trace_puts()
+// - trace_putchar();
+//
+// The implementation is done in
+// - trace_write()
+//
+// Trace support is enabled by adding the TRACE definition.
+// By default the trace messages are forwarded to the ITM output,
+// but can be rerouted via any device or completely suppressed by
+// changing the definitions required in system/src/diag/trace_impl.c
+// (currently OS_USE_TRACE_ITM, OS_USE_TRACE_SEMIHOSTING_DEBUG/_STDOUT).
+//
+// When TRACE is not defined, all functions are inlined to empty bodies.
+// This has the advantage that the trace call do not need to be conditionally
+// compiled with #ifdef TRACE/#endif
+
+
+#if defined(TRACE)
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+  void
+  trace_initialize(void);
+
+  // Implementation dependent
+  ssize_t
+  trace_write(const char* buf, size_t nbyte);
+
+  // ----- Portable -----
+
+  int
+  trace_printf(const char* format, ...);
+
+  int
+  trace_puts(const char *s);
+
+  int
+  trace_putchar(int c);
+
+  void
+  trace_dump_args(int argc, char* argv[]);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#else // !defined(TRACE)
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+  inline void
+  trace_initialize(void);
+
+  // Implementation dependent
+  inline ssize_t
+  trace_write(const char* buf, size_t nbyte);
+
+  inline int
+  trace_printf(const char* format, ...);
+
+  inline int
+  trace_puts(const char *s);
+
+  inline int
+  trace_putchar(int c);
+
+  inline void
+  trace_dump_args(int argc, char* argv[]);
+
+#if defined(__cplusplus)
+}
+#endif
+
+inline void
+__attribute__((always_inline))
+trace_initialize(void)
+{
+}
+
+// Empty definitions when trace is not defined
+inline ssize_t
+__attribute__((always_inline))
+trace_write(const char* buf __attribute__((unused)),
+    size_t nbyte __attribute__((unused)))
+{
+  return 0;
+}
+
+inline int
+__attribute__((always_inline))
+trace_printf(const char* format __attribute__((unused)), ...)
+  {
+    return 0;
+  }
+
+inline int
+__attribute__((always_inline))
+trace_puts(const char *s __attribute__((unused)))
+{
+  return 0;
+}
+
+inline int
+__attribute__((always_inline))
+trace_putchar(int c)
+{
+  return c;
+}
+
+inline void
+__attribute__((always_inline))
+trace_dump_args(int argc __attribute__((unused)),
+    char* argv[] __attribute__((unused)))
+{
+}
+
+#endif // defined(TRACE)
+
+// ----------------------------------------------------------------------------
+
+#endif // DIAG_TRACE_H_

--- a/library/third_party/semihost/trace_impl.cpp
+++ b/library/third_party/semihost/trace_impl.cpp
@@ -1,0 +1,276 @@
+//
+// This file is part of the µOS++ III distribution.
+// Copyright (c) 2014 Liviu Ionescu.
+//
+
+// ----------------------------------------------------------------------------
+
+#if defined(TRACE)
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+
+#include "trace.h"
+#include "L0_Platform/lpc40xx/LPC40xx.h"
+
+using ::sjsu::cortex::DWT_Type;
+using ::sjsu::cortex::CoreDebug_Type;
+// ----------------------------------------------------------------------------
+
+// One of these definitions must be passed via the compiler command line
+// Note: small Cortex-M0/M0+ might implement a simplified debug interface.
+
+//#define OS_USE_TRACE_ITM
+//#define OS_USE_TRACE_SEMIHOSTING_DEBUG
+//#define OS_USE_TRACE_SEMIHOSTING_STDOUT
+
+#if !(defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__))
+#if defined(OS_USE_TRACE_ITM)
+#undef OS_USE_TRACE_ITM
+#warning "ITM unavailable"
+#endif // defined(OS_USE_TRACE_ITM)
+#endif // !(defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__))
+
+// ----------------------------------------------------------------------------
+
+// Forward definitions.
+
+#if defined(OS_USE_TRACE_ITM)
+static ssize_t
+_trace_write_itm (const char* buf, size_t nbyte);
+#endif
+
+#if defined(OS_USE_TRACE_SEMIHOSTING_STDOUT)
+static ssize_t
+_trace_write_semihosting_stdout(const char* buf, size_t nbyte);
+#endif
+
+#if defined(OS_USE_TRACE_SEMIHOSTING_DEBUG)
+static ssize_t
+_trace_write_semihosting_debug(const char* buf, size_t nbyte);
+#endif
+
+// ----------------------------------------------------------------------------
+
+void
+trace_initialize(void)
+{
+  // No initialisations required for ITM / semihosting
+}
+
+// ----------------------------------------------------------------------------
+
+// This function is called from _write() for fd==1 or fd==2 and from some
+// of the trace_* functions.
+
+ssize_t
+trace_write (const char* buf __attribute__((unused)),
+	     size_t nbyte __attribute__((unused)))
+{
+#if defined(OS_USE_TRACE_ITM)
+  return _trace_write_itm (buf, nbyte);
+#elif defined(OS_USE_TRACE_SEMIHOSTING_STDOUT)
+  return _trace_write_semihosting_stdout(buf, nbyte);
+#elif defined(OS_USE_TRACE_SEMIHOSTING_DEBUG)
+  return _trace_write_semihosting_debug(buf, nbyte);
+#endif
+
+  return -1;
+}
+
+// ----------------------------------------------------------------------------
+
+#if defined(OS_USE_TRACE_ITM)
+
+#if defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+
+// ITM is the ARM standard mechanism, running over SWD/SWO on Cortex-M3/M4
+// devices, and is the recommended setting, if available.
+//
+// The JLink probe and the GDB server fully support SWD/SWO
+// and the JLink Debugging plug-in enables it by default.
+// The current OpenOCD does not include support to parse the SWO stream,
+// so this configuration will not work on OpenOCD (will not crash, but
+// nothing will be displayed in the output console).
+
+#if !defined(OS_INTEGER_TRACE_ITM_STIMULUS_PORT)
+#define OS_INTEGER_TRACE_ITM_STIMULUS_PORT     (0)
+#endif
+
+static ssize_t
+_trace_write_itm (const char* buf, size_t nbyte)
+{
+  for (size_t i = 0; i < nbyte; i++)
+    {
+      // Check if ITM or the stimulus port are not enabled
+      if (((ITM->TCR & ITM_TCR_ITMENA_Msk) == 0)
+	  || ((ITM->TER & (1UL << OS_INTEGER_TRACE_ITM_STIMULUS_PORT)) == 0))
+	{
+	  return (ssize_t)i; // return the number of sent characters (may be 0)
+	}
+
+      // Wait until STIMx is ready...
+      while (ITM->PORT[OS_INTEGER_TRACE_ITM_STIMULUS_PORT].u32 == 0)
+	;
+      // then send data, one byte at a time
+      ITM->PORT[OS_INTEGER_TRACE_ITM_STIMULUS_PORT].u8 = (uint8_t) (*buf++);
+    }
+
+  return (ssize_t)nbyte; // all characters successfully sent
+}
+
+#endif // defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+
+#endif // OS_USE_TRACE_ITM
+
+// ----------------------------------------------------------------------------
+
+#if defined(OS_USE_TRACE_SEMIHOSTING_DEBUG) || defined(OS_USE_TRACE_SEMIHOSTING_STDOUT)
+
+#include "semihosting.h"
+
+// Semihosting is the other output channel that can be used for the trace
+// messages. It comes in two flavours: STDOUT and DEBUG. The STDOUT channel
+// is the equivalent of the stdout in POSIX and in most cases it is forwarded
+// to the GDB server stdout stream. The debug channel is a separate
+// channel. STDOUT is buffered, so nothing is displayed until a \n;
+// DEBUG is not buffered, but can be slow.
+//
+// Choosing between semihosting stdout and debug depends on the capabilities
+// of your GDB server, and also on specific needs. It is recommended to test
+// DEBUG first, and if too slow, try STDOUT.
+//
+// The JLink GDB server fully support semihosting, and both configurations
+// are available; to activate it, use "monitor semihosting enable" or check
+// the corresponding button in the JLink Debugging plug-in.
+// In OpenOCD, support for semihosting can be enabled using
+// "monitor arm semihosting enable".
+//
+// Note: Applications built with semihosting output active cannot be
+// executed without the debugger connected and active, since they use
+// BKPT to communicate with the host. Attempts to run them standalone or
+// without semihosting enabled will usually be terminated with hardware faults.
+
+#endif // OS_USE_TRACE_SEMIHOSTING_DEBUG_*
+
+// ----------------------------------------------------------------------------
+
+#if defined(OS_USE_TRACE_SEMIHOSTING_STDOUT)
+
+static ssize_t
+_trace_write_semihosting_stdout (const char* buf, size_t nbyte)
+{
+#if (defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)) && !defined(OS_HAS_NO_CORE_DEBUG)
+  // Check if the debugger is enabled. CoreDebug is available only on CM3/CM4.
+  // [Contributed by SourceForge user diabolo38]
+  if ((CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) == 0)
+    {
+      // If not, pretend we wrote all bytes
+      return (ssize_t) (nbyte);
+    }
+#endif // defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+
+  static int handle;
+  void* block[3];
+  int ret;
+
+  if (handle == 0)
+    {
+      // On the first call get the file handle from the host
+      block[0] = (void*) ":tt"; // special filename to be used for stdin/out/err
+      block[1] = (void*) 4; // mode "w"
+      // length of ":tt", except null terminator
+      block[2] = (void*) (sizeof(":tt") - 1);
+
+      ret = call_host (SEMIHOSTING_SYS_OPEN, (void*) block);
+      if (ret == -1)
+        return -1;
+
+      handle = ret;
+    }
+
+  block[0] = (void*) handle;
+  block[1] = (void*) buf;
+  block[2] = (void*) nbyte;
+  // send character array to host file/device
+  ret = call_host (SEMIHOSTING_SYS_WRITE, (void*) block);
+  // this call returns the number of bytes NOT written (0 if all ok)
+
+  // -1 is not a legal value, but SEGGER seems to return it
+  if (ret == -1)
+    return -1;
+
+  // The compliant way of returning errors
+  if (ret == (int) nbyte)
+    return -1;
+
+  // Return the number of bytes written
+  return (ssize_t) (nbyte) - (ssize_t) ret;
+}
+
+#endif // OS_USE_TRACE_SEMIHOSTING_STDOUT
+
+// ----------------------------------------------------------------------------
+
+#if defined(OS_USE_TRACE_SEMIHOSTING_DEBUG)
+
+#define OS_INTEGER_TRACE_TMP_ARRAY_SIZE  (16)
+
+static ssize_t
+_trace_write_semihosting_debug (const char* buf, size_t nbyte)
+{
+#if (defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)) && !defined(OS_HAS_NO_CORE_DEBUG)
+  // Check if the debugger is enabled. CoreDebug is available only on CM3/CM4.
+  // [Contributed by SourceForge user diabolo38]
+  if ((CoreDebug->DHCSR & CoreDebug_DHCSR_C_DEBUGEN_Msk) == 0)
+    {
+      // If not, pretend we wrote all bytes
+      return (ssize_t) (nbyte);
+    }
+#endif // defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+
+  // Since the single character debug channel is quite slow, try to
+  // optimise and send a null terminated string, if possible.
+  if (buf[nbyte] == '\0')
+    {
+      // send string
+      call_host (SEMIHOSTING_SYS_WRITE0, (void*) buf);
+    }
+  else
+    {
+      // If not, use a local buffer to speed things up
+      char tmp[OS_INTEGER_TRACE_TMP_ARRAY_SIZE];
+      size_t togo = nbyte;
+      while (togo > 0)
+        {
+          unsigned int n = ((togo < sizeof(tmp)) ? togo : sizeof(tmp));
+          unsigned int i = 0;
+          for (; i < n; ++i, ++buf)
+            {
+              tmp[i] = *buf;
+            }
+          tmp[i] = '\0';
+
+          call_host (SEMIHOSTING_SYS_WRITE0, (void*) tmp);
+
+          togo -= n;
+        }
+    }
+
+  // All bytes written
+  return (ssize_t) nbyte;
+}
+
+#endif // OS_USE_TRACE_SEMIHOSTING_DEBUG
+
+#pragma GCC diagnostic pop
+
+#endif // TRACE
+
+// ----------------------------------------------------------------------------
+

--- a/library/third_party/third_party.mk
+++ b/library/third_party/third_party.mk
@@ -1,2 +1,3 @@
 include $(LIBRARY_DIR)/third_party/microrl/microrl.mk
 include $(LIBRARY_DIR)/third_party/printf/printf.mk
+include $(LIBRARY_DIR)/third_party/semihost/semihost.mk

--- a/makefile
+++ b/makefile
@@ -333,7 +333,7 @@ CFLAGS_COMMON = $(COMMON_FLAGS) $(INCLUDES) $(SYSTEM_INCLUDES) -MMD -MP -c
 
 ifndef LINKFLAGS
 LINKFLAGS = $(COMMON_FLAGS) -Wl,--gc-sections -Wl,-Map,"$(MAP)" \
-            -specs=nano.specs \
+            --specs=nano.specs --specs=rdimon.specs \
             -T $(LIBRARY_DIR)/L0_Platform/$(PLATFORM)/linker.ld
 endif
 
@@ -358,7 +358,7 @@ CPPFLAGS = -fprofile-arcs -fPIC -fexceptions -fno-inline -fno-builtin \
          -O0 -MMD -MP -c
 CFLAGS = $(CPPFLAGS)
 else
-CFLAGS = $(CFLAGS_COMMON) -D TARGET=Application
+CFLAGS = $(CFLAGS_COMMON) -D TARGET=Application -DTRACE -DOS_USE_TRACE_SEMIHOSTING_STDOUT
 CPPFLAGS = $(CFLAGS) $(CPPWARNINGS) $(CPPOPTIMIZE) $(WARNINGS)
 endif
 

--- a/projects/hello_world/source/main.cpp
+++ b/projects/hello_world/source/main.cpp
@@ -2,18 +2,18 @@
 
 #include "utility/log.hpp"
 #include "utility/time.hpp"
+#include "third_party/semihost/trace.h"
 
 int main()
 {
-  LOG_INFO("Staring Hello World Application");
+  LOG_INFO("Starting Hello World Application");
   while (true)
   {
     for (uint8_t i = 0; i < 16; i++)
     {
       LOG_INFO("Hello World 0x%X", i);
-      sjsu::Delay(500ms);
+      sjsu::Delay(0ms);
     }
   }
-
   return -1;
 }

--- a/tools/launch_openocd_gdb.sh
+++ b/tools/launch_openocd_gdb.sh
@@ -35,7 +35,8 @@ else # For all other platforms
     exit 1
   fi
   # When the GDB session closes, kill openocd below
-  $DEVICE_GDB $EXECUTABLE -ex "target remote :3333" $GDB_ARGS
+  $DEVICE_GDB $EXECUTABLE \
+      -ex "target remote :3333" -ex "monitor arm semihosting enable" $GDB_ARGS
 
   echo "Killing OpenOCD PID: $OPENOCD_PID"
   kill $OPENOCD_PID


### PR DESCRIPTION
Semihosting printf will only occur if a debugger is attached to the
device. Otherwise, the trace_write() function will simply return.

Resolves #929