### PR TITLE
Fix break in STDIN in newlib

### DIFF
--- a/demos/multiplatform/stdin/source/main.cpp
+++ b/demos/multiplatform/stdin/source/main.cpp
@@ -1,19 +1,16 @@
-#include <inttypes.h>
 #include <cstdint>
+#include <array>
+
 #include "utility/log.hpp"
-#include "utility/time.hpp"
 
 int main()
 {
-  LOG_INFO("STDIN Application Starting...");
-
-  LOG_INFO(
-      "This project demonstrates the use of scanf with an embedded processor.");
+  LOG_INFO("STDIN Application Starting...\n");
 
   int number = 0;
   printf("Type in a number: ");
   scanf("%d", &number);
-  printf("The number you typed was %d\n", number);
+  printf("The number you typed was %d\n\n", number);
 
   LOG_INFO("End of program.");
   return 0;

--- a/library/newlib/newlib.cpp
+++ b/library/newlib/newlib.cpp
@@ -20,12 +20,14 @@ extern "C"
   {
     return 1;
   }
+
   // Dummy implementation of kill
   // NOLINTNEXTLINE(readability-identifier-naming)
   int _kill(int, int)
   {
     return -1;
   }
+
   // Dummy implementation of fstat, makes the assumption that the "device"
   // representing, in this case STDIN, STDOUT, and STDERR as character devices.
   // NOLINTNEXTLINE(readability-identifier-naming)
@@ -47,12 +49,14 @@ extern "C"
     heap_position += increment;
     return previous_heap_position;
   }
+
   // NOLINTNEXTLINE(readability-identifier-naming)
   int _write([[maybe_unused]] int file, const char * ptr, int length)
   {
     trace_write(ptr, length);
     return sjsu::newlib::out(ptr, length);
   }
+
   // NOLINTNEXTLINE(readability-identifier-naming)
   int _read(FILE * file, char * ptr, [[maybe_unused]] int length)
   {
@@ -82,35 +86,36 @@ extern "C"
   int puts(const char * str)  // NOLINT
   {
     int string_length = static_cast<int>(strlen(str));
-    int result           = 0;
+    int result        = 0;
     result += _write(0, str, string_length);
     result += _write(0, "\n", 1);
     // + 1 because puts adds an additional newline '\n' character.
     return result;
   }
 
-// Removing this from the build for now, as rdimon links these in on its own.
-#if 0
   // Dummy implementation of _lseek
   // NOLINTNEXTLINE(readability-identifier-naming)
-  int _lseek([[maybe_unused]] int file, [[maybe_unused]] int ptr,
-             [[maybe_unused]] int dir)
+  int _lseek_r([[maybe_unused]] int file,
+               [[maybe_unused]] int ptr,
+               [[maybe_unused]] int dir)
   {
     return 0;
   }
+
   // Dummy implementation of close
   // NOLINTNEXTLINE(readability-identifier-naming)
-  int _close([[maybe_unused]] int file)
+  int _close_r([[maybe_unused]] int file)
   {
     return -1;
   }
+
   // Dummy implementation of isatty
   // NOLINTNEXTLINE(readability-identifier-naming)
-  int _isatty([[maybe_unused]] int file)
+  int _isatty_r([[maybe_unused]] int file)
   {
     return 1;
   }
-#endif
+
   // Dummy implementation of exit with return code placed into
   // Arm register r3
   // NOLINTNEXTLINE(readability-identifier-naming)


### PR DESCRIPTION
Problems occured when _lseek, _close, _isatty were not defined within
newlib.cpp and where thus defined by rdimon, which would cause a
hardfault when debugger is not plugged in and the system attempts to
read from stdin.

Solution to this was to not define the above functions but to define
their reentrant variants. The reentrant variants which were not hard
defined by rdimon, but get called by rdimon's version of those functions.

Now stdin can be used without a debug port being plugged in.

Also cleanup on log_level_print demo.

Resolves #1037