### PR TITLE
Add StreamExtract bit algorithm

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,6 +8,8 @@ BinPackArguments: true
 AlignConsecutiveAssignments: true
 AlignEscapedNewlines: Left
 BinPackParameters: false
+AlignAfterOpenBracket: Align
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Empty

--- a/demos/sjtwo/i2c_device/source/main.cpp
+++ b/demos/sjtwo/i2c_device/source/main.cpp
@@ -3,14 +3,15 @@
 #include "L1_Peripheral/lpc40xx/i2c.hpp"
 #include "L2_HAL/device_memory_map.hpp"
 #include "utility/log.hpp"
+#include "utility/bit.hpp"
 
 constexpr uint8_t kAccelerometerAddress = 0x1C;
 constexpr uint8_t kGestureAddress       = 0x39;
 
+using sjsu::Endian;
 using sjsu::ReadFnt;
 using sjsu::WriteFnt;
 using sjsu::device::Array_t;
-using sjsu::device::Endian;
 using sjsu::device::Register_t;
 using sjsu::device::Reserved_t;
 
@@ -71,15 +72,11 @@ GestureMemoryMap_t  // APDS-9960
 
 sjsu::lpc40xx::I2c i2c(sjsu::lpc40xx::I2c::Bus::kI2c2);
 
-sjsu::I2cDevice<kAccelerometerAddress,
-                sjsu::device::Endian::kBig,
-                AccelerometerMemoryMap_t>
+sjsu::I2cDevice<kAccelerometerAddress, Endian::kBig, AccelerometerMemoryMap_t>
     accelerometer(&i2c);
 
