### PR TITLE
Migrate from IsrPointer to std::function

### DIFF
--- a/demos/arm_cortex/system_timer/source/main.cpp
+++ b/demos/arm_cortex/system_timer/source/main.cpp
@@ -15,7 +15,7 @@ int main()
   sjsu::cortex::SystemTimer system_timer(
       sjsu::GetInactive<sjsu::SystemController>());
 
-  system_timer.SetInterrupt(DemoSystemIsr);
+  system_timer.SetCallback(DemoSystemIsr);
   system_timer.SetTickFrequency(10_Hz);
   system_timer.StartTimer();
 

--- a/demos/sjtwo/parallel_gpio/source/main.cpp
+++ b/demos/sjtwo/parallel_gpio/source/main.cpp
@@ -1,25 +1,28 @@
+#include <iterator>
+
 #include "L2_HAL/io/parallel_bus/parallel_gpio.hpp"
 #include "L1_Peripheral/lpc40xx/gpio.hpp"
 #include "utility/log.hpp"
 #include "utility/time.hpp"
 
+sjsu::lpc40xx::Gpio led0(2, 3);
+sjsu::lpc40xx::Gpio led1(1, 26);
+sjsu::lpc40xx::Gpio led2(1, 24);
+sjsu::lpc40xx::Gpio led3(1, 18);
 int main()
 {
   LOG_INFO("Staring Parallel Gpio Application");
 
   LOG_INFO("Creating gpio (led) objects...");
-  sjsu::lpc40xx::Gpio led0(2, 3);
-  sjsu::lpc40xx::Gpio led1(1, 26);
-  sjsu::lpc40xx::Gpio led2(1, 24);
-  sjsu::lpc40xx::Gpio led3(1, 18);
 
-  LOG_INFO("Creating ParallelGpio object using led gpios...");
-  sjsu::ParallelGpio parallel_leds({
-      &led0,
-      &led1,
-      &led2,
-      &led3,
-  });
+  LOG_INFO("Creating ParallelGpio object using led Gpios...");
+  sjsu::Gpio * leds[] = {
+    &led0,
+    &led1,
+    &led2,
+    &led3,
+  };
+  sjsu::ParallelGpio parallel_leds(leds, std::size(leds));
 
   while (true)
   {
@@ -28,7 +31,7 @@ int main()
       LOG_INFO("Displaying 0x%X in binary on leds", i);
       // Each LED above the 4 buttons on the SJTwo is active low, meaning it
       // turns on when the pin is set to state LOW. In order to make an LED
-      // shine when the corrisponding bit is 1, I need to invert the value of
+      // shine when the corrissponding bit is 1, I need to invert the value of
       // i. To do this, we use the bitwise invert operator ~
       parallel_leds.Write(~i);
       sjsu::Delay(500ms);

--- a/documentation/design_docs/L2/infrared_receiver_interface.md
+++ b/documentation/design_docs/L2/infrared_receiver_interface.md
@@ -40,10 +40,10 @@ class InfraredReceiver
     uint32_t number_of_pulses;
   };
 
-  using DataReceivedHandler = void (*)(DataFrame_t *);
+  using DataReceivedHandler = std::function<void(DataFrame_t *)>;
 
   virtual Status Initialize()                                   const = 0;
-  virtual void SetInterruptHandler(DataReceivedHandler handler) const = 0;
+  virtual void SetInterruptCallback(DataReceivedHandler handler) const = 0;
 };
 }
 ```
@@ -56,9 +56,9 @@ device and returns `Status::kSuccess` upon successful initialization. If the
 device fails to be initialized, the appropriate failure `Status` is returned.
 
 ```c++
-virtual void SetInterruptHandler(DataReceivedHandler handler) const = 0;
+virtual void SetInterruptCallback(DataReceivedHandler handler) const = 0;
 ```
-`SetInterruptHandler` sets the interrupt callback handler that is invoked when
+`SetInterruptCallback` sets the interrupt callback handler that is invoked when
 a new data is successfully received.
 
 # Caveats

--- a/documentation/design_docs/L2/tsop752.md
+++ b/documentation/design_docs/L2/tsop752.md
@@ -57,7 +57,7 @@ class Tsop752 final : public InfraredReceiver
                              sjsu::Timer & timer);
 
   Status Initialize() const override;
-  void SetInterruptHandler(DataReceivedHandler handler) const override;
+  void SetInterruptCallback(DataReceivedHandler handler) const override;
 
  private:
   static void HandlePulseCaptured();
@@ -87,9 +87,9 @@ The following sequence is performed to initialize the driver:
 
 ### Capturing The De-modulated IR signal
 ```C++
