### PR TITLE
Increase JTAG adapter speed to 4MHz

### DIFF
--- a/library/L0_Platform/example/example.cfg
+++ b/library/L0_Platform/example/example.cfg
@@ -21,7 +21,7 @@ source [find target/lpc40xx.cfg]
 
 # JTAG Clock rate in kHz (max for lpc40xx is 4Mhz)
 # lower this if you are getting glitches
-adapter_khz 400
+adapter_khz 4000
 
 $_TARGETNAME configure -event gdb-attach {
    halt

--- a/library/L0_Platform/lpc17xx/lpc17xx.cfg
+++ b/library/L0_Platform/lpc17xx/lpc17xx.cfg
@@ -3,7 +3,7 @@ source [find target/lpc17xx.cfg]
 
 # JTAG Clock rate in kHz
 # lower this if you are getting glitches
-adapter_khz 400
+adapter_khz 4000
 
 $_TARGETNAME configure -event gdb-attach {
    halt

--- a/library/L0_Platform/lpc40xx/lpc40xx.cfg
+++ b/library/L0_Platform/lpc40xx/lpc40xx.cfg
@@ -3,7 +3,7 @@ source [find target/lpc40xx.cfg]
 
 # JTAG Clock rate in kHz (max for lpc40xx is 4Mhz)
 # lower this if you are getting glitches
-adapter_khz 400
+adapter_khz 4000
 
 $_TARGETNAME configure -event gdb-attach {
    halt

--- a/library/L0_Platform/stm32f10x/stm32f10x.cfg
+++ b/library/L0_Platform/stm32f10x/stm32f10x.cfg
@@ -3,7 +3,7 @@ source [find target/stm32f1x.cfg]
 
 # JTAG Clock rate in kHz
 # lower this if you are getting glitches
-adapter_khz 400
+adapter_khz 4000
 
 $_TARGETNAME configure -event gdb-attach {
    halt


### PR DESCRIPTION
Makes debugging and flashing 10x as fast compared to the 400kHz we
were using before.