### PR TITLE
Adding Tsop752 Infrared Receiver

### DIFF
--- a/demos/sjone/ir_receiver/makefile
+++ b/demos/sjone/ir_receiver/makefile
@@ -1,0 +1,15 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/demos/sjone/ir_receiver/project.mk
+++ b/demos/sjone/ir_receiver/project.mk
@@ -1,0 +1,2 @@
+USER_TESTS += $(LIBRARY_DIR)/L2_HAL/communication/test/tsop752_test.cpp
+PLATFORM = lpc17xx

--- a/demos/sjone/ir_receiver/project_config.hpp
+++ b/demos/sjone/ir_receiver/project_config.hpp
@@ -1,0 +1,10 @@
+// This file overrides the default configuration options in the
+// library/config.hpp file. Open library/config.hpp to see which configuration
+// options you can change.
+#pragma once
+
+#include "log_levels.hpp"
+
+// #define SJ2_LOG_LEVEL SJ2_LOG_LEVEL_DEBUG
+
+#include "config.hpp"

--- a/demos/sjone/ir_receiver/source/main.cpp
+++ b/demos/sjone/ir_receiver/source/main.cpp
@@ -1,0 +1,82 @@
+#include "L1_Peripheral/lpc17xx/system_controller.hpp"
+#include "L1_Peripheral/lpc17xx/pulse_capture.hpp"
+#include "L1_Peripheral/lpc17xx/timer.hpp"
+#include "L2_HAL/communication/tsop752.hpp"
+#include "utility/infrared_algorithms.hpp"
+#include "utility/log.hpp"
+
+enum RemoteCode : uint16_t
+{
+  kPower           = 0x0A5F,
+  kVolumeUp        = 0x32CD,
+  kVolumeDown      = 0xB24D,
+  kToggleBluetooth = 0x40BF,
+};
+/// @see https://www.sbprojects.net/knowledge/ir/nec.php
+constexpr sjsu::infrared::PulseDurationConfiguration_t kNecConfiguration = {
+  .header_mark_duration  = 9000us,
+  .header_space_duration = 4500us,
+  .data_duration         = 560us,
+  .logic_high_duration   = 1690us,
+  .logic_low_duration    = 560us,
+  .encoding_type         = sjsu::infrared::PulseDurationType::kDistance,
+  .tolerance             = 0.25f,  // value may vary based on device latency
+  .uses_repeat_frames    = true,
+  .header_repeat_space   = 2250us,
+};
+
+void HandleDataFrame(const sjsu::infrared::DataFrame_t * data_frame)
+{
+  // Attempt to decode the received frame using the NEC protocol.
+  const sjsu::infrared::DecodedFrame_t kDecodedFrame =
+      sjsu::infrared::Decode(data_frame, kNecConfiguration);
+  // Do nothing if the frame is invalid or the command is from another remote
+  if (!kDecodedFrame.is_valid)
+  {
+    return;
+  }
+  // Check whether a repeat frame was decoded. A repeat frame after the initial
+  // frame is continuously sent while a button is held down.
+  if (kDecodedFrame.is_repeat)
+  {
+    LOG_INFO("Button is held down repeating previous action.");
+  }
+  else
+  {
+    constexpr auto kCommandMask = sjsu::bit::CreateMaskFromRange(0, 15);
+    const uint16_t kCommand     = static_cast<uint16_t>(
+        sjsu::bit::Extract(kDecodedFrame.data, kCommandMask));
+    switch (kCommand)
+    {
+      case RemoteCode::kPower: LOG_INFO("Power Button Pressed"); break;
+      case RemoteCode::kVolumeUp: LOG_INFO("Increasing Volume"); break;
+      case RemoteCode::kVolumeDown: LOG_INFO("Decreasing Volume"); break;
+      case RemoteCode::kToggleBluetooth:
+        LOG_INFO("Toggling Bluetooth Mode");
+        break;
+      default: LOG_INFO("Button Pressed"); break;
+    }
+  }
+}
+
+int main()
+{
+  LOG_INFO("Starting Tsop752 IR Receiver Example...");
+  // Using timeout of 9ms since the header mark of the NEC remote is 9ms long.
+  constexpr std::chrono::microseconds kTimeout               = 9ms;
+  constexpr units::frequency::hertz_t kPulseCaptureFrequency = 1_MHz;
+
+  sjsu::lpc17xx::PulseCapture pulse_capture(
+      sjsu::lpc17xx::PulseCaptureChannel::kCaptureTimer1,
+      sjsu::lpc17xx::PulseCapture::CaptureChannelNumber::kChannel0,
+      kPulseCaptureFrequency);
+  sjsu::lpc17xx::Timer timer(sjsu::lpc17xx::TimerPeripheral::kTimer2);
+
+  sjsu::Tsop752 ir_receiver(pulse_capture, timer, kTimeout);
+  ir_receiver.SetInterruptCallback(HandleDataFrame);
+  SJ2_ASSERT_FATAL(ir_receiver.Initialize() == sjsu::Status::kSuccess,
+                   "Failed to initialize Tsop752.");
+
+  sjsu::Halt();
+  return 0;
+}