-void SetInterruptHandler(DataReceivedHandler handler) const override
+void SetInterruptCallback(DataReceivedHandler handler) const override
 ```
-`SetInterruptHandler` sets the `interrupt_handler` that is invoked when a data
+`SetInterruptCallback` sets the `interrupt_handler` that is invoked when a data
 frame is successfully received.
 
 ```C++

--- a/library/L0_Platform/lpc17xx/startup.cpp
+++ b/library/L0_Platform/lpc17xx/startup.cpp
@@ -109,7 +109,7 @@ extern "C"
     // It is critical that this happens before you set the system_clock,
     // since The system_timer keeps the time that the system_clock uses to
     // delay itself.
-    system_timer.SetInterrupt(xPortSysTickHandler);
+    system_timer.SetCallback(xPortSysTickHandler);
   }
 }
 
@@ -119,7 +119,7 @@ SJ2_SECTION(".crp") const uint32_t kCrpWord = 0xFFFFFFFF;
 // This relies on the linker script to place at correct location in memory.
 SJ2_SECTION(".isr_vector")
 // NOLINTNEXTLINE(readability-identifier-naming)
-const sjsu::IsrPointer kInterruptVectorTable[] = {
+const sjsu::InterruptHandler kInterruptVectorTable[] = {
   // Core Level - CM4
   &StackTop,                           // 0, The initial stack pointer
   ArmResetHandler,                     // 1, The reset handler

--- a/library/L0_Platform/lpc40xx/startup.cpp
+++ b/library/L0_Platform/lpc40xx/startup.cpp
@@ -111,7 +111,7 @@ extern "C"
     // It is critical that this happens before you set the system_clock,
     // since The system_timer keeps the time that the system_clock uses to
     // delay itself.
-    system_timer.SetInterrupt(xPortSysTickHandler);
+    system_timer.SetCallback(xPortSysTickHandler);
   }
 }
 
@@ -121,7 +121,7 @@ SJ2_SECTION(".crp") const uint32_t kCrpWord = 0xFFFFFFFF;
 // This relies on the linker script to place at correct location in memory.
 SJ2_SECTION(".isr_vector")
 // NOLINTNEXTLINE(readability-identifier-naming)
