### PR TITLE
Stopwatch Upgrade supports time output

### DIFF
--- a/demos/multiplatform/delay/source/main.cpp
+++ b/demos/multiplatform/delay/source/main.cpp
@@ -1,5 +1,6 @@
-#include <inttypes.h>
+#include <cinttypes>
 #include <cstdint>
+
 #include "utility/log.hpp"
 #include "utility/time.hpp"
 

--- a/demos/multiplatform/stopwatch/makefile
+++ b/demos/multiplatform/stopwatch/makefile
@@ -1,0 +1,15 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/demos/multiplatform/stopwatch/project.mk
+++ b/demos/multiplatform/stopwatch/project.mk
@@ -1,0 +1,1 @@
+USER_TESTS += $(LIBRARY_DIR)/utility/test/stopwatch_test.cpp

--- a/demos/multiplatform/stopwatch/source/main.cpp
+++ b/demos/multiplatform/stopwatch/source/main.cpp
@@ -1,0 +1,44 @@
+#include <cinttypes>
+#include <cstdint>
+
+#include "utility/log.hpp"
+#include "utility/stopwatch.hpp"
+
+int main()
+{
+  LOG_INFO("Stopwatch Application Starting...");
+  sjsu::StopWatch stopwatch;
+  LOG_INFO("Calibrating stop watch...");
+  stopwatch.Calibrate();
+  LOG_INFO("Uptime() call time = %" PRId32 ".",
+           static_cast<int32_t>(stopwatch.GetCalibrationDelta().count()));
+
+  LOG_INFO("Calibration figures out how much time it takes to call Uptime()");
+  LOG_INFO("This time can differ depending on the platform.");
+
+  while (true)
+  {
+    // Setup
+    LOG_INFO(
+        "Starting timer and executing code that will take time perform...");
+    stopwatch.Start();
+
+    // Exercise
+    printf(
+        "Payload message! This typically requires communication via JTAG or "
+        "UART to perform!\n");
+    sjsu::Delay(200ms);
+
+    // Record the time it took to run the printf command and stream the data to
+    // stdout.
+    auto time_delta = stopwatch.Stop();
+
+    // Displaying to the user the amount of time it took.
+    LOG_INFO("Printing the message above took = %" PRId32 " us",
+             static_cast<int32_t>(time_delta.count()));
+
+    sjsu::Delay(1s);
+  }
+
+  return 0;
+}

--- a/library/L1_Peripheral/cortex/dwt_counter.hpp
+++ b/library/L1_Peripheral/cortex/dwt_counter.hpp
@@ -24,6 +24,7 @@ class DwtCounter
     dwt->CYCCNT = 0;
     dwt->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
   }
+
   /// Return the current number of ticks. Note that this is typically 2x the
   /// system frequency as it counts on rising and falling edges.
   uint32_t GetCount()

--- a/library/L4_Testing/testing_frameworks.hpp
+++ b/library/L4_Testing/testing_frameworks.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#define CATCH_CONFIG_ENABLE_CHRONO_STRINGMAKER
+
 #include "third_party/catch2/catch.hpp"
 #include "third_party/fakeit/fakeit.hpp"
 #include "third_party/fff/fff.h"

--- a/library/utility/ansi_terminal_codes.hpp
+++ b/library/utility/ansi_terminal_codes.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "config.hpp"
 
 #if defined(SJ2_ENABLE_ANSI_CODES) && SJ2_ENABLE_ANSI_CODES == true

--- a/library/utility/test/stopwatch_test.cpp
+++ b/library/utility/test/stopwatch_test.cpp
@@ -3,99 +3,81 @@
 
 #include "L4_Testing/testing_frameworks.hpp"
 #include "utility/stopwatch.hpp"
