### PR TITLE
CI: Removed Coveralls install in xcode images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,11 @@ matrix:
               branch: master
         - os: osx
           osx_image: xcode10
-          before_install:
-            - pip install --user cpp-coveralls
           script:
             - cd projects/hello_world/
             - make presubmit
         - os: osx
           osx_image: xcode11.3
-          before_install:
-            - pip install --user cpp-coveralls
           script:
             - cd projects/hello_world/
             - make presubmit


### PR DESCRIPTION
This must have been residual code left over when Coveralls was called on
all platforms. But in this case, it is only called in Linux, so there is
no need to call it on any xcode images.

Resolves #1112