-const sjsu::IsrPointer kInterruptVectorTable[] = {
+const sjsu::InterruptHandler kInterruptVectorTable[] = {
   // Core Level - CM4
   &StackTop,                           // 0, The initial stack pointer
   ArmResetHandler,                     // 1, The reset handler

--- a/library/L1_Peripheral/cortex/interrupt.hpp
+++ b/library/L1_Peripheral/cortex/interrupt.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <array>
 #include <cstddef>
-#include <iterator>
 
 #include "L0_Platform/arm_cortex/m4/core_cm4.h"
 #include "L1_Peripheral/interrupt.hpp"
@@ -32,10 +32,10 @@ class InterruptController final : public sjsu::InterruptController
 
   struct VectorTable_t
   {
-    IsrPointer vector[kNumberOfInterrupts];
+    std::array<InterruptHandler, kNumberOfInterrupts> vector;
     void Print()
     {
-      for (size_t i = 0; i < std::size(vector); i++)
+      for (size_t i = 0; i < vector.size(); i++)
       {
         LOG_INFO("vector[%zu] = %p", i, vector[i]);
       }
@@ -52,7 +52,7 @@ class InterruptController final : public sjsu::InterruptController
       }
       // For all other exceptions, give a handler that will disable the ISR if
       // it is enabled but has not been registered.
-      for (size_t i = kArmIrqOffset; i < std::size(temp_table.vector); i++)
+      for (size_t i = kArmIrqOffset; i < temp_table.vector.size(); i++)
       {
         temp_table.vector[i] = UnregisteredInterruptHandler;
       }
@@ -72,7 +72,7 @@ class InterruptController final : public sjsu::InterruptController
     return index - kArmIrqOffset;
   }
 
-  static IsrPointer * GetVector(int irq)
+  static InterruptHandler * GetVector(int irq)
   {
     return &table.vector[IrqToIndex(irq)];
   }
@@ -82,7 +82,7 @@ class InterruptController final : public sjsu::InterruptController
   {
     int active_isr = (scb->ICSR & 0xFF);
     current_vector = active_isr;
-    IsrPointer isr = table.vector[active_isr];
+    InterruptHandler isr = table.vector[active_isr];
     isr();
   }
 

--- a/library/L1_Peripheral/cortex/system_timer.hpp
+++ b/library/L1_Peripheral/cortex/system_timer.hpp
@@ -2,7 +2,8 @@
 // up the SystemTimer.
 #pragma once
 
-// NOTE: Support for cortex M4 also supports M3 and possibly M0 and M0+ as well.
+#include <functional>
+
 #include "L0_Platform/arm_cortex/m4/core_cm4.h"
 #include "L1_Peripheral/cortex/interrupt.hpp"
 #include "L1_Peripheral/system_controller.hpp"
@@ -32,10 +33,10 @@ class SystemTimer final : public sjsu::SystemTimer
   };
   /// Address of the ARM Cortex SysTick peripheral.
   inline static SysTick_Type * sys_tick = SysTick;
-  /// system_timer_isr defaults to nullptr. The actual SystemTickHandler should
-  /// check if the isr is set to nullptr, and if it is, turn off the timer, if
-  /// set a proper function then execute it.
-  inline static IsrPointer system_timer_isr = nullptr;
+  /// callback defaults to nullptr. The actual SystemTickHandler
+  /// should check if the isr is set to nullptr, and if it is, turn off the
+  /// timer, if set a proper function then execute it.
+  inline static InterruptCallback callback = nullptr;
   /// Used to count the number of times system_timer has executed. If the
   /// frequency of the SystemTimer is set to 1kHz, this could be used as a
   /// milliseconds counter.
@@ -57,9 +58,9 @@ class SystemTimer final : public sjsu::SystemTimer
     // This assumes that SysTickHandler is called every millisecond.
     // Changing that frequency will distort the milliseconds time.
     counter += 1ms;
-    if (system_timer_isr != nullptr)
+    if (callback)
     {
-      system_timer_isr();
+      callback();
     }
   }
   /// @return returns the current system_timer counter value.
@@ -84,9 +85,9 @@ class SystemTimer final : public sjsu::SystemTimer
 
   void Initialize() const override {}
 
-  void SetInterrupt(IsrPointer isr) const override
+  void SetCallback(InterruptCallback isr) const override
   {
-    system_timer_isr = isr;
+    callback = isr;
   }
 
   Status StartTimer() const override

--- a/library/L1_Peripheral/gpio.hpp
+++ b/library/L1_Peripheral/gpio.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 
 #include "L1_Peripheral/interrupt.hpp"
 #include "L1_Peripheral/lpc40xx/pin.hpp"
@@ -54,17 +55,16 @@ class Gpio
   virtual const sjsu::Pin & GetPin() const = 0;
   /// Attach an interrupt call to a pin
   ///
-  /// @param function - the function to execute when the interrupt condition
-  ///        occurs
+  /// @param callback - the callback supplied here will be executed when the
+  ///        interrupt condition occurs
   /// @param edge - the pin condition that will trigger the interrupt
-  virtual void AttachInterrupt(IsrPointer function, Edge edge) = 0;
+  virtual void AttachInterrupt(InterruptCallback callback, Edge edge) = 0;
   /// Remove interrupt call from pin and deactivate interrupts for this pin
   virtual void DetachInterrupt() const = 0;
 
   // ==============================
   // Utility Methods
   // ==============================
-
   /// Set pin to HIGH voltage
   void SetHigh() const
   {

--- a/library/L1_Peripheral/inactive.hpp
+++ b/library/L1_Peripheral/inactive.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <type_traits>
+#include <functional>
 
 #include "config.hpp"
 #include "L1_Peripheral/adc.hpp"
@@ -122,7 +123,7 @@ const sjsu::Gpio & GetInactive<sjsu::Gpio>()
     {
       return GetInactive<sjsu::Pin>();
     }
-    void AttachInterrupt(IsrPointer, Edge) override {}
+    void AttachInterrupt(InterruptCallback, Edge) override {}
     void DetachInterrupt() const override {}
   };
 