+#include "utility/log.hpp"
 
 namespace sjsu
 {
-// Blank namespace: Within scope of this file,
-// anything inside this file cannot see this scope
-// so same variable names within the namespaces won't conflict
-namespace
-{
-// 1. Global setup
-FAKE_VALUE_FUNC(uint32_t, tick);
-FAKE_VALUE_FUNC(uint32_t, calibrate_tick);
-
-uint32_t calibration_result = 0;
-uint32_t CalibrateTicksHandler()
-{
-  calibration_result += 100;
-  return calibration_result;
-}
-}  // namespace
-
 TEST_CASE("Testing StopWatch Utilities", "[stopwatch]")
 {
-  // 2. Defining expected
-  StopWatch test_sw(tick);
-
-  SECTION("CurrentTicks")
+  SECTION("Calibrate")
   {
-    // 2. Defining expected
-    constexpr uint32_t kExpected0 = 123;
-    constexpr uint32_t kExpected1 = 12'000'231;
+    // Setup
+    StopWatch test_subject;
 
-    // 3. Setup
-    // Minimize human error when typing numbers
-    tick_fake.return_val = kExpected0;
-    CHECK(kExpected0 == test_sw.CurrentTicks());
+    // Exercise
+    test_subject.Calibrate();
 
-    tick_fake.return_val = kExpected1;
-    CHECK(kExpected1 == test_sw.CurrentTicks());
-
-    // Template specialize, return maximum value at compile time
-    tick_fake.return_val = std::numeric_limits<uint32_t>::max();
-    CHECK(std::numeric_limits<uint32_t>::max() == test_sw.CurrentTicks());
+    // Verify
+    CHECK(1us == test_subject.GetCalibrationDelta());
   }
 
   SECTION("Start and Stop")
   {
-    constexpr uint32_t kStartTicks0    = 0;
-    constexpr uint32_t kStopTicks0     = 200;
-    constexpr uint32_t kExpectedDelta0 = kStopTicks0 - kStartTicks0;
+    // Setup
+    StopWatch test_subject;
+    test_subject.Calibrate();
 
-    tick_fake.return_val = kStartTicks0;
-    test_sw.Start();
-    tick_fake.return_val    = kStopTicks0;
-    uint32_t actual_delta_0 = test_sw.Stop();
-    CHECK(kExpectedDelta0 == actual_delta_0);
+    constexpr std::chrono::microseconds kDelay[] = {
+      200us, 1215us, 1124us, 65513us, 10us, 5us, 0xDEADBEEFus
+    };
+    constexpr std::chrono::microseconds kAfterDelay[] = {
+      111us, 451us, 972us, 248us, 463us, 1045us, 0us
+    };
 
-    constexpr uint32_t kStartTicks1    = 3'435;
-    constexpr uint32_t kStopTicks1     = 96'059'321;
-    constexpr uint32_t kExpectedDelta1 = kStopTicks1 - kStartTicks1;
+    // Exercise
+    test_subject.Start();
+    Delay(kDelay[0]);
+    auto actual_delta0 = test_subject.Stop();
+    Delay(kAfterDelay[0]);
 
-    tick_fake.return_val = kStartTicks1;
-    test_sw.Start();
-    tick_fake.return_val   = kStopTicks1;
-    uint32_t actual_delta1 = test_sw.Stop();
-    CHECK(kExpectedDelta1 == actual_delta1);
+    test_subject.Start();
+    Delay(kDelay[1]);
+    auto actual_delta1 = test_subject.Stop();
+    Delay(kAfterDelay[1]);
 
-    // Checks for edge case when ticks overflows
-    constexpr uint32_t kStartTicks2 =
-        std::numeric_limits<uint32_t>::max() - 200;
-    constexpr uint32_t kStopTicks2     = 300;
-    constexpr uint32_t kExpectedDelta2 = kStopTicks2 - kStartTicks2;
+    test_subject.Start();
+    Delay(kDelay[2]);
+    auto actual_delta2 = test_subject.Stop();
+    Delay(kAfterDelay[2]);
 
-    tick_fake.return_val = kStartTicks2;
-    test_sw.Start();
-    tick_fake.return_val   = kStopTicks2;
-    uint32_t actual_delta2 = test_sw.Stop();
-    CHECK(kExpectedDelta2 == actual_delta2);
-  }
+    test_subject.Start();
+    Delay(kDelay[3]);
+    auto actual_delta3 = test_subject.Stop();
+    Delay(kAfterDelay[3]);
 
-  SECTION("Calibrate")
-  {
-    constexpr uint32_t kExpectedDelta0         = 500;
-    constexpr uint32_t kAddToCalibrationResult = 500;
+    test_subject.Start();
+    Delay(kDelay[4]);
+    auto actual_delta4 = test_subject.Stop();
+    Delay(kAfterDelay[4]);
 
-    calibrate_tick_fake.custom_fake = CalibrateTicksHandler;
+    test_subject.Start();
+    Delay(kDelay[5]);
+    auto actual_delta5 = test_subject.Stop();
+    Delay(kAfterDelay[5]);
 
-    StopWatch test_calibrate_sw(calibrate_tick);
+    test_subject.Start();
+    Delay(kDelay[6]);
+    auto actual_delta6 = test_subject.Stop();
+    Delay(kAfterDelay[6]);
 
-    test_calibrate_sw.Calibrate();
-    test_calibrate_sw.Start();
-    calibration_result += kAddToCalibrationResult;
-    uint32_t actual_delta0 = test_calibrate_sw.Stop();
-    CHECK(actual_delta0 == kExpectedDelta0);
+    // Verify
+    CHECK(kDelay[0] == actual_delta0);
+    CHECK(kDelay[1] == actual_delta1);
+    CHECK(kDelay[2] == actual_delta2);
+    CHECK(kDelay[3] == actual_delta3);
+    CHECK(kDelay[4] == actual_delta4);
+    CHECK(kDelay[5] == actual_delta5);
+    CHECK(kDelay[6] == actual_delta6);
   }
 }
 }  // namespace sjsu

--- a/library/utility/test/time_test.cpp
+++ b/library/utility/test/time_test.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Testing Time Utility", "[time]")
     Delay(delay_time);
 
     // Verify
-    CHECK((current_timestamp + 2us + delay_time) == Uptime());
+    CHECK((current_timestamp + 1us + delay_time) == Uptime());
   }
 
   SECTION("Wait() with callback times out")
@@ -68,7 +68,7 @@ TEST_CASE("Testing Time Utility", "[time]")
 
     // Verify
     CHECK(wait_status == Status::kTimedOut);
-    CHECK((current_timestamp + 2us + timeout_time) == Uptime());
+    CHECK((current_timestamp + 1us + timeout_time) == Uptime());
   }
 
   SECTION("Wait() function times out")

--- a/tools/doxygen_ignore_list.txt
+++ b/tools/doxygen_ignore_list.txt
@@ -32,4 +32,3 @@ L4_Testing/factory_test.hpp
 utility/allocator.hpp
 utility/ansi_terminal_codes.hpp
 utility/math/average.hpp
-utility/stopwatch.hpp


### PR DESCRIPTION
- Refactored code to use Uptime()
- Stopwatch::Stop() now returns the time in microseconds
- Modifies util/time.hpp's Wait() method to work better in unit tests
- Modifies " Wait() method to return on <= rather than < to sharpen the
  accuracy of the function.
- Addes API documentation to StopWatch{}.

Resolves #850
Resolves #678
Resolves #677