### PR TITLE
Migrate Logging from #define to C++

### DIFF
--- a/documentation/design_docs/utility/none.md
+++ b/documentation/design_docs/utility/none.md
@@ -1,1 +1,0 @@
-# Nothing yet!

--- a/library/utility/constexpr.hpp
+++ b/library/utility/constexpr.hpp
@@ -4,29 +4,6 @@
 
 namespace sjsu
 {
-/// Constructing this structure with a file path, will generate a structure with
-/// a character array containing just the bare basename.
-///
-/// @tparam kPathLength - length of the full string path
-/// @tparam kBasenameLength - length of the string basename.
-template <size_t kPathLength, size_t kBasenameLength>
-struct FileBasename_t
-{
-  /// Stores the contents of the basename into the char[] basename field.
-  constexpr explicit FileBasename_t(const char (&path)[kPathLength])
-      : basename{}
-  {
-    size_t base_position = 0;
-    for (size_t i = kPathLength - kBasenameLength; i < kPathLength; i++)
-    {
-      basename[base_position] = path[i];
-      base_position++;
-    }
-    basename[base_position - 1] = '\0';
-  }
-  /// Holds the path's basename string.
-  char basename[kBasenameLength];
-};
 /// @param str - a string to have its length computed.
 /// @return The length of the input string.
 constexpr size_t StringLength(const char * str)
@@ -38,6 +15,7 @@ constexpr size_t StringLength(const char * str)
   }
   return result + 1;
 }
+
 /// @param path - path to calculate the basename length for.
 /// @return the number of characters from the end of a string that contains the
 ///         basename.
@@ -53,5 +31,33 @@ constexpr size_t BasenameLength(const char * path)
     }
   }
   return forward_slash;
+}
+
+/// Returns a pointer to path's basename in the basename pointer.
+/// If one is not found then the whole path will be returned.
+/// Can only be used on string literals.
+///
+/// @tparam kPathLength - length of the full string path
+/// @param path - path to find the base name of.
+template <size_t kPathLength>
+constexpr const char * FileBasename(const char (&path)[kPathLength])
+{
+  const size_t kBasenameLength = BasenameLength(path);
+  const char * basename        = &path[kPathLength - (kBasenameLength - 1)];
+  return basename;
+}
+
+/// Returns a pointer to path's basename in the basename pointer.
+/// If one is not found then the whole path will be returned.
+/// This implementation, if used outside of a constexpr context will occur at
+/// runtime.
+///
+/// @param path - path to find the base name of.
+constexpr const char * FileBasename(const char * path)
+{
+  const size_t kBasenameLength = BasenameLength(path);
+  const size_t kPathLength     = StringLength(path);
+  const char * basename        = &path[kPathLength - (kBasenameLength - 1)];
+  return basename;
 }
 }  // namespace sjsu

--- a/library/utility/dummy/source_location
+++ b/library/utility/dummy/source_location
@@ -1,0 +1,17 @@
+#include <cstdint>
+
+namespace std::experimental
+{
+class source_location
+{
+ public:
+    constexpr const char * file_name() const { return ""; }
+    constexpr const char * function_name() const { return ""; }
+    constexpr std::uint_least32_t line() const { return 0; }
+    constexpr std::uint_least32_t column() const { return 0; }
+
+    static constexpr source_location current() {
+        return std::experimental::source_location{};
+    }
+};
+}  // namespace std::experimental

--- a/projects/hello_world/source/main.cpp
+++ b/projects/hello_world/source/main.cpp
@@ -5,12 +5,12 @@
 
 int main()
 {
-  LOG_INFO("Starting Hello World Application");
+  sjsu::LogInfo("Starting Hello World Application");
   while (true)
   {
     for (uint8_t i = 0; i < 16; i++)
     {
-      LOG_INFO("Hello World 0x%X", i);
+      sjsu::LogInfo("Hello World 0x%X", i);
       sjsu::Delay(500ms);
     }
   }


### PR DESCRIPTION
Migrate from using preprocessor definitions like __LINE__, __FILE__, etc
with std::experimental::source_location, allowing for the logging
implementations to be ported to C++.

New names will be LogDebug(), LogInfo(), LogWarning(), LogError()
whereas the previous #define names are LOG_DEBUG(), LOG_INFO etc.

The previous LOG_* macros will continue to exist but will be considered
deprecated and should not be used.

Resolves #1069