@@ -238,7 +239,7 @@ const sjsu::SystemTimer & GetInactive<sjsu::SystemTimer>()
   {
    public:
     void Initialize() const override {}
-    void SetInterrupt(IsrPointer) const override {}
+    void SetCallback(InterruptCallback) const override {}
     Status StartTimer() const override
     {
       return Status::kNotImplemented;
@@ -261,7 +262,7 @@ const sjsu::Timer & GetInactive<sjsu::Timer>()
   {
    public:
     Status Initialize(units::frequency::hertz_t,
-                      IsrPointer,
+                      InterruptCallback,
                       int32_t) const override
     {
       return Status::kNotImplemented;

--- a/library/L1_Peripheral/interrupt.hpp
+++ b/library/L1_Peripheral/interrupt.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 
 namespace sjsu
 {
 // Define an alias for an interrupt service routine function pointer.
-using IsrPointer = void (*)(void);
+using InterruptHandler = void (*)(void);
+// Standard callback for most callbacks when interrupts fire.
+using InterruptCallback = std::function<void(void)>;
 
 class InterruptController
 {
@@ -13,7 +16,7 @@ class InterruptController
   struct RegistrationInfo_t
   {
     int interrupt_request_number;
-    IsrPointer interrupt_service_routine;
+    InterruptHandler interrupt_service_routine;
     bool enable_interrupt = true;
     int priority          = -1;
   };

--- a/library/L1_Peripheral/lpc17xx/pulse_capture.hpp
+++ b/library/L1_Peripheral/lpc17xx/pulse_capture.hpp
@@ -15,7 +15,7 @@ using ::sjsu::lpc40xx::PulseCapture;
 struct PulseCaptureChannel  // NOLINT
 {
  private:
-  inline static lpc40xx::PulseCapture::CaptureIsr timer0_isr = nullptr;
+  inline static lpc40xx::PulseCapture::CaptureCallback timer0_isr = nullptr;
   inline static lpc40xx::PulseCapture::CaptureChannelNumber
       timer0_channel_number =
           lpc40xx::PulseCapture::CaptureChannelNumber::kChannel1;
@@ -32,7 +32,7 @@ struct PulseCaptureChannel  // NOLINT
                          .capture_pin1   = kCapture0Channel1Pin,
                          .channel_number = &timer0_channel_number };
 
-  inline static lpc40xx::PulseCapture::CaptureIsr timer1_isr = nullptr;
+  inline static lpc40xx::PulseCapture::CaptureCallback timer1_isr = nullptr;
   inline static lpc40xx::PulseCapture::CaptureChannelNumber
       timer1_channel_number =
           lpc40xx::PulseCapture::CaptureChannelNumber::kChannel1;
@@ -49,7 +49,7 @@ struct PulseCaptureChannel  // NOLINT
                          .capture_pin1   = kCapture1Channel1Pin,
                          .channel_number = &timer1_channel_number };
 
-  inline static lpc40xx::PulseCapture::CaptureIsr timer2_isr = nullptr;
+  inline static lpc40xx::PulseCapture::CaptureCallback timer2_isr = nullptr;
   inline static lpc40xx::PulseCapture::CaptureChannelNumber
       timer2_channel_number =
           lpc40xx::PulseCapture::CaptureChannelNumber::kChannel1;
@@ -66,7 +66,7 @@ struct PulseCaptureChannel  // NOLINT
                          .capture_pin1   = kCapture2Channel1Pin,
                          .channel_number = &timer2_channel_number };
 
-  inline static lpc40xx::PulseCapture::CaptureIsr timer3_isr = nullptr;
+  inline static lpc40xx::PulseCapture::CaptureCallback timer3_isr = nullptr;
   inline static lpc40xx::PulseCapture::CaptureChannelNumber
       timer3_channel_number =
           lpc40xx::PulseCapture::CaptureChannelNumber::kChannel1;
@@ -87,22 +87,22 @@ struct PulseCaptureChannel  // NOLINT
   /// Structure that defines the capture channels associated with timer 0
   inline static const lpc40xx::PulseCapture::CaptureChannel_t kCaptureTimer0 = {
     .channel = kTimerPartial0,
-    .isr     = lpc40xx::PulseCapture::TimerHandler<kTimerPartial0>
+    .handler = lpc40xx::PulseCapture::TimerHandler<kTimerPartial0>
   };
   /// Structure that defines the capture channels associated with timer 1
   inline static const lpc40xx::PulseCapture::CaptureChannel_t kCaptureTimer1 = {
     .channel = kTimerPartial1,
-    .isr     = lpc40xx::PulseCapture::TimerHandler<kTimerPartial1>
+    .handler = lpc40xx::PulseCapture::TimerHandler<kTimerPartial1>
   };
   /// Structure that defines the capture channels associated with timer 2
   inline static const lpc40xx::PulseCapture::CaptureChannel_t kCaptureTimer2 = {
     .channel = kTimerPartial2,
-    .isr     = lpc40xx::PulseCapture::TimerHandler<kTimerPartial2>
+    .handler = lpc40xx::PulseCapture::TimerHandler<kTimerPartial2>
   };
   /// Structure that defines the capture channels associated with timer 3
   inline static const lpc40xx::PulseCapture::CaptureChannel_t kCaptureTimer3 = {
     .channel = kTimerPartial3,
-    .isr     = lpc40xx::PulseCapture::TimerHandler<kTimerPartial3>
+    .handler = lpc40xx::PulseCapture::TimerHandler<kTimerPartial3>
   };
 };
 };  // namespace sjsu::lpc17xx

--- a/library/L1_Peripheral/lpc17xx/timer.hpp
+++ b/library/L1_Peripheral/lpc17xx/timer.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "L1_Peripheral/lpc17xx/pin.hpp"
 #include "L1_Peripheral/lpc17xx/system_controller.hpp"
 #include "L1_Peripheral/lpc40xx/timer.hpp"
@@ -14,51 +16,51 @@ using ::sjsu::lpc40xx::Timer;
 struct TimerChannel  // NOLINT
 {
  private:
-  inline static IsrPointer timer0_isr                                 = nullptr;
+  inline static InterruptCallback timer0_callback                     = nullptr;
   inline static const lpc40xx::Timer::ChannelPartial_t kTimerPartial0 = {
     .timer_register = reinterpret_cast<lpc40xx::LPC_TIM_TypeDef *>(LPC_TIM0),
     .power_id       = SystemController::Peripherals::kTimer0,
     .irq            = static_cast<lpc40xx::IRQn>(IRQn::TIMER0_IRQn),
-    .user_callback  = &timer0_isr,
+    .user_callback  = &timer0_callback,
   };
-  inline static IsrPointer timer1_isr                                 = nullptr;
+  inline static InterruptCallback timer1_callback                     = nullptr;
   inline static const lpc40xx::Timer::ChannelPartial_t kTimerPartial1 = {
     .timer_register = reinterpret_cast<lpc40xx::LPC_TIM_TypeDef *>(LPC_TIM1),
     .power_id       = SystemController::Peripherals::kTimer1,
     .irq            = static_cast<lpc40xx::IRQn>(IRQn::TIMER1_IRQn),
-    .user_callback  = &timer1_isr,
+    .user_callback  = &timer1_callback,
   };
-  inline static IsrPointer timer2_isr                                 = nullptr;
+  inline static InterruptCallback timer2_callback                     = nullptr;
   inline static const lpc40xx::Timer::ChannelPartial_t kTimerPartial2 = {
     .timer_register = reinterpret_cast<lpc40xx::LPC_TIM_TypeDef *>(LPC_TIM2),
     .power_id       = SystemController::Peripherals::kTimer2,
     .irq            = static_cast<lpc40xx::IRQn>(IRQn::TIMER2_IRQn),
-    .user_callback  = &timer2_isr,
+    .user_callback  = &timer2_callback,
   };
-  inline static IsrPointer timer3_isr                                 = nullptr;
+  inline static InterruptCallback timer3_callback                     = nullptr;
   inline static const lpc40xx::Timer::ChannelPartial_t kTimerPartial3 = {
     .timer_register = reinterpret_cast<lpc40xx::LPC_TIM_TypeDef *>(LPC_TIM3),
     .power_id       = SystemController::Peripherals::kTimer3,
     .irq            = static_cast<lpc40xx::IRQn>(IRQn::TIMER3_IRQn),
-    .user_callback  = &timer3_isr,
+    .user_callback  = &timer3_callback,
   };
 
  public:
   inline static const lpc40xx::Timer::Channel_t kTimer0 = {
     .channel = kTimerPartial0,
-    .isr     = lpc40xx::Timer::TimerHandler<kTimerPartial0>,
+    .handler = lpc40xx::Timer::TimerHandler<kTimerPartial0>,
   };
   inline static const lpc40xx::Timer::Channel_t kTimer1 = {
     .channel = kTimerPartial1,
-    .isr     = lpc40xx::Timer::TimerHandler<kTimerPartial1>,
+    .handler = lpc40xx::Timer::TimerHandler<kTimerPartial1>,
   };
   inline static const lpc40xx::Timer::Channel_t kTimer2 = {
     .channel = kTimerPartial2,
-    .isr     = lpc40xx::Timer::TimerHandler<kTimerPartial2>,
+    .handler = lpc40xx::Timer::TimerHandler<kTimerPartial2>,
   };
   inline static const lpc40xx::Timer::Channel_t kTimer3 = {
     .channel = kTimerPartial3,
-    .isr     = lpc40xx::Timer::TimerHandler<kTimerPartial3>,
+    .handler = lpc40xx::Timer::TimerHandler<kTimerPartial3>,
   };
 };
 }  // namespace lpc17xx

--- a/library/L1_Peripheral/lpc40xx/gpio.hpp
+++ b/library/L1_Peripheral/lpc40xx/gpio.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 
 #include "L1_Peripheral/gpio.hpp"
 
+#include "L1_Peripheral/interrupt.hpp"
 #include "L1_Peripheral/cortex/interrupt.hpp"
 #include "L0_Platform/lpc40xx/LPC40xx.h"
 #include "L1_Peripheral/lpc40xx/pin.hpp"
@@ -31,8 +33,8 @@ class Gpio final : public sjsu::Gpio
   };
 
   /// Lookup table that holds developer gpio interrupt handelers.
