### PR TITLE
Esp8266 consistently working

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -397,6 +397,8 @@
         "SDRAM",
         "SDSC",
         "SDXC",
+        "CWSAP",
+        "CWLIF",
         "SHIFTR",
         "LLVM's",
         "SIRQ",

--- a/demos/sjtwo/esp8266/project.mk
+++ b/demos/sjtwo/esp8266/project.mk
@@ -1,3 +1,3 @@
-USER_TESTS += $(LIBRARY_DIR)/L1_Peripheral/lpc40xx/test/i2c_test.cpp
+USER_TESTS += $(LIBRARY_DIR)/utility/test/timeout_timer_test.cpp
 
 PLATFORM = lpc40xx

--- a/demos/sjtwo/esp8266/source/main.cpp
+++ b/demos/sjtwo/esp8266/source/main.cpp
@@ -7,18 +7,11 @@
 #include "utility/log.hpp"
 #include "utility/debug.hpp"
 
-constexpr char kGetRequestExample[] =
+constexpr std::string_view kHost = "www.example.com";
+constexpr std::string_view kGetRequestExample =
     "GET / HTTP/1.1\r\n"
-    "Host: www.example.com\r\n\r\n";
-
-#define LOG_IF_NOT_SUCCESSFUL(expression)                     \
-  {                                                           \
-    sjsu::Status log_no_success_status = (expression);        \
-    if (log_no_success_status != sjsu::Status::kSuccess)      \
-    {                                                         \
-      sjsu::LogWarning("Expression Failed: %s", #expression); \
-    }                                                         \
-  }
+    "Host: www.example.com\r\n"
+    "\r\n";
 
 int main()
 {
@@ -26,47 +19,41 @@ int main()
   sjsu::lpc40xx::Uart uart3(sjsu::lpc40xx::Uart::Port::kUart3);
   sjsu::Esp8266 wifi(uart3);
 
-  sjsu::LogInfo("Initializing Wifi...");
-  LOG_IF_NOT_SUCCESSFUL(wifi.Initialize());
+  sjsu::LogInfo("Initializing Esp8266 module...");
+  LOG_ON_FAILURE(wifi.Initialize());
 
   while (true)
   {
-    sjsu::LogInfo("Attempting to connect...");
-    auto status = wifi.ConnectToAccessPoint("KAMMCE-PHONE", "roverteam");
+    sjsu::LogInfo("Connecting to WiFi...");
+    auto status = wifi.ConnectToAccessPoint("wifi-ssid", "password");
     if (status == sjsu::Status::kSuccess)
     {
       break;
     }
-    sjsu::LogInfo("Failed to connect... Retrying ...");
+    sjsu::LogWarning("Failed to connect to WiFi... Retrying ...");
     wifi.DisconnectFromAccessPoint();
   }
 
-  sjsu::LogInfo("Connected to Wifi");
+  sjsu::LogInfo("Connected to WiFi!!");
 
-  for (int i = 0; i < 2; i++)
-  {
-    sjsu::LogInfo("Connecting to server...");
-    LOG_IF_NOT_SUCCESSFUL(wifi.Connect(
-        sjsu::InternetSocket::Protocol::kTCP, "www.example.com", 80, 5s));
+  sjsu::LogInfo("Connecting to server (%s)...", kHost.data());
+  LOG_ON_FAILURE(
+      wifi.Connect(sjsu::InternetSocket::Protocol::kTCP, kHost, 9000, 5s));
 
-    sjsu::LogInfo("Send Write Request...");
-    LOG_IF_NOT_SUCCESSFUL(
-        wifi.Write(kGetRequestExample, sizeof(kGetRequestExample), 100ms));
+  LOG_ON_FAILURE(
+      wifi.Write(kGetRequestExample.data(), kGetRequestExample.size(), 5s));
 
-    sjsu::LogInfo("Read Back Response...");
-    char response[1024 * 4] = {};
-    size_t read_back        = wifi.Read(response, sizeof(response), 10s);
+  std::array<char, 2048> response;
+  size_t read_back = 0;
+  read_back += wifi.Read(&response[read_back], response.size(), 10s);
+  read_back +=
+      wifi.Read(&response[read_back], response.size() - read_back, 10s);
 
-    sjsu::LogInfo("Hexdumping Response...");
-    sjsu::debug::Hexdump(response, read_back);
+  sjsu::LogInfo("Printing Server Response:");
+  printf("%.*s\n", read_back, response.data());
+  puts("===================================================================");
 
-    sjsu::LogInfo("Direct Print...");
-    printf("%.*s\r", read_back, response);
-
-    wifi.Close();
-    sjsu::Delay(5s);
-  }
-
+  wifi.Close();
   wifi.DisconnectFromAccessPoint();
 
   return 0;

--- a/library/L2_HAL/communication/internet_socket.hpp
+++ b/library/L2_HAL/communication/internet_socket.hpp
@@ -18,6 +18,7 @@ class InternetSocket
     kTCP,
     kUDP,
   };
+
   virtual Status Connect(Protocol protocol,
                          std::string_view address,
                          uint16_t port,
@@ -37,11 +38,26 @@ class WiFi
  public:
   struct NetworkConnection_t
   {
-    Status status;
+    Status status = Status::kNotImplemented;
     std::array<uint8_t, 4> ip;
     std::array<uint8_t, 4> netmask;
     std::array<uint8_t, 4> gateway;
     std::array<uint8_t, 6> mac;
+  };
+
+  enum class AccessPointSecurity
+  {
+    kOpen       = 0,
+    kWpaPsk     = 2,
+    kWpa2Psk    = 3,
+    kWpaWpa2Psk = 4,
+  };
+
+  enum class WifiMode
+  {
+    kClient = 1,
+    kAccessPoint,
+    kBoth,
   };
 
   virtual Status Initialize()                                           = 0;

--- a/library/utility/log.hpp
+++ b/library/utility/log.hpp
@@ -26,6 +26,7 @@
 #include "utility/debug.hpp"
 #include "utility/macros.hpp"
 #include "utility/time.hpp"
+#include "utility/status.hpp"
 
 namespace sjsu
 {
@@ -245,6 +246,17 @@ LogError(const char * format, Params...)->LogError<Params...>;
     {                                                                     \
       ::sjsu::LogWarning(warning_message SJ2_COLOR_RESET, ##__VA_ARGS__); \
     }                                                                     \
+  } while (0)
+
+/// Logs the expression if it returns any but Status::kSuccess
+#define LOG_ON_FAILURE(expression)                              \
+  do                                                            \
+  {                                                             \
+    sjsu::Status log_on_failure_status = (expression);          \
+    if (log_on_failure_status != sjsu::Status::kSuccess)        \
+    {                                                           \
+      ::sjsu::LogWarning("Expression Failed: %s", #expression); \
+    }                                                           \
   } while (0)
 
 /// When the condition is false, issue a critical level message to the user and

--- a/library/utility/test/timeout_timer_test.cpp
+++ b/library/utility/test/timeout_timer_test.cpp
@@ -1,0 +1,82 @@
+#include <cstdint>
+#include <limits>
+
+#include "L4_Testing/testing_frameworks.hpp"
+#include "utility/timeout_timer.hpp"
+
+namespace sjsu
+{
+TEST_CASE("Testing TimeoutTimer", "[timeout-timer]")
+{
+  // Setup
+  TimeoutTimer timer(1000us);
+  constexpr std::chrono::microseconds kDelayOffset = 1us;
+
+  SECTION("Does not expire")
+  {
+    // Exercise
+    Delay(500us - kDelayOffset);
+
+    // Verify
+    CHECK(500us == timer.GetTimeLeft());
+    CHECK(!timer.HasExpired());
+  }
+
+  SECTION("Expires")
+  {
+    // Exercise
+    Delay(1500us - kDelayOffset);
+
+    // Verify
+    CHECK(-500us == timer.GetTimeLeft());
+    CHECK(timer.HasExpired());
+  }
+
+  SECTION("Expires on the dot")
+  {
+    // Exercise
+    Delay(1000us - kDelayOffset);
+
+    // Verify
+    CHECK(0us == timer.GetTimeLeft());
+    CHECK(timer.HasExpired());
+  }
+
+  SECTION("Multiple delays")
+  {
+    // Exercise
+    Delay(250us - kDelayOffset);
+    auto time_left_0   = timer.GetTimeLeft();
+    auto has_expired_0 = timer.HasExpired();
+
+    Delay(250us - (kDelayOffset * 2));
+    auto time_left_1   = timer.GetTimeLeft();
+    auto has_expired_1 = timer.HasExpired();
+
+    Delay(250us - (kDelayOffset * 2));
+    auto time_left_2   = timer.GetTimeLeft();
+    auto has_expired_2 = timer.HasExpired();
+
+    Delay(250us - (kDelayOffset * 2));
+    auto time_left_3   = timer.GetTimeLeft();
+    auto has_expired_3 = timer.HasExpired();
+
+    Delay(250us - (kDelayOffset * 2));
+    auto time_left_4   = timer.GetTimeLeft();
+    auto has_expired_4 = timer.HasExpired();
+
+    // Verify
+    CHECK(750us == time_left_0);
+    CHECK(500us == time_left_1);
+    CHECK(250us == time_left_2);
+    CHECK(0us == time_left_3);
+    CHECK(-250us == time_left_4);
+
+    CHECK(!has_expired_0);
+    CHECK(!has_expired_1);
+    CHECK(!has_expired_2);
+    CHECK(has_expired_3);
+    CHECK(has_expired_4);
+  }
+}
+}  // namespace sjsu

--- a/library/utility/timeout_timer.hpp
+++ b/library/utility/timeout_timer.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "utility/time.hpp"
+#include "utility/units.hpp"
+
+namespace sjsu
+{
+/// TimeoutTimer is a utility that helps keep track of the amount of time left
+/// before a timeout occurs. This is useful when performing an operation that
+/// cannot exceed a certain amount of time, and apart of this operation is
+/// calling other functions or operations that take a timeout. The idea is to
+///
+/// Example Usage:
+///
+///   Status GetWaterLevel(std::chrono::nanoseconds timeout)
+///   {
+///     // Construct TimeoutTimer with the given timeout above. Lets assume it
+///     // is 1 second.
+///     TimeoutTimer timeout(timeout);
+///     // An example device that takes time to perform its operations.
+///     WaterLevelDevice water_level;
+///     // Reusable status variable
+///     Status status;
+///
+///     // In this case, we give the remaining time left for calibration
+///     // operation. Lets assume that the time is still around 1 second. The
+///     // `CalibrateSensor()` method now has 1s to perform its work.
+///     status = water_level.CalibrateSensor(timeout.GetTimeLeft());
+///     if (!IsOk(status))
+///     {
+///       return status;
+///     }
+///
+///     // Lets now assume that `CalibrateSensor()` took about 250ms to perform
+///     // its task. Now we pass 750ms to `MeasureWaterLevelWhenSteady()`.
+///     status = water_level.MeasureWaterLevelWhenSteady(timeout.GetTimeLeft());
+///     // If `MeasureWaterLevelWhenSteady()` reached the timeout of 750ms,
+///     // then we return with Status::kTimeout.
+///     // If we still have time left, and no other problems occurred, then
+///     // status will return Status::kSuccess.
+///     if (!IsOk(status))
+///     {
+///       return status;
+///     }
+///
+///     return Status::kSuccess;
+///   }
+///
+/// See L2_HAL/communication/esp8266.hpp for good examples of TimeoutTimer being
+/// used.
+class TimeoutTimer
+{
+ public:
+  /// @param timeout - the amount of time before this timer expires. For
+  /// example, if you set this to 1s, then this timer will timeout after 1s has
+  /// elapsed in real time.
+  explicit TimeoutTimer(std::chrono::nanoseconds timeout) : future_timeout_{ 0 }
+  {
+    SetNewTimeout(timeout);
+  }
+
+  /// Returns the amount of time left in the timer. The values will return
+  /// negative. If the timer has expired.
+  std::chrono::nanoseconds GetTimeLeft()
+  {
+    return future_timeout_ - Uptime();
+  }
+
+  /// Sets a new future deadline for the timer just like during the construction
+  /// of this object. Information about the previous timeout start time is
+  /// lost.
+  ///
+  /// @param new_timeout - the new timeout to set this timer to.
+  void SetNewTimeout(std::chrono::nanoseconds new_timeout)
+  {
+    future_timeout_ = Uptime() + new_timeout;
+  }
+
+  /// This is useful if you want to perform a loop or particular task where you
+  /// can continually check (poll) on this object to determine if the operation
+  /// has surpassed the alloted amount of time.
+  ///
+  /// @return true if there is no more time left in the timeout timer.
+  bool HasExpired()
+  {
+    return GetTimeLeft() < 0ns;
+  }
+
+ private:
+  std::chrono::nanoseconds future_timeout_;
+};
+}  // namespace sjsu

--- a/library/utility/utility.mk
+++ b/library/utility/utility.mk
@@ -16,6 +16,7 @@ TESTS += $(LIBRARY_DIR)/utility/test/rtos_test.cpp
 TESTS += $(LIBRARY_DIR)/utility/test/status_test.cpp
 TESTS += $(LIBRARY_DIR)/utility/test/stopwatch_test.cpp
 TESTS += $(LIBRARY_DIR)/utility/test/time_test.cpp
+TESTS += $(LIBRARY_DIR)/utility/test/timeout_timer_test.cpp
 TESTS += $(LIBRARY_DIR)/utility/math/test/average_test.cpp
 TESTS += $(LIBRARY_DIR)/utility/containers/test/string_test.cpp
 TESTS += $(LIBRARY_DIR)/utility/containers/test/vector_test.cpp


### PR DESCRIPTION
Methods using timeouts now expire properly.

Introducing the TimeoutTimer which takes a timeout and can return the
amount of time left since the TimeoutTimer's creation based on the
systems Uptime() function.

Read no longer waits for multiple +IPD packets. It will simply return
the results of the first +IPD packet it encounters. For HTTP requests,
"Content-Length" should be checked to see if further packets will need
to be read from the stream.