-sjsu::I2cDevice<kGestureAddress,
-                sjsu::device::Endian::kLittle,
-                GestureMemoryMap_t>
-    gesture(&i2c);
+sjsu::I2cDevice<kGestureAddress, Endian::kLittle, GestureMemoryMap_t> gesture(
+    &i2c);
 
 int main()
 {

--- a/library/L2_HAL/device_memory_map.hpp
+++ b/library/L2_HAL/device_memory_map.hpp
@@ -11,6 +11,7 @@
 #include "L1_Peripheral/lpc40xx/i2c.hpp"
 #include "utility/macros.hpp"
 #include "utility/status.hpp"
+#include "utility/bit.hpp"
 
 /// Boiler plate for defining memory comparision operations
 #define MEMORY_OPERATION(op)                                \
@@ -44,13 +45,6 @@ using ReadFnt = void (*)(intptr_t, size_t, uint8_t *);
 
 namespace device
 {
-/// The Endianess of the system
-enum class Endian
-{
-  kLittle,
-  kBig
-};
-
 /// Represents a register within the memory map of a device.
 ///
 /// @tparam Int - the int type to represent this register. This can be uint8_t,
@@ -227,8 +221,8 @@ Array_t
 /// @tparam endianess - the endianess of the device to communicate with
 /// @tparam MemoryMap - the memory map structure to use.
 template <class DeviceProtocol,
-          device::Endian endianess,
-          template <device::Endian endian, WriteFnt write, ReadFnt read>
+          Endian endianess,
+          template <Endian endian, WriteFnt write, ReadFnt read>
           class MemoryMap>
 class Device
 {
@@ -294,8 +288,8 @@ class Device
 /// @tparam endianess - The endianess of the I2C device
 /// @tparam MemoryMap - The memory map structure of the device
 template <const uint8_t kDeviceAddress,
-          device::Endian endianess,
-          template <device::Endian endian, WriteFnt write, ReadFnt read>
+          Endian endianess,
+          template <Endian endian, WriteFnt write, ReadFnt read>
           class MemoryMap>
 class I2cDevice : public Device<I2cDevice<kDeviceAddress, endianess, MemoryMap>,
                                 endianess,

--- a/library/L2_HAL/sensors/optical/apds9960.hpp
+++ b/library/L2_HAL/sensors/optical/apds9960.hpp
@@ -32,7 +32,7 @@ class Apds9960
   /// @tparam endianess - endianness of the memory map
   /// @tparam write - write function associated with the memory map
   /// @tparam read - read function associated with the memory map
-  template <device::Endian endianess, WriteFnt write, ReadFnt read>
+  template <Endian endianess, WriteFnt write, ReadFnt read>
   struct [[gnu::packed]] MemoryMap_t
   {
     //! @cond Doxygen_Suppress
@@ -505,8 +505,8 @@ class Apds9960
   }
 
   const I2c & i2c_;
-  I2cDevice<0x39, device::Endian::kLittle, MemoryMap_t> gesture_ =
-      I2cDevice<0x39, device::Endian::kLittle, MemoryMap_t>(&i2c_);
+  I2cDevice<0x39, Endian::kLittle, MemoryMap_t> gesture_ =
+      I2cDevice<0x39, Endian::kLittle, MemoryMap_t>(&i2c_);
 
   int8_t up_sensitivity_;
   int8_t down_sensitivity_;

--- a/library/L2_HAL/test/device_memory_map_test.cpp
+++ b/library/L2_HAL/test/device_memory_map_test.cpp
@@ -5,7 +5,7 @@ namespace sjsu
 {
 namespace
 {
-template <device::Endian endianess, WriteFnt write, ReadFnt read>
+template <Endian endianess, WriteFnt write, ReadFnt read>
 SJ2_PACKED(struct)
 TestMemoryMap_t
 {
@@ -39,7 +39,7 @@ lpc40xx::I2c test_i2c(lpc40xx::I2c::Bus::kI2c0);
 
 TEST_CASE("Testing Device Memory Map", "[device_memory_map]")
 {
-  I2cDevice<0x39, device::Endian::kLittle, TestMemoryMap_t> test(&test_i2c);
+  I2cDevice<0x39, Endian::kLittle, TestMemoryMap_t> test(&test_i2c);
   SECTION("Initialize") {}
 }
 }  // namespace sjsu

--- a/library/utility/test/bit_test.cpp
+++ b/library/utility/test/bit_test.cpp
@@ -7,6 +7,86 @@ namespace sjsu
 {
 TEST_CASE("Testing Bit Manipulations", "[bit manipulation]")
 {
+  SECTION("CreateMaskFromRange()")
+  {
+    SECTION("(start, end)")
+    {
+      CHECK(bit::Mask{ .position = 5, .width = 16 - 4 } ==
+            bit::CreateMaskFromRange(5, 16));
+      static_assert(bit::Mask{ .position = 5, .width = 16 - 4 } ==
+                    bit::CreateMaskFromRange(5, 16));
+
+      CHECK(bit::Mask{ .position = 16, .width = 47 - 15 } ==
+            bit::CreateMaskFromRange(16, 47));
+      static_assert(bit::Mask{ .position = 16, .width = 47 - 15 } ==
+                    bit::CreateMaskFromRange(16, 47));
+
+      CHECK(bit::Mask{ .position = 1, .width = 61 } ==
+            bit::CreateMaskFromRange(1, 61));
+      static_assert(bit::Mask{ .position = 1, .width = 61 } ==
+                    bit::CreateMaskFromRange(1, 61));
+
+      CHECK(bit::Mask{ .position = 55, .width = 89 - 54 } ==
+            bit::CreateMaskFromRange(55, 89));
+      static_assert(bit::Mask{ .position = 55, .width = 89 - 54 } ==
+                    bit::CreateMaskFromRange(55, 89));
+    }
+    SECTION("Single Bit")
+    {
+      CHECK(bit::Mask{ .position = 5, .width = 1 } ==
+            bit::CreateMaskFromRange(5));
+      static_assert(bit::Mask{ .position = 5, .width = 1 } ==
+                    bit::CreateMaskFromRange(5));
+
+      CHECK(bit::Mask{ .position = 47, .width = 1 } ==
+            bit::CreateMaskFromRange(47));
+      static_assert(bit::Mask{ .position = 47, .width = 1 } ==
+                    bit::CreateMaskFromRange(47));
+
+      CHECK(bit::Mask{ .position = 61, .width = 1 } ==
+            bit::CreateMaskFromRange(61));
+      static_assert(bit::Mask{ .position = 61, .width = 1 } ==
+                    bit::CreateMaskFromRange(61));
+
+      CHECK(bit::Mask{ .position = 7, .width = 1 } ==
+            bit::CreateMaskFromRange(7));
+      static_assert(bit::Mask{ .position = 7, .width = 1 } ==
+                    bit::CreateMaskFromRange(7));
+    }
+  }
+
+  SECTION("Extract")
+  {
+    // Static_assert is used to make sure that the functions work at compile
+    // time.
+    CHECK(0b0011 == bit::Extract(0b0000'1111, 2, 4));
+    static_assert(0b0011 == bit::Extract(0b0000'1111, 2, 4));
+
+    CHECK(0b0000 == bit::Extract(0b0000'1111, 4, 4));
+    static_assert(0b0000 == bit::Extract(0b0000'1111, 4, 4));
+
+    CHECK(0b0001 == bit::Extract(0b0000'1111, 0, 1));
+    static_assert(0b0001 == bit::Extract(0b0000'1111, 0, 1));
+
+    CHECK(0x00AA == bit::Extract(0xAA00'0000, 24, 8));
+    static_assert(0x00AA == bit::Extract(0xAA00'0000, 24, 8));
+
+    CHECK(0xFFFF == bit::Extract(0xFFFF'FFFF, 15, 16));
+    static_assert(0xFFFF == bit::Extract(0xFFFF'FFFF, 15, 16));
+
+    CHECK(0b0001 == bit::Extract(0xFFFF'FFFF, 31, 16));
+    static_assert(0b0001 == bit::Extract(0xFFFF'FFFF, 31, 16));
+
+    CHECK(0xBEEF == bit::Extract(0xDEAD'BEEF, 0, 16));
+    static_assert(0xBEEF == bit::Extract(0xDEAD'BEEF, 0, 16));
+
+    CHECK(0xDEAD == bit::Extract(0xDEAD'BEEF, 16, 16));
+    static_assert(0xDEAD == bit::Extract(0xDEAD'BEEF, 16, 16));
+
+    CHECK(0x00AD == bit::Extract(0xDEAD'BEEF, 16, 8));
+    static_assert(0x00AD == bit::Extract(0xDEAD'BEEF, 16, 8));
+  }
+
   SECTION("Extract")
   {
     // Static_assert is used to make sure that the functions work at compile
@@ -72,94 +152,80 @@ TEST_CASE("Testing Bit Manipulations", "[bit manipulation]")
 
   SECTION("Insert with Mask")
   {
-    CHECK(0b0110'0000 == bit::Insert(0,
-                                     0b11,
+    CHECK(0b0110'0000 == bit::Insert(0, 0b11,
                                      {
                                          .position = 5,
                                          .width    = 2,
                                      }));
-    static_assert(0b0110'0000 == bit::Insert(0,
-                                             0b11,
+    static_assert(0b0110'0000 == bit::Insert(0, 0b11,
                                              {
                                                  .position = 5,
                                                  .width    = 2,
                                              }));
 
-    CHECK(0b0000'1110 == bit::Insert(0,
-                                     0b111,
+    CHECK(0b0000'1110 == bit::Insert(0, 0b111,
                                      {
                                          .position = 1,
                                          .width    = 3,
                                      }));
-    static_assert(0b0000'1110 == bit::Insert(0,
-                                             0b111,
+    static_assert(0b0000'1110 == bit::Insert(0, 0b111,
                                              {
                                                  .position = 1,
                                                  .width    = 3,
                                              }));
 
-    CHECK(0b0000'1111 == bit::Insert(0,
-                                     0b1111,
+    CHECK(0b0000'1111 == bit::Insert(0, 0b1111,
                                      {
                                          .position = 0,
                                          .width    = 4,
                                      }));
-    static_assert(0b0000'1111 == bit::Insert(0,
-                                             0b1111,
+    static_assert(0b0000'1111 == bit::Insert(0, 0b1111,
                                              {
                                                  .position = 0,
                                                  .width    = 4,
                                              }));
 
-    CHECK(0xAB00'0000 == bit::Insert(0,
-                                     0xAB,
+    CHECK(0xAB00'0000 == bit::Insert(0, 0xAB,
                                      {
                                          .position = 24,
                                          .width    = 8,
                                      }));
-    static_assert(0xAB00'0000 == bit::Insert(0,
-                                             0xAB,
+    static_assert(0xAB00'0000 == bit::Insert(0, 0xAB,
                                              {
                                                  .position = 24,
                                                  .width    = 8,
                                              }));
 
-    CHECK(0xDEAD'BEEF == bit::Insert(0xD00D'BEEF,
-                                     0xEA,
+    CHECK(0xDEAD'BEEF == bit::Insert(0xD00D'BEEF, 0xEA,
                                      {
                                          .position = 20,
                                          .width    = 8,
                                      }));
-    static_assert(0xDEAD'BEEF == bit::Insert(0xD00D'BEEF,
-                                             0xEA,
+    static_assert(0xDEAD'BEEF == bit::Insert(0xD00D'BEEF, 0xEA,
                                              {
                                                  .position = 20,
                                                  .width    = 8,
                                              }));
 
     // Shows replacement of DEAD -> BEEF
-    CHECK(0xDEAD'BEEF == bit::Insert(0xDEAD'DEAD,
-                                     0xBEEF,
+    CHECK(0xDEAD'BEEF == bit::Insert(0xDEAD'DEAD, 0xBEEF,
                                      {
                                          .position = 0,
                                          .width    = 16,
                                      }));
-    static_assert(0xDEAD'BEEF == bit::Insert(0xDEAD'DEAD,
-                                             0xBEEF,
+    static_assert(0xDEAD'BEEF == bit::Insert(0xDEAD'DEAD, 0xBEEF,
                                              {
                                                  .position = 0,
                                                  .width    = 16,
                                              }));
 
     // Shows replacement of 0101 -> 1111 in the middle of byte
-    CHECK(0b1011'1101 == bit::Insert(0b1010'0101,
-                                     0b1111,
+    CHECK(0b1011'1101 == bit::Insert(0b1010'0101, 0b1111,
                                      {
                                          .position = 2,
                                          .width    = 4,
                                      }));
-    static_assert(0b1011'1101 == bit::Insert(0b1010'0101,
-                                             0b1111,
+    static_assert(0b1011'1101 == bit::Insert(0b1010'0101, 0b1111,
                                              {
                                                  .position = 2,
                                                  .width    = 4,
@@ -168,8 +234,7 @@ TEST_CASE("Testing Bit Manipulations", "[bit manipulation]")
     uint32_t target        = 0xAAAA'BBBB;
     int8_t value_to_insert = 0xCD;
     // Shows replacement of 0101 -> 1111 in the middle of byte
-    CHECK(0xAAAA'BCDB == bit::Insert(target,
-                                     value_to_insert,
+    CHECK(0xAAAA'BCDB == bit::Insert(target, value_to_insert,
                                      {
                                          .position = 4,
                                          .width    = 8,
@@ -240,6 +305,139 @@ TEST_CASE("Testing Bit Manipulations", "[bit manipulation]")
 
     CHECK(false == bit::Read(0x0000, 31));
     static_assert(false == bit::Read(0x0000, 31));
+  }
+
+  SECTION("StreamExtract")
+  {
+    SECTION("Little Endian")
+    {
+      SECTION("32-bit value in a 128 bit (16 byte) stream")
+      {
+        // Setup
+        std::array<uint8_t, 16> test = {
+          0x00, 0x00, 0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        };
+
+        constexpr uint32_t kExpectedBase = 0xDEADBEEF;
+
+        for (int i = 0; i < 16; i++)
+        {
+          uint32_t current_expected = kExpectedBase >> i;
+          bit::Mask mask            = {
+            .position = static_cast<uint8_t>(64 + i),
+            .width    = static_cast<uint8_t>(32 - i),
+          };
+          INFO("Failure on index [" << i << "]");
+          CHECK(current_expected == bit::StreamExtract<uint32_t>(test, mask));
+        }
+
+        for (int i = 0; i < 16; i++)
+        {
+          uint32_t current_expected = kExpectedBase & (0xFF'FF'FF'FF >> i);
+          bit::Mask mask            = {
+            .position = static_cast<uint8_t>(64),
+            .width    = static_cast<uint8_t>(32 - i),
+          };
+          INFO("Failure on index [" << i << "]");
+          CHECK(current_expected == bit::StreamExtract<uint32_t>(test, mask));
+        }
+      }
+
+      SECTION("8 bit value in a single byte stream")
+      {
+        std::array<uint8_t, 1> test = { 0b0011'1100 };
+        bit::Mask mask              = bit::CreateMaskFromRange(2, 5);
+        CHECK(0b1111 == bit::StreamExtract<uint8_t>(test, mask));
+      }
+
+      SECTION("8 bit value that crosses two bytes")
+      {
+        std::array<uint8_t, 2> test = { 0b0000'0111, 0b1110'0000 };
+        bit::Mask mask              = { .position = 4, .width = 8 };
+        CHECK(0b0111'1110 == bit::StreamExtract<uint32_t>(test, mask));
+      }
+
+      SECTION("Real Life Example")
+      {
+        // Example: CSD register for SanDisk 8 GB Micro SD card
+        constexpr std::array<uint8_t, 16> kCSD = {
+          /* [0] = */ 0x40,  /* [1] = */ 0x0E,  /* [2] = */ 0x00,
+          /* [3] = */ 0x32,  /* [4] = */ 0x5B,
+          /* [5] = */ 0x59,  /* [6] = */ 0x00,  /* [7] = */ 0x00,
+          /* [8] = */ 0x3B,  /* [9] = */ 0x37,
+          /* [10] = */ 0x7F, /* [11] = */ 0x80, /* [12] = */ 0x0A,
+          /* [13] = */ 0x40, /* [14] = */ 0x40,
+          /* [15] = */ 0xAF,
+        };
+
+        // Bits in SD card driver are [48:69]
+        constexpr bit::Mask kCSizeMask = bit::CreateMaskFromRange(48, 69);
+        // C_SIZE should equal 15159 & 0x3b37
+        constexpr uint32_t kCSizeBytes = kCSD[7] << 16 | kCSD[8] << 8 | kCSD[9];
+        constexpr uint32_t kExpected =
+            bit::Extract(kCSizeBytes, { .position = 0, .width = 21 });
+
+        INFO("position = " << static_cast<int>(kCSizeMask.position)
+                           << " :: width = "
+                           << static_cast<int>(kCSizeMask.width));
+
+        CHECK(kExpected == bit::StreamExtract<uint32_t>(kCSD, kCSizeMask));
+      }
+    }
+
+    SECTION("Big Endian")
+    {
+      SECTION("32-bit value in a 128 bit (16 byte) stream")
+      {
+        // Setup
+        std::array<uint8_t, 16> test = {
+          0x00, 0x00, 0x00, 0x00, 0xEF, 0xBE, 0xAD, 0xDE,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        };
+
+        constexpr uint32_t kExpectedBase = 0xDEADBEEF;
+
+        for (int i = 0; i < 16; i++)
+        {
+          uint32_t current_expected = kExpectedBase >> i;
+          bit::Mask mask            = {
+            .position = static_cast<uint8_t>(32 + i),
+            .width    = static_cast<uint8_t>(32 - i),
+          };
+          INFO("Failure on index [" << i << "]");
+          CHECK(current_expected ==
+                bit::StreamExtract<uint32_t>(test, mask, Endian::kBig));
+        }
+
+        for (int i = 0; i < 16; i++)
+        {
+          uint32_t current_expected = kExpectedBase & (0xFF'FF'FF'FF >> i);
+          bit::Mask mask            = {
+            .position = static_cast<uint8_t>(32),
+            .width    = static_cast<uint8_t>(32 - i),
+          };
+          INFO("Failure on index [" << i << "]");
+          CHECK(current_expected ==
+                bit::StreamExtract<uint32_t>(test, mask, Endian::kBig));
+        }
+      }
+
+      SECTION("8 bit value in a single byte stream")
+      {
+        std::array<uint8_t, 1> test = { 0b0011'1100 };
+        bit::Mask mask              = bit::CreateMaskFromRange(2, 5);
+        CHECK(0b1111 == bit::StreamExtract<uint8_t>(test, mask, Endian::kBig));
+      }
+
+      SECTION("8 bit value that crosses two bytes")
+      {
+        std::array<uint8_t, 2> test = { 0b1110'0000, 0b0000'0111 };
+        bit::Mask mask              = { .position = 4, .width = 8 };
+        CHECK(0b0111'1110 ==
+              bit::StreamExtract<uint32_t>(test, mask, Endian::kBig));
+      }
+    }
   }
 }
 }  // namespace sjsu

--- a/projects/hello_world/project.mk
+++ b/projects/hello_world/project.mk
@@ -1,4 +1,4 @@
 # USER_TESTS += $(LIBRARY_DIR)/L1_Peripheral/cortex/test/dwt_counter_test.cpp
-# USER_TESTS += $(LIBRARY_DIR)/L1_Peripheral/cortex/test/interrupt_test.cpp
-USER_TESTS += $(LIBRARY_DIR)/L1_Peripheral/test/uart_test.cpp
-USER_TESTS += $(LIBRARY_DIR)/L2_HAL/sensors/distance/time_of_flight/test/tfmini_test.cpp
+USER_TESTS += $(LIBRARY_DIR)/utility/test/bit_test.cpp
+# USER_TESTS += $(LIBRARY_DIR)/L1_Peripheral/test/uart_test.cpp
+# USER_TESTS += $(LIBRARY_DIR)/L2_HAL/sensors/distance/time_of_flight/test/tfmini_test.cpp


### PR DESCRIPTION
Allows a user to extract bits from an array of bytes.

Additional changes:

- Moves Endian out of device_memory_map. Was originally used to swap the
  endianess but this feature was dropped for now. Necessary namespacing
  changes were made.
- Updated clang format. This will cause no changes to its behaviour. The
  added fields were already active but this makes it more clear that they
  are meant to be active.

Resolves #1109