-  inline static IsrPointer interrupthandlers[kNumberOfInterruptPorts]
-                                            [kNumberOfPins];
+  inline static InterruptCallback interrupt_handlers[kNumberOfInterruptPorts]
+                                                    [kNumberOfPins];
 
   /// This structure makes the access of gpio interrupt registers more readable
   struct GpioInterruptRegisterMap_t
@@ -129,16 +131,16 @@ class Gpio final : public sjsu::Gpio
   }
 
   /// Assigns the developer's ISR function to the port/pin gpio instance.
-  void SetInterruptRoutine(IsrPointer function) const
+  void SetInterruptRoutine(InterruptCallback callback) const
   {
     ValidPortCheck();
-    interrupthandlers[interupt_port_][pin_.GetPin()] = function;
+    interrupt_handlers[interupt_port_][pin_.GetPin()] = callback;
   }
 
   /// Clears the developers ISR function from the port/pin gio instance.
   void ClearInterruptRoutine() const
   {
-    interrupthandlers[interupt_port_][pin_.GetPin()] = nullptr;
+    interrupt_handlers[interupt_port_][pin_.GetPin()] = nullptr;
   }
 
   /// Sets the selected edge that the gpio interrupt will be triggered on.
@@ -207,11 +209,11 @@ class Gpio final : public sjsu::Gpio
 
   /// Assign the developer's ISR and sets the selected edge that the gpio
   /// interrupt will be triggered on.