--- a/demos/sjtwo/timer/source/main.cpp
+++ b/demos/sjtwo/timer/source/main.cpp
@@ -47,6 +47,11 @@ int main()
   timer3.SetMatchBehavior(10'000'000,
                           sjsu::Timer::MatchAction::kInterruptRestart);
 
+  timer0.Start();
+  timer1.Start();
+  timer2.Start();
+  timer3.Start();
+
   sjsu::Halt();
   return 0;
 }

--- a/documentation/design_docs/L2/infrared_receiver_interface.md
+++ b/documentation/design_docs/L2/infrared_receiver_interface.md
@@ -18,8 +18,27 @@ Interface
 
 # Background
 Infrared (IR) receivers typically use a photo-diode to convert IR light into an
-electrical signal that can be processed by a micro-controller. One of the common
-applications of infrared communication is remote control systems.
+electrical signal that can be processed by a micro-controller. Common
+applications include continuous data communication and consumer remote control
+systems.
+
+IrDA is the standard used for continuous data transmission applications;
+however, the receiver/transceiver device must be IrDA compatible. The standard
+mode for IrDA, serial Infrared (SIR), allows serial data to be transmitted or
+received through standard UART.
+
+For consumer IR remote applications, commonly used data formats include:
+1. Bi-phase Encoding (ie.
+   [RC-5](https://www.sbprojects.net/knowledge/ir/rc5.php),
+   [RC-6](https://www.sbprojects.net/knowledge/ir/rc6.php))
+2. Pulse Distance Encoding (ie.
+   [NEC](https://www.sbprojects.net/knowledge/ir/nec.php))
+3. Pulse Length Encoding (ie.
+   [SIRC](https://www.sbprojects.net/knowledge/ir/sirc.php))
+
+More information regarding these three data formats can be found
+[here](https://www.vishay.com/docs/80071/dataform.pdf). Additionally
+[LIRC](http://www.lirc.org/) contains a large database of remote control codes.
 
 # Overview
 The `InfraredReceiver` interface should be inherited by communication drivers
@@ -33,16 +52,9 @@ namespace sjsu
 class InfraredReceiver
 {
  public:
-  struct DataFrame_t
-  {
-    inline static constexpr uint32_t kMaxPulseBufferSize = 100;
-    uint32_t pulse_buffer[kMaxPulseBufferSize];
-    uint32_t number_of_pulses;
-  };
+  using DataReceivedHandler = std::function<void(const DataFrame_t *)>;
 
-  using DataReceivedHandler = std::function<void(DataFrame_t *)>;
-
-  virtual Status Initialize()                                   const = 0;
+  virtual Status Initialize()                                    const = 0;
   virtual void SetInterruptCallback(DataReceivedHandler handler) const = 0;
 };
 }

--- a/documentation/design_docs/L2/tsop752.md
+++ b/documentation/design_docs/L2/tsop752.md
@@ -7,8 +7,8 @@
 - [Overview](#overview)
 - [Detailed Design](#detailed-design)
   - [API](#api)
-    - [Initialization](#initialization)
-    - [Capturing The De-modulated IR signal](#capturing-the-de-modulated-ir-signal)
+  - [Initialization](#initialization)
+  - [Capturing and Handling the De-modulated IR signal](#capturing-and-handling-the-de-modulated-ir-signal)
 - [Caveats](#caveats)
 - [Future Advancements](#future-advancements)
 - [Testing Plan](#testing-plan)
@@ -31,19 +31,14 @@ The device data-sheet can be found
 
 # Overview
 The Tsop752 outputs IR data frames which consist of a de-modulated pulse train.
-The `Capture` module is used to capture incoming pulses of each frame from the
-device. When a rising and/or falling edge of a signal is detected, a timestamp
-in milliseconds is recorded. The logic level of data in the received frame is
-determined by examining the period of each pulse.
+The `PulseCapture` module is used to capture incoming pulses of each frame from
+the device. When a rising or falling edge of a signal is detected, a timestamp
+in microseconds is recorded. The logic levels of the data in the received frame
+is determined by examining the period of each pulse.
 
 In addition to the capture module, the `Timer` module will be utilized to
 determine the end of transmission frame when no consecutive pulse is received
 within a timeout period after the last received pulse.
-
-For consumer IR applications, such as IR remote control systems, two of the
-commonly used IR transmission protocols include RC-5 and NEC. An example of a
-typical IR transmission frame conforming to the NEC protocol can be found
-[here](https://techdocs.altium.com/sites/default/files/wiki_attachments/296329/NECMessageFrame.png).
 
 # Detailed Design
 ## API
@@ -53,82 +48,107 @@ namespace sjsu
 class Tsop752 final : public InfraredReceiver
 {
  public:
-  constexpr explicit Tsop752(sjsu::Capture & capture,
-                             sjsu::Timer & timer);
+  explicit Tsop752(sjsu::PulseCapture & capture,
+                   sjsu::Timer & timer,
+                   std::chrono::microseconds timeout);
 
-  Status Initialize() const override;
-  void SetInterruptCallback(DataReceivedHandler handler) const override;
+  Status Initialize() override;
+  void SetInterruptCallback(DataReceivedHandler handler) override;
+  void HandlePulseCaptured(PulseCapture::CaptureStatus_t status);
+  void HandleEndOfFrame();
 
  private:
-  static void HandlePulseCaptured();
-  static void HandleEndOfDataFrame();
-
-  inline static DataFrame_t data_frame;
-  inline static DataReceivedHandler interrupt_handler;
-
-  const sjsu::Capture & capture_;
+  const sjsu::PulseCapture & capture_;
   const sjsu::Timer & timer_;
+  const std::chrono::microseconds kTimeout;
+  DataFrame_t data_frame_;
+  bool is_start_of_new_frame_;
+  uint32_t last_received_timestamp_;
+  DataReceivedHandler user_callback_ = nullptr;
 };
 }  // namespace sjsu
 ```
 
-### Initialization
+## Initialization
 ```C++
-constexpr explicit Tsop752(sjsu::Capture & capture,
-                           sjsu::Timer & timer)
-
 Status Initialize() const override
 ```
 The following sequence is performed to initialize the driver:
-1. Initialize and configure `capture_`.
+1. Initialize and configure `capture_`. If the peripheral fails to initialize,
+   the failure status shall be returned.
 2. Initialize and configure `timer_`.
 3. Return `Status::kSuccess` if both drivers are initialize successfully,
    Otherwise return the failure `Status`.
 
-### Capturing The De-modulated IR signal
+## Capturing and Handling the De-modulated IR signal
 ```C++
 void SetInterruptCallback(DataReceivedHandler handler) const override
 ```
-`SetInterruptCallback` sets the `interrupt_handler` that is invoked when a data
+`SetInterruptCallback` sets the `user_callback_` that is invoked when a data
 frame is successfully received.
 
 ```C++
-static void HandlePulseCaptured()
+void HandlePulseCaptured(PulseCapture::CaptureStatus_t status)
 ```
 The capture module is configured to increment at 1MHz (1µs).
-The `HandlePulseCaptured` is invoked when a pulse edge is detected and the
+`HandlePulseCaptured` is invoked when a pulse edge is detected and the
 value of Capture Register, CRn, will serve as a timestamp for when the edge was
-detected. The timestamp is appended to the `pulse_buffer` of `data_frame`.
-Additionally, upon capturing a pulse edge, the timer is reset.
+detected. The duration of the pulse is determined by calculating the difference
+of the previously received timestamp and the current timestamp. Additionally,
+upon capturing a pulse edge, the timer is reset and restarted.
 
 ```C++
-static void HandleEndOfDataFrame()
+void HandleEndOfDataFrame()
 ```
-The `HandleEndOfDataFrame` is invoked when the timeout period of the time is
-reached after receiving after a pulse edge is received. This signifies the end
-of the transmission frame. The `interrupt_handler` is invoked to allow the user
-to process the received data.
+`HandleEndOfDataFrame` is invoked when one of the following conditions is met:
+1. The timeout period of the timer is reached after receiving a pulse edge.
+2. The data_frame's `pulse_buffer_length` reaches the `kMaxPulseBufferSize`.
+
+This signifies the end of the transmission frame and the `user_callback_` is
+invoked to allow the received data frame to be further processed.
 
 # Caveats
-N/A
+For the LPC17xx and LPC40xx series MCU, the `PulseCapture` and `Timer`
+peripherals must not share the same channels. Each channel for both peripherals
+share the same NVIC. Due to the implementation of both peripherals, initializing
+the peripherals with the same channel will cause the interrupt callback to be
+overwritten. For example, suppose `PulseCapture` and `Timer` are initialized
+using the same channel with interrupts enabled. If the `Timer` was last to be
+initialized, only the interrupt callbacks of the `Timer` peripheral will be
+invoked.
 
 # Future Advancements
 N/A
 
 # Testing Plan
 ## Unit Testing Scheme
-The `Capture` and `Timer` modules shall be mocked and stubbed to provide test
-inputs for the `Tsop752` driver.
+The `PulseCapture` and `Timer` modules shall be mocked and stubbed to provide
+test inputs for the `Tsop752` driver.
 
 The following functions shall be tested:
-- `Initialize`
-  - Should return the failure `Status` when `Initialize` of either `Capture`
-    or `Timer` are stubbed to not return `Status::kSuccess`.
-  - Should return `Status::kSuccess` when `Initialize` of both `Capture` and
-    `Timer` are stubbed to return `Status::kSuccess`.
+1. `Initialize()`
+   - Should return the failure `Status` when `Initialize` of `PulseCapture` is
+     stubbed to return a `Status` that is not `Status::kSuccess`.
+   - Should return the failure `Status` when `Initialize` of`Timer` is stubbed
+     to return a `Status` that is not `Status::kSuccess`.
+   - Should return `Status::kSuccess` when `Initialize` of both `Capture` and
+     `Timer` are stubbed to return `Status::kSuccess`.
+2. `HandlePulseCaptured()`
+   - Test input timestamps: `{ 0, 9'000, 13'500, 14'060, 15'750, 16'310 }` shall
+     be used.
+   - At each iteration, the method should:
+     - Invoke the `Reset` and `Start` methods of `Timer` once.
+3. `HandleEndOfFrame()`
+   - Test input timestamps: `{ 0, 9'000, 13'500, 14'060, 15'750, 16'310 }` shall
+     be used.
+   - The method should:
+     - Invoke the `Stop` method of `Timer` once.
+     - Invoke the mocked user callback.
+       - The resulting pulse buffer should be equivalent to
+         `{ 9'000, 4'500, 560, 1'690, 560 }`
+       - The data frame's `pulse_buffer_length` should be `5`.
 
 ## Demonstration Project
-A remote control utilizing the NEC will be used to transmit IR signals. The
-program shall use a interrupt handler function that is invoked when a button on
-the remote is pressed. The handler function shall decode the received data frame
-and output the received IR code.
+A demonstration project using the LPC17xx platform to receive remote control
+signals from a NEC remote can be found
+[here](/demos/sjone/ir_receiver/source/main.cpp).

--- a/library/L1_Peripheral/inactive.hpp
+++ b/library/L1_Peripheral/inactive.hpp
@@ -292,6 +292,9 @@ inline sjsu::Timer & GetInactive<sjsu::Timer>()
     {
       return 3;
     }
+    void Start() const override {}
+    void Stop() const override {}
+    void Reset() const override {}
   };
 
   static InactiveTimer inactive;

--- a/library/L1_Peripheral/timer.hpp
+++ b/library/L1_Peripheral/timer.hpp
@@ -63,5 +63,11 @@ class Timer
   virtual uint8_t GetAvailableMatchRegisters() const = 0;
   /// Get the current count in the count register
   virtual uint32_t GetCount() const = 0;
+  /// Starts the timer.
+  virtual void Start() const = 0;
+  /// Stops the timer.
+  virtual void Stop() const  = 0;
+  /// Resets the timer.
+  virtual void Reset() const = 0;
 };
 }  // namespace sjsu

--- a/library/L2_HAL/L2.mk
+++ b/library/L2_HAL/L2.mk
@@ -15,6 +15,7 @@ TESTS += $(LIBRARY_DIR)/L2_HAL/audio/test/buzzer_test.cpp
 # Communication
 # ==============================================================================
 TESTS += $(LIBRARY_DIR)/L2_HAL/communication/test/esp8266_test.cpp
+TESTS += $(LIBRARY_DIR)/L2_HAL/communication/test/tsop752_test.cpp
 # ==============================================================================
 # Displays
 # ==============================================================================

--- a/library/L2_HAL/communication/infrared_receiver.hpp
+++ b/library/L2_HAL/communication/infrared_receiver.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <functional>
+
+#include "utility/infrared_algorithms.hpp"
+#include "utility/status.hpp"
+
+namespace sjsu
+{
+/// An abstract interface for communication drivers responsible for receiving
+/// infrared (IR) data.
+class InfraredReceiver
+{
+ public:
+  /// Callback handler that is invoked when a complete data frame is
+  /// successfully received.
+  using DataReceivedHandler =
+      std::function<void(const infrared::DataFrame_t *)>;
+  /// Initialize and enable hardware. This must be called before any other
+  /// method in this interface is called.
+  virtual Status Initialize() = 0;
+  /// Sets the callback handler that is invoked when a data frame is received.
+  ///
+  /// @param handler Callback handler to invoke.
+  virtual void SetInterruptCallback(DataReceivedHandler handler) = 0;
+};
+}  // namespace sjsu

--- a/library/L2_HAL/communication/test/tsop752_test.cpp
+++ b/library/L2_HAL/communication/test/tsop752_test.cpp
@@ -1,0 +1,154 @@
+#include <array>
+
+#include "L2_HAL/communication/tsop752.hpp"
+#include "L4_Testing/testing_frameworks.hpp"
+
+namespace sjsu
+{
+EMIT_ALL_METHODS(Tsop752);
+
+TEST_CASE("Tsop752 Infrared Receiver Test", "[tsop752]")
+{
+  Mock<PulseCapture> mock_pulse_capture;
+  Mock<Timer> mock_timer;
+
+  Fake(Method(mock_pulse_capture, ConfigureCapture),
+       Method(mock_pulse_capture, EnableCaptureInterrupt));
+  Fake(Method(mock_timer, SetMatchBehavior),
+       Method(mock_timer, Start),
+       Method(mock_timer, Stop),
+       Method(mock_timer, Reset));
+
+  const std::array kFailureStatus = {
+    Status::kTimedOut,          Status::kBusError,
+    Status::kDeviceNotFound,    Status::kInvalidSettings,
+    Status::kNotImplemented,    Status::kNotReadyYet,
+    Status::kInvalidParameters,
+  };
+  constexpr std::chrono::microseconds kTimeout = 5ms;
+
+  Tsop752 ir_receiver(mock_pulse_capture.get(), mock_timer.get(), kTimeout);
+
+  SECTION("Initialize")
+  {
+    SECTION("PulseCapture peripheral initialization failure")
+    {
+      mock_timer.ClearInvocationHistory();
+      When(Method(mock_timer, Initialize)).AlwaysReturn(Status::kSuccess);
+      for (size_t i = 0; i < kFailureStatus.size(); i++)
+      {
+        INFO(
+            "Testing pulse capture initialization failure with failure status: "
+            << i);
+        const Status kExpectedStatus = kFailureStatus[i];
+        mock_pulse_capture.ClearInvocationHistory();
+        When(Method(mock_pulse_capture, Initialize))
+            .AlwaysReturn(kExpectedStatus);
+        // Upon failing to initialize the pulse capture peripheral, the failure
+        // Status should be immediately returned.
+        CHECK(ir_receiver.Initialize() == kExpectedStatus);
+        Verify(Method(mock_pulse_capture, Initialize)).Once();
+        VerifyNoOtherInvocations(mock_pulse_capture, mock_timer);
+      }
+    }
+    SECTION("Timer peripheral initialization failure")
+    {
+      When(Method(mock_pulse_capture, Initialize))
+          .AlwaysReturn(Status::kSuccess);
+
+      for (size_t i = 0; i < kFailureStatus.size(); i++)
+      {
+        INFO("Testing timer initialization failure with failure status: " << i);
+        const Status kExpectedStatus = kFailureStatus[i];
+        mock_pulse_capture.ClearInvocationHistory();
+        mock_timer.ClearInvocationHistory();
+        When(Method(mock_timer, Initialize)).AlwaysReturn(kExpectedStatus);
+
+        CHECK(ir_receiver.Initialize() == kExpectedStatus);
+        Verify(Method(mock_pulse_capture, Initialize),
+               Method(mock_pulse_capture, ConfigureCapture),
+               Method(mock_pulse_capture, EnableCaptureInterrupt),
+               Method(mock_timer, Initialize),
+               Method(mock_timer, SetMatchBehavior))
+            .Once();
+      }
+    }
+    SECTION("Both peripherals initialization success")
+    {
+      constexpr Status kExpectedStatus              = Status::kSuccess;
+      constexpr uint32_t kExpectedTimerMatchCount   = kTimeout.count();
+      constexpr uint8_t kExpectedTimerMatchRegister = 0;
+
+      mock_pulse_capture.ClearInvocationHistory();
+      mock_timer.ClearInvocationHistory();
+      When(Method(mock_pulse_capture, Initialize))
+          .AlwaysReturn(kExpectedStatus);
+      When(Method(mock_timer, Initialize)).AlwaysReturn(kExpectedStatus);
+
+      CHECK(ir_receiver.Initialize() == kExpectedStatus);
+      Verify(Method(mock_pulse_capture, Initialize)).Once();
+      Verify(Method(mock_pulse_capture, ConfigureCapture)
+                 .Using(sjsu::PulseCapture::CaptureEdgeMode::kBoth),
+             Method(mock_pulse_capture, EnableCaptureInterrupt).Using(true))
+          .Once();
+      Verify(Method(mock_timer, Initialize),
+             Method(mock_timer, SetMatchBehavior)
+                 .Using(kExpectedTimerMatchCount,
+                        sjsu::Timer::MatchAction::kInterrupt,
+                        kExpectedTimerMatchRegister))
+          .Once();
+    }
+  }
+
+  SECTION("Interrupt Callbacks")
+  {
+    constexpr std::array<uint32_t, 6> kTestTimestamps = {
+      0, 9'000, 13'500, 14'060, 15'750, 16'310
+    };
+    constexpr std::array<uint16_t, 5> kExpectedPulses = {
+      9'000, 4'500, 560, 1'690, 560
+    };
+    constexpr uint32_t kPulseCaptureFlags = 0x0;
+
+    SECTION("Handle pulse captured")
+    {
+      for (size_t i = 0; i < kTestTimestamps.size(); i++)
+      {
+        mock_timer.ClearInvocationHistory();
+        ir_receiver.HandlePulseCaptured({
+            .count = kTestTimestamps[i],
+            .flags = kPulseCaptureFlags,
+        });
+        Verify(Method(mock_timer, Reset), Method(mock_timer, Start)).Once();
+      }
+    }
+    SECTION("Handle end of frame")
+    {
+      bool user_callback_invoked = false;
+      InfraredReceiver::DataReceivedHandler mock_user_callback =
+          [&](auto data_frame) {
+            user_callback_invoked = true;
+            for (size_t i = 0; i < kExpectedPulses.size(); i++)
+            {
+              INFO("Handling end of frame pulse edge index " << i);
+              CHECK(data_frame->pulse_buffer[i] == kExpectedPulses[i]);
+            }
+            CHECK(data_frame->pulse_buffer_length == kExpectedPulses.size());
+          };
+
+      for (size_t i = 0; i < kTestTimestamps.size(); i++)
+      {
+        ir_receiver.HandlePulseCaptured({
+            .count = kTestTimestamps[i],
+            .flags = kPulseCaptureFlags,
+        });
+      }
+      ir_receiver.SetInterruptCallback(mock_user_callback);
+      ir_receiver.HandleEndOfFrame();
+
+      Verify(Method(mock_timer, Stop)).Once();
+      CHECK(user_callback_invoked);
+    }
+  }
+}
+}  // namespace sjsu

--- a/library/L2_HAL/communication/tsop752.hpp
+++ b/library/L2_HAL/communication/tsop752.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include "L1_Peripheral/pulse_capture.hpp"
+#include "L1_Peripheral/timer.hpp"
+#include "L2_HAL/communication/infrared_receiver.hpp"
+#include "utility/status.hpp"
+#include "utility/units.hpp"
+
+namespace sjsu
+{
+/// Tsop752 Infrared (IR) Receiver is a device optimized for remote control
+/// applications with carrier frequencies ranging from 30kHz to 56kHz.The driver
+/// uses pulse capture to receive incoming IR remote control signals.
+class Tsop752 final : public InfraredReceiver
+{
+ public:
+  /// @param capture Pulse capture peripheral used to capture the de-modulated
+  ///                signal frame.
+  /// @param timer   Timer peripheral used to detect then end of the data frame.
+  /// @param timeout Timeout time with microsecond precision.
+  explicit Tsop752(sjsu::PulseCapture & capture,
+                   sjsu::Timer & timer,
+                   std::chrono::microseconds timeout)
+      : capture_(capture),
+        timer_(timer),
+        kTimeout(timeout),
+        data_frame_({ {}, 0 }),
+        is_start_of_new_frame_(true),
+        last_received_timestamp_(0)
+  {
+  }
+  /// Initializes the PulseCapture and Timer peripherals.
+  ///
+  /// @return The initialization status. Returns Status::kSuccess if the driver
+  ///         has been successfully initialized.
+  Status Initialize() override
+  {
+    Status status = capture_.Initialize(
+        [this](auto capture_status) { HandlePulseCaptured(capture_status); });
+    if (status != Status::kSuccess)
+    {
+      return status;
+    }
+    capture_.ConfigureCapture(sjsu::PulseCapture::CaptureEdgeMode::kBoth);
+    capture_.EnableCaptureInterrupt(true);
+
+    constexpr uint8_t kTimerMatchRegister = 0;
+    // using 1 MHz for 1µs precision (1 / 1'000'000 Hz = 1µs)
+    constexpr units::frequency::hertz_t kFrequency = 1_MHz;
+
+    status = timer_.Initialize(kFrequency, [this]() { HandleEndOfFrame(); });
+    timer_.SetMatchBehavior(static_cast<uint32_t>(kTimeout.count()),
+                            sjsu::Timer::MatchAction::kInterrupt,
+                            kTimerMatchRegister);
+    return status;
+  }
+  /// @param handler User callback handler to invoke when a frame is received.
+  void SetInterruptCallback(DataReceivedHandler handler) override
+  {
+    user_callback_ = handler;
+  }
+  /// Invoked when a pulse is captured.
+  ///
+  /// Example timing diagram:
+  ///                           __     __    __
+  ///   Remote Control:      __|  |___|  |__|  |___
+  ///                        __    ___    __    ___
+  ///   IR Receiver Output:    |__|   |__|  |__|
+  ///   pulse_buffer_length: 0 1  2   3  4  5  6
+  ///
+  /// @param status Status of the interrupt.
+  void HandlePulseCaptured(PulseCapture::CaptureStatus_t status)
+  {
+    timer_.Reset();
+    if (is_start_of_new_frame_)
+    {
+      is_start_of_new_frame_ = false;
+    }
+    else
+    {
+      data_frame_.pulse_buffer[data_frame_.pulse_buffer_length++] =
+          static_cast<uint16_t>(status.count - last_received_timestamp_);
+    }
+    last_received_timestamp_ = status.count;
+    timer_.Start();
+
+    if (data_frame_.pulse_buffer_length ==
+        infrared::DataFrame_t::kMaxPulseBufferSize)
+    {
+      HandleEndOfFrame();
+    }
+  }
+  /// Invoked when a data frame is currently being received and no new pulse
+  /// edge is captured after a timeout period, signifying the end of the data
+  /// frame.
+  void HandleEndOfFrame()
+  {
+    timer_.Stop();
+    if (user_callback_ != nullptr)
+    {
+      user_callback_(&data_frame_);
+    }
+    data_frame_.pulse_buffer_length = 0;
+    is_start_of_new_frame_          = true;
+  }
+
+ private:
+  /// Pulse capture peripheral used to capture incoming pulse edges.
+  const sjsu::PulseCapture & capture_;
+  /// Timer peripheral for keeping track of the timeout period in between
+  /// captured pulses.
+  const sjsu::Timer & timer_;
+  /// Timeout period used determine if the end of a frame is reached.
+  const std::chrono::microseconds kTimeout;
+  /// Data frame containing an array of timestamps for captured pulse edges.
+  infrared::DataFrame_t data_frame_;
+  /// True if captured pulse is the first edge of a new frame.
+  bool is_start_of_new_frame_;
+  /// The timestamp of the most recent captured pulse edge.
+  uint32_t last_received_timestamp_;
+  /// The callback that is invoked when a data frame is received.
+  DataReceivedHandler user_callback_ = nullptr;
+};
+}  // namespace sjsu

--- a/library/utility/infrared_algorithms.hpp
+++ b/library/utility/infrared_algorithms.hpp
@@ -1,0 +1,260 @@
+#pragma once
+
+#include <cstdint>
+
+#include "utility/bit.hpp"
+#include "utility/log.hpp"
+#include "utility/units.hpp"
+
+namespace sjsu
+{
+namespace infrared
+{
+// ==============================
+// Infrared Data Frame Structures
+// ==============================
+
+/// A structure containing the timestamps for the received de-modulated infrared
+/// data frame.
+struct DataFrame_t
+{
+  /// Maximum size of the pulse_buffer. A value of 67 is chosen since formats
+  /// using pulse duration modulation consists of a header (2 pulses), up to 32
+  /// bits of data (64 pulses), and a stop pulse.
+  inline static constexpr size_t kMaxPulseBufferSize = 67;
+  /// Buffer containing the pulse edge timestamps.
+  uint16_t pulse_buffer[kMaxPulseBufferSize];
+  /// Current number of timestamps of pulse edges stored in pulse_buffer.
+  size_t pulse_buffer_length;
+};
+/// A structure containing a decoded infrared data frame.
+struct DecodedFrame_t
+{
+  /// The decoded data. This value is set to kRepeatCode to signify a repeat
+  /// command is detected when decoding.
+  uint32_t data;
+  /// True if the frame was successfully decoded.
+  bool is_valid;
+  /// True if the decoded frame is a repeat frame.
+  bool is_repeat;
+};
+
+// ==============================
+// Helper Methods for Decoding
+// ==============================
+
+/// Helper function to check if a duration is within an acceptable tolerance.
+///
+/// @param duration The duration value to check.
+/// @param expected_duration The expected duration to check against.
+/// @param tolerance The acceptable tolerance percentage.
+/// @return True if the specified duration is within tolerance of the expected
+///         duration.
+inline bool IsDurationWithinTolerance(
+    uint16_t duration,
+    std::chrono::microseconds expected_duration,
+    float tolerance)
+{
+  // Calculate the acceptable minimum and maximum ranges:
+  // min = expected_duration * (100% - tolerance)
+  // max = expected_duration * (100% + tolerance)
+  uint16_t min = static_cast<uint16_t>(
+      static_cast<float>(expected_duration.count()) * (1.0f - tolerance));
+  uint16_t max = static_cast<uint16_t>(
+      static_cast<float>(expected_duration.count()) * (1.0f + tolerance));
+  return (min <= duration) && (duration <= max);
+}
+
+// ==================================
+// Pulse Duration Modulation Decoding
+// ==================================
+
+/// Pulse Duration Modulation uses either the "mark" or "space" to determine
+/// logic levels of a data bit.
+///
+///  _____________________                       ___________
+/// |                     |                     |
+/// ^                     v                     ^
+/// |                     |_____________________|
+///
+/// |<------ mark ------->|<------ space ------>|
+enum class PulseDurationType
+{
+  kLength,    // The mark is used to determine the logic level
+  kDistance,  // The space is used to determine the logic level
+};
+/// A structure containing the configuration settings for infrared data formats
+/// that utilize pulse duration modulation.
+///
+/// @note The tolerance value is important for verifying a captured pulse
+///       duration because the captured duration will not be the exact value of
+///       the specified duration configurations due to varying latency.
+struct PulseDurationConfiguration_t
+{
+  /// The expected duration of the header mark.
+  std::chrono::microseconds header_mark_duration;
+  /// The expected duration of the header space.
+  std::chrono::microseconds header_space_duration;
+  /// The expected fixed duration for a data pulse based on the specified
+  /// encoding_type.
+  std::chrono::microseconds data_duration;
+  /// The expected duration to recognize a data pulse as a logical high.
+  std::chrono::microseconds logic_high_duration;
+  /// The expected duration to recognize a data pulse as a logical low.
+  std::chrono::microseconds logic_low_duration;
+  /// The pulse duration encoding type.
+  PulseDurationType encoding_type;
+  /// The acceptable tolerance level in percentage of each of the duration
+  /// configurations. For example, a value of 0.25f means ±25%.
+  float tolerance;
+  /// True if the encoding uses a repeat frame. That is after the initial frame,
+  /// a repeat code is continuously received when a button is held down. For
+  /// most protocols this can be determined by the different duration in the
+  /// header space.
+  bool uses_repeat_frames = false;
+  /// This optional value should be set if repeat frames with a different header
+  /// space is used.
+  std::chrono::microseconds header_repeat_space = 0us;
+};
+/// Generic decoding function to decode data frames that is encoded using pulse
+/// duration modulation.
+///
+/// @note This function can detect repeat frames for most protocols that uses a
+///       repeat frame such as NEC and Samsung by checking the different header
+///       space. However, for the JVC protocol only the initial frame can be
+///       decoded since the header is removed during the consecutive repeat
+///       frames.
+///
+/// @param data_frame The desired data frame to decode.
+/// @param configurations The pulse duration encoding configuration used for
+///                       decoding the frame.
+/// @return The decoded frame. If the frame was invalid, the is_valid flag will
+///         be false. A frame can be invalid if it is corrupt or an invalid
+///         configuration is used for decoding.
+inline const DecodedFrame_t Decode(
+    const DataFrame_t * data_frame,
+    const PulseDurationConfiguration_t & configurations)
+{
+  static constexpr DecodedFrame_t kInvalidFrame = {
+    .data      = 0,
+    .is_valid  = false,
+    .is_repeat = false,
+  };
+  // Minimum number of pulses to prevent array out of bounds.
+  // Additionally, if the encoding protocol uses repeats sequences, there needs
+  // to be 3 pulses which consists of a header mark, header space, and a stop
+  // mark.
+  constexpr uint8_t kMinimumPulseCount = 3;
+  if (data_frame->pulse_buffer_length < kMinimumPulseCount)
+  {
+    LOG_DEBUG("Invalid frame too short");
+    return kInvalidFrame;
+  }
+  // Validate the frame's header by checking the first two pulses
+  const uint16_t kHeaderMark  = data_frame->pulse_buffer[0];
+  const uint16_t kHeaderSpace = data_frame->pulse_buffer[1];
+  LOG_DEBUG("%d %d", kHeaderMark, kHeaderSpace);
+  const bool kHeaderMarkIsValid =
+      IsDurationWithinTolerance(kHeaderMark,
+                                configurations.header_mark_duration,
+                                configurations.tolerance);
+  if (!kHeaderMarkIsValid)
+  {
+    LOG_DEBUG("Invalid header mark: %d", kHeaderMark);
+    return kInvalidFrame;
+  }
+  // If the encoding utilizes a repeat frame, check for the repeat duration in
+  // the header space before verifying it with the default
+  // header_space_duration. This is because the header space is different in a
+  // repeat sequence.
+  if ((data_frame->pulse_buffer_length == kMinimumPulseCount) &&
+      configurations.uses_repeat_frames)
+  {
+    const uint16_t kStopMark = data_frame->pulse_buffer[2];
+    const bool kRepeatSpaceValid =
+        IsDurationWithinTolerance(kHeaderSpace,
+                                  configurations.header_repeat_space,
+                                  configurations.tolerance);
+    const bool kStopMarkValid = IsDurationWithinTolerance(
+        kStopMark, configurations.data_duration, configurations.tolerance);
+    if (kRepeatSpaceValid && kStopMarkValid)
+    {
+      return DecodedFrame_t({
+          .data      = 0,
+          .is_valid  = true,
+          .is_repeat = true,
+      });
+    }
+  }
+  const bool kHeaderSpaceIsValid =
+      IsDurationWithinTolerance(kHeaderSpace,
+                                configurations.header_space_duration,
+                                configurations.tolerance);
+  if (!kHeaderSpaceIsValid)
+  {
+    LOG_DEBUG("Invalid header space: %d", kHeaderSpace);
+    return kInvalidFrame;
+  }
+  // Set all bits to be logically low and only set to high if needed during
+  // decoding.
+  uint32_t decoded_data = 0;
+  // Start decoding the data pulses from the first data pulse edge and stop at
+  // the last post (the stop pulse)
+  //
+  // The following is performed based on the modulation type:
+  //   Pulse Distance Modulation:
+  //     1. Verify the fixed mark duration.
+  //     2. Verify the space for the logic level and validity.
+  //   Pulse Length Modulation:
+  //     1. Verify the fixed space duration.
+  //     2. Verify the mark for the logic level and validity.
+  for (size_t i = 2; i < data_frame->pulse_buffer_length - 1; i += 2)
+  {
+    const uint16_t kDataMark  = data_frame->pulse_buffer[i];
+    const uint16_t kDataSpace = data_frame->pulse_buffer[i + 1];
+    LOG_DEBUG("%d %d", kDataMark, kDataSpace);
+
+    uint16_t fixed_data_duration;
+    uint16_t duration_for_logic_level;
+    switch (configurations.encoding_type)
+    {
+      case PulseDurationType::kDistance:
+        fixed_data_duration      = kDataMark;
+        duration_for_logic_level = kDataSpace;
+        break;
+      case PulseDurationType::kLength:
+        fixed_data_duration      = kDataSpace;
+        duration_for_logic_level = kDataMark;
+        break;
+    }
+
+    if (!IsDurationWithinTolerance(fixed_data_duration,
+                                   configurations.data_duration,
+                                   configurations.tolerance))
+    {
+      return kInvalidFrame;
+    }
+
+    decoded_data <<= 1;
+    if (IsDurationWithinTolerance(duration_for_logic_level,
+                                  configurations.logic_high_duration,
+                                  configurations.tolerance))
+    {
+      decoded_data = sjsu::bit::Set(decoded_data, 0);
+    }
+    else if (!IsDurationWithinTolerance(duration_for_logic_level,
+                                        configurations.logic_low_duration,
+                                        configurations.tolerance))
+    {
+      return kInvalidFrame;
+    }
+    // else do nothing, this pulse is valid but the bit is a logical low
+  }
+  return DecodedFrame_t({
+      .data      = decoded_data,
+      .is_valid  = true,
+      .is_repeat = false,
+  });
+}
+}  // namespace infrared
+}  // namespace sjsu


### PR DESCRIPTION
- Added InfraredReceiver interface.
- Added example project for the Tsop752 using the SJOne.
- Added Start(), Stop(), and Reset() to Timer.
- Changed Initialize() in lpc40xx::Timer to not automatically enable the timer
  peripheral during initialization. This allows more flexibility in controlling
  when the timer can be started.
- Updated Interface Receiver Interface and Tsop752 design docs.

Resolves: #534
Resolves: #597