### PR TITLE
Fixing dynamic allocation for LPC17xx

### DIFF
--- a/library/L0_Platform/lpc17xx/linker.ld
+++ b/library/L0_Platform/lpc17xx/linker.ld
@@ -1,39 +1,18 @@
 MEMORY
 {
-    /* Flash memory region for the program, offset by the bootloader section */
-    FLASH (rx) : ORIGIN = 0, LENGTH = 512K
-
-    /* 32K (Heap starts here) */
-    SRAM (rwx) : ORIGIN = 0x10000000, LENGTH = 32K
-
-    /* 32K (Globals at bottom, stack on top), heap continues from here */
-    SRAM_AHB (rwx) : ORIGIN = 0x2007c000, LENGTH = 32K
-
-    /* Heap starts at SRAM because if heap starts from higher memory, then
-     * malloc tracking routines get confused when sbrk() system function
-     * returns higher heap memory first, and then lower heap memory.
-     * So we start heap from SRAM, and then move it up to SRAM_AHB if SRAM
-     * portion runs out completely.
-     */
-
-     /* Symbol Table */
-     /*FLASH_SYMBOL_TABLE : ORIGIN = 0x1000, LENGTH = 32K*/
+  FLASH (rx) : ORIGIN = 0, LENGTH = 512K
+  SRAM (rwx) : ORIGIN = 0x10000000, LENGTH = 32K
+  SRAM_AHB (rwx) : ORIGIN = 0x2007c000, LENGTH = 32K
 }
 
-  /* Define a symbol for the top of each memory region */
-  __base_MFlash512 = 0x0  ; /* MFlash512 */
-  __base_Flash = 0x0 ; /* Flash */
-  __top_MFlash512 = 0x0 + 0x80000 ; /* 512K bytes */
-  __top_Flash = 0x0 + 0x80000 ; /* 512K bytes */
-  __base_RamLoc64 = 0x10000000  ; /* RamLoc64 */
-  __base_RAM = 0x10000000 ; /* RAM */
-  __top_RamLoc64 = 0x10000000 + 32K ; /* 64K bytes */
-  __top_RAM = 0x10000000 + 32K ; /* 64K bytes */
-  __base_RamPeriph32 = 0x2007c000  ; /* RamPeriph32 */
-  __base_RAM2 = 0x2007c000 ; /* RAM2 */
-  __top_RamPeriph32 = 0x2007c000 + 0x8000 ; /* 32K bytes */
-  __top_RAM2 = 0x2007c000 + 0x8000 ; /* 32K bytes */
-  __user_heap_base = __base_RAM2 ; /* SJSU-Dev2: RAM2 is solely for heap */
+/* Define a symbol for the top of each memory region */
+__base_Flash = 0x0 ;               /* Flash */
+__top_Flash = 0x0 + 0x80000 ;      /* 512K bytes */
+__base_RAM = 0x10000000 ;          /* RAM */
+__top_RAM = 0x10000000 + 32K ;     /* 32K bytes */
+__base_RAM2 = 0x2007c000 ;         /* RAM2 */
+__top_RAM2 = 0x2007c000 + 0x8000 ; /* 32K bytes */
+__user_heap_base = __base_RAM2 ;   /* SJSU-Dev2: RAM2 is solely for heap */
 
 /* Program entry point */
 ENTRY(ArmResetHandler)
@@ -61,7 +40,7 @@ SECTIONS
 		section_table_end = . ;
 		/* End of Global Section Table */
 
-        /* Functions that are placed after the interrupt vector */
+    /* Functions that are placed after the interrupt vector */
 		*(.after_vectors*)
 
 		*(.text*)
@@ -120,25 +99,13 @@ SECTIONS
 	} > FLASH
 	__exidx_end = .;
 
-/*
-	.debug : ALIGN(4)
-    {
-        *(.debug* *debug.*)
-    } > FLASH
-
-    .stabs : ALIGN(4)
-    {
-        *(.stabs* *stabs.*)
-    } > FLASH
-*/
-
 	_etext = .;
 
 	/* MAIN DATA SECTION */
 	.uninit_RESERVED : ALIGN(4)
 	{
 		KEEP(*(.bss.$RESERVED*))
-	} > SRAM_AHB
+	} > SRAM
 
 	.data : ALIGN(4)
 	{
@@ -148,7 +115,7 @@ SECTIONS
 		*(.data*)
 		. = ALIGN(4) ;
 		_edata = .;
-	} > SRAM_AHB AT>FLASH
+	} > SRAM AT>FLASH
 
 	/* MAIN BSS SECTION */
 	.bss : ALIGN(4)
@@ -159,23 +126,10 @@ SECTIONS
 		. = ALIGN(4) ;
 		_ebss = .;
 		PROVIDE(end = .);
-	} > SRAM_AHB
-
-	/*
-	.symbol_table : ALIGN(4)
-    {
-        __symbol_table_start = .;
-        KEEP(*(.symbol_table))
-        __symbol_table_end = .;
-    } > FLASH_SYMBOL_TABLE
-	*/
+	} > SRAM
 
 	/* Provide a symbol of the heap pointer to C/C++ code */
   PROVIDE(heap = DEFINED(__user_heap_base) ? __user_heap_base : .);
   PROVIDE(heap_end = __top_RAM2);
-
-	/* Provide the start of the initial stack pointer
-	 * Debugger and ISP may use 32-bytes of space?
-	 */
-	PROVIDE(StackTop = ORIGIN(SRAM_AHB) + LENGTH(SRAM_AHB) - 32);
+	PROVIDE(StackTop = DEFINED(__user_stack_top) ? __user_stack_top : __top_RAM);
 }


### PR DESCRIPTION
The .data and .bss sections was previously configured in SRAM_AHB and was
being overwritten by the start of the heap if dynamic allocation was used.

Also changed stack to grown downward from the top of SRAM instead of SRAM_AHB.