-  void AttachInterrupt(IsrPointer function, Edge edge) override
+  void AttachInterrupt(InterruptCallback callback, Edge edge) override
   {
     EnableInterrupts();
     ValidPortCheck();
-    SetInterruptRoutine(function);
+    SetInterruptRoutine(callback);
     SetInterruptEdge(edge);
   }
 
@@ -242,14 +244,14 @@ class Gpio final : public sjsu::Gpio
     interrupt_controller_.Deregister(GPIO_IRQn);
   }
 
-  /// The gpio internal ISR that calls the developer's ISR's.
+  /// The gpio interrupt handler that calls the attached interrupt callbacks.
   static void InterruptHandler()
   {
     int triggered_port = (*port_status >> 2);
     int triggered_pin =
         __builtin_ctz(*interrupt[triggered_port].rising_edge_status |
                       *interrupt[triggered_port].falling_edge_status);
-    interrupthandlers[triggered_port][triggered_pin]();
+    interrupt_handlers[triggered_port][triggered_pin]();
     *interrupt[triggered_port].clear |= (1 << triggered_pin);
   }
 

--- a/library/L1_Peripheral/lpc40xx/i2c.hpp
+++ b/library/L1_Peripheral/lpc40xx/i2c.hpp
@@ -92,7 +92,7 @@ class I2c final : public sjsu::I2c
     /// Reference to partial bus, used as template parameter.
     const PartialBus_t & bus;
     /// Contains a pointer to the I2C Handler object.
-    IsrPointer handler;
+    InterruptHandler handler;
   };
   /// Template I2cHandler that passes a PartialBus_t reference to the actual I2C
   /// handler via template parameter.

--- a/library/L1_Peripheral/lpc40xx/pin.hpp
+++ b/library/L1_Peripheral/lpc40xx/pin.hpp
@@ -53,7 +53,7 @@ class Pin final : public sjsu::Pin
   /// Bitmask for enabling/disabling digital to analog pin mode.
   static constexpr bit::Mask kDacEnable = bit::CreateMaskFromRange(16);
   /// Pin map table for maping pins and ports to registers.
-  struct [[gnu::packed]] PinMap_t
+  struct PinMap_t
   {
     /// Register matrix that maps against the 6 ports and the 32 pins per port
     volatile uint32_t register_matrix[6][32];

--- a/library/L1_Peripheral/pulse_capture.hpp
+++ b/library/L1_Peripheral/pulse_capture.hpp
@@ -22,7 +22,7 @@ class PulseCapture
   };
 
   /// Interrupt callback that passes capture status information
-  using CaptureIsr = void (*)(PulseCapture::CaptureStatus_t);
+  using CaptureCallback = std::function<void(PulseCapture::CaptureStatus_t)>;
 
   /// Define which edges to capture input on
   enum class CaptureEdgeMode : uint8_t
@@ -34,7 +34,7 @@ class PulseCapture
   };
 
   /// Initialize timer for capturing
-  virtual Status Initialize(CaptureIsr isr             = nullptr,
+  virtual Status Initialize(CaptureCallback isr        = nullptr,
                             int32_t interrupt_priority = -1) const = 0;
 
   /// Select edge type to capture on

--- a/library/L1_Peripheral/system_timer.hpp
+++ b/library/L1_Peripheral/system_timer.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 
 #include "L1_Peripheral/interrupt.hpp"
 #include "utility/status.hpp"
@@ -21,11 +22,11 @@ class SystemTimer
   // ==============================
   /// Initialize system timer hardware.
   virtual void Initialize() const = 0;
-  /// Set the interrupt handler for the system timer
+  /// Set the function to be called when the System Timer interrupt fires.
   ///
-  /// @param isr - interrupt service routine
-  virtual void SetInterrupt(IsrPointer isr) const = 0;
-  /// Set frequency of the timer
+  /// @param callback - function to be called on system timer event.
+  virtual void SetCallback(InterruptCallback callback) const = 0;
+  /// Set frequency of the timer.
   ///
   /// @param frequency - How many times per second should the system timer
   ///         interrupt be called.

--- a/library/L1_Peripheral/timer.hpp
+++ b/library/L1_Peripheral/timer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 
 #include "L1_Peripheral/interrupt.hpp"
 #include "utility/status.hpp"
@@ -38,13 +39,13 @@ class Timer
   /// @param counter_frequency - the frequency that the timer's count register
   ///        will increment by. If this is set to 1'000'000Hz then the counter
   ///        will increment every microsecond. register will be 10 ms.
-  /// @param isr - the ISR that will fire when the condition set by SetTimer
-  ///        method is achieved.
+  /// @param callback - a callback that will be called when the condition set by
+  ///        SetTimer method has occurred.
   /// @param priority - sets the Timer interrupt's priority level, defaults to
   ///        -1 which uses the platforms default priority.
   virtual Status Initialize(units::frequency::hertz_t counter_frequency,
-                            IsrPointer isr   = nullptr,
-                            int32_t priority = -1) const = 0;
+                            InterruptCallback callback = nullptr,
+                            int32_t priority                   = -1) const = 0;
   /// Set a timer to execute your timer command when the time counter equals the
   /// match register. time in ticks dependent on initialization Functionality is
   /// defined by mode: interrupt, stop, or reset on match.

