### PR TITLE
Add GpioCounter, a HardwareCounter implementation

### DIFF
--- a/demos/sjtwo/gpio_hardware_counter/makefile
+++ b/demos/sjtwo/gpio_hardware_counter/makefile
@@ -1,0 +1,15 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjtwo/gpio_hardware_counter/project.mk
+++ b/demos/sjtwo/gpio_hardware_counter/project.mk
@@ -1,0 +1,2 @@
+USER_TESTS += $(LIBRARY_DIR)/L1_Peripheral/test/hardware_counter_test.cpp
+PLATFORM = lpc40xx

--- a/demos/sjtwo/gpio_hardware_counter/source/main.cpp
+++ b/demos/sjtwo/gpio_hardware_counter/source/main.cpp
@@ -1,0 +1,41 @@
+#include "L1_Peripheral/lpc40xx/gpio.hpp"
+#include "L1_Peripheral/hardware_counter.hpp"
+#include "utility/time.hpp"
+#include "utility/log.hpp"
+
+int main()
+{
+  // Create a GPIO to read from. This can be any GPIO that supports GPIO
+  // interrupts. On the LPC40xx, that would be pins on port 0 and port 2.
+  //
+  // Feel free to change this to some other gpio port and pin number.
+  sjsu::lpc40xx::Gpio gpio(0, 0);
+  // Pass the GPIO above into the gpio counter to be controlled by it.
+  // The second parameter allows you to change which event triggers a count.
+  // In this case, we want to trigger on rising and falling edges of the pin.
+  // Note that this
+  sjsu::GpioCounter counter(gpio, sjsu::Gpio::Edge::kEdgeBoth);
+  // Required: Initialize the hardware.
+  counter.Initialize();
+  // Required: Enable the counter.
+  counter.Enable();
+
+  uint32_t previous_count = 0;
+  while (true)
+  {
+    uint32_t current_count = counter.GetCount();
+    // Anytime the count changes, we print out the latest count.
+    if (previous_count != current_count)
+    {
+      LOG_INFO("Hardare Count %" PRIu32 "\n", current_count);
+      previous_count = current_count;
+    }
+    // This throttles how often we print as well as demonstrates that the
+    // counter still counts even when the processor is stuck in a busy loop.
+    // This is due to the fact that sjsu::HardwareCounters must be able to work
+    // in a asynchronous manner, such as utilizing interrupts, internal
+    // peripheral counters, or external counters.
+    sjsu::Delay(1s);
+  }
+  return 0;
+}

--- a/library/L1_Peripheral/L1.mk
+++ b/library/L1_Peripheral/L1.mk
@@ -4,3 +4,4 @@ include $(LIBRARY_DIR)/L1_Peripheral/lpc17xx/L1_lpc17xx.mk
 include $(LIBRARY_DIR)/L1_Peripheral/lpc40xx/L1_lpc40xx.mk
 
 TESTS += $(LIBRARY_DIR)/L1_Peripheral/test/interrupt_test.cpp
+TESTS += $(LIBRARY_DIR)/L1_Peripheral/test/hardware_counter_test.cpp

--- a/library/L1_Peripheral/hardware_counter.hpp
+++ b/library/L1_Peripheral/hardware_counter.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include "L1_Peripheral/gpio.hpp"
 
 namespace sjsu
 {
@@ -26,5 +27,60 @@ class HardwareCounter
   virtual void Disable() = 0;
   /// Get the current count from hardware timer.
   virtual uint32_t GetCount() = 0;
+  /// Default virtual destructor
+  virtual ~HardwareCounter() = default;
+};
+
+/// A class that utilizes a generic sjsu::Gpio implementation to implement
+/// a hardware
+class GpioCounter : public HardwareCounter
+{
+ public:
+  /// @param gpio - Reference to a gpio object
+  /// @param edge - The digital signal edge to count up on.
+  /// @param pull - Set the pull resistor for the pin, when the pin is not
+  ///        connected.
+  GpioCounter(sjsu::Gpio & gpio,
+              sjsu::Gpio::Edge edge,
+              sjsu::Pin::Resistor pull = sjsu::Pin::Resistor::kPullUp)
+      : gpio_(gpio), edge_(edge), pull_(pull)
+  {
+  }
+  void Initialize() override
+  {
+    gpio_.GetPin().SetPull(pull_);
+    gpio_.SetAsInput();
+  }
+  void Set(uint32_t new_count_value) override
+  {
+    count_ = new_count_value;
+  }
+  void Enable() override
+  {
+    gpio_.AttachInterrupt([this] { count_++; }, edge_);
+  }
+  /// Stops counting from clock input. Current count is retained.
+  void Disable() override
+  {
+    gpio_.DetachInterrupt();
+  }
+  /// Get the current count from hardware timer.
+  uint32_t GetCount() override
+  {
+    return count_;
+  }
+  /// Destructor of this object will detach the interrupt from the GPIO. This is
+  /// to keep the gpio interrupt service routine from calling this objects
+  /// callback when this object has been destroyed.
+  ~GpioCounter()
+  {
+    gpio_.DetachInterrupt();
+  }
+
+ private:
+  sjsu::Gpio & gpio_;
+  sjsu::Gpio::Edge edge_;
+  sjsu::Pin::Resistor pull_;
+  uint32_t count_ = 0;
 };
 }  // namespace sjsu

--- a/library/L1_Peripheral/test/hardware_counter_test.cpp
+++ b/library/L1_Peripheral/test/hardware_counter_test.cpp
@@ -1,0 +1,35 @@
+#include "L1_Peripheral/hardware_counter.hpp"
+#include "L4_Testing/testing_frameworks.hpp"
+
+namespace sjsu
+{
+// Helps with test coverage. Every object should be wrapped in the
+// EMIT_ALL_METHODS macro.
+EMIT_ALL_METHODS(GpioCounter);
+
+TEST_CASE("Testing L1 GpioCounter", "[gpio-counter]")
+{
+  Mock<sjsu::Pin> mock_pin;
+  Fake(Method(mock_pin, SetPull));
+
+  // Create mocked versions of the sjsu::Pin
+  Mock<sjsu::Gpio> mock_gpio;
+  Fake(Method(mock_gpio, SetDirection));
+  Fake(Method(mock_gpio, AttachInterrupt));
+  Fake(Method(mock_gpio, DetachInterrupt));
+  When(Method(mock_gpio, GetPin)).AlwaysReturn(mock_pin.get());
+
+  SECTION("Initialize() with rising edge and default pull up resistor")
+  {
+    // Setup
+    GpioCounter test_subject(mock_gpio.get(), sjsu::Gpio::Edge::kEdgeBoth);
+    // Execute
+    test_subject.Initialize();
+    // Verify
+    Verify(Method(mock_gpio, SetDirection)
+               .Using(sjsu::Gpio::Direction::kInput));
+    Verify(Method(mock_pin, SetPull)
+               .Using(sjsu::Pin::Resistor::kPullUp));
+  }
+}
+}  // namespace sjsu


### PR DESCRIPTION
GpioCounter implements HardwareCounter by utilizing the gpio interrupt
functionality of that class. On each interrupt event, the counter is
incremented.

Resolves #955