--- a/library/L2_HAL/io/parallel_bus/parallel_gpio.hpp
+++ b/library/L2_HAL/io/parallel_bus/parallel_gpio.hpp
@@ -22,24 +22,6 @@ class ParallelGpio : public sjsu::ParallelBus
       : io_(array), kWidth(width)
   {
   }
-  /// Constructor of ParallelGpio that takes a std::initializer_list of
-  /// sjsu::Gpio pointers. This simplifies the usage of parallel bus and helps
-  /// to eliminate mistakes where the array size is not correct.
-  ///
-  /// Example Usage:
-  ///
-  ///    ParallelGpio parallel_gpio({
-  ///        gpio_led0,
-  ///        gpio_led1,
-  ///        gpio_led2,
-  ///        gpio_led3,
-  ///    });
-  ///
-  /// @param array - std::initializer_list of sjsu::Gpio pointers.
-  explicit ParallelGpio(const std::initializer_list<sjsu::Gpio *> & array)
-      : io_(array.begin()), kWidth(array.size())
-  {
-  }
   void Initialize() override
   {
     bool parallel_gpio_bus_initialized_successfully = true;

--- a/library/L2_HAL/sensors/movement/accelerometer/mma8452q.hpp
+++ b/library/L2_HAL/sensors/movement/accelerometer/mma8452q.hpp
@@ -58,7 +58,7 @@ class Mma8452q : public Accelerometer
                         sizeof(tilt_val));
     tilt_reading = (tilt_val[0] << kMsbShift) | tilt_val[1];
     axis_tilt    = static_cast<int16_t>(tilt_reading);
-    return axis_tilt / kDataOffset;
+    return static_cast<int16_t>(axis_tilt / kDataOffset);
   }
   int16_t X() const override
   {

--- a/tools/presubmit.sh
+++ b/tools/presubmit.sh
@@ -74,7 +74,7 @@ cd "$SJBASE/projects/starter"
 # Clean the build and start building from scratch
 SILENCE=$(make clean)
 # Check if the system can build without any warnings!
-SILENCE=$(make -s application)
+SILENCE=$(make -s application WARNINGS_ARE_ERRORS=-Werror)
 # Set build capture to return code from the build
 SPECIFIC_BUILD_CAPTURE=$?
 BUILD_CAPTURE=$(($BUILD_CAPTURE + $SPECIFIC_BUILD_CAPTURE))
@@ -87,7 +87,7 @@ cd "$SJBASE/projects/barebones"
 # Clean the build and start building from scratch
 SILENCE=$(make clean)
 # Check if the system can build without any warnings!
-SILENCE=$(make -s application)
+SILENCE=$(make -s application WARNINGS_ARE_ERRORS=-Werror)
 # Set build capture to return code from the build
 SPECIFIC_BUILD_CAPTURE=$?
 BUILD_CAPTURE=$(($BUILD_CAPTURE + $SPECIFIC_BUILD_CAPTURE))


### PR DESCRIPTION
Split usage of IsrPointer into two different categories of interrupt
callables.

For actual interrupts that get put into the IVT, such as an interrupt
service routine, they will be named `InterruptHandler`.
For calling a callable objects from within an interrupt service routine,
these will be called `InterruptCallback`.

`InterruptHanlder` is defined as a function pointer of void(*)(void),
where as `InterruptCallback` a std::function<void(void)>, which allows
the usage of function pointers as well as capturing lambdas, bindings
to class methods, and usage of functors.

Caveats to this is that the <functional> header increases compile time
and occupies 32 bytes of space per object, which is 4x the size of a
pointer.

Resolves #952