### PR TITLE
Refactor Can interface & lpc40xx Can implementation

### DIFF
--- a/api/sjsu-dev2-doxygen.conf
+++ b/api/sjsu-dev2-doxygen.conf
@@ -337,12 +337,10 @@ GENERATE_TAGFILE       =
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 EXTERNAL_PAGES         = YES
-PERL_PATH              = /usr/bin/perl
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 CLASS_DIAGRAMS         = YES
-MSCGEN_PATH            =
 DIA_PATH               =
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = YES

--- a/demos/sjtwo/can/project.mk
+++ b/demos/sjtwo/can/project.mk
@@ -1,0 +1,2 @@
+USER_TESTS += $(LIBRARY_DIR)/L1_Peripheral/lpc40xx/test/can_test.cpp
+PLATFORM = lpc40xx

--- a/library/L1_Peripheral/can.hpp
+++ b/library/L1_Peripheral/can.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
@@ -17,67 +19,32 @@ class Can
   // Interface Defintions
   // ===========================================================================
 
-  /// Data section of a CANBUS message
-  union Data_t {
-    /// Full payload
-    uint64_t qword;
-    /// Payload divided into 2 32-bit chunks
-    uint32_t dword[2];
-    /// Payload divided into 4 16-bit chunks
-    uint16_t word[4];
-    /// Payload divided into 8 bytes
-    uint8_t bytes[8];
-  };
-
   /// This struct represents a transmit message based on the BOSCH CAN
-  /// spec 2.0B. It is HW mapped to 32-bit registers TFI, TID, TDx (pg. 568).
-  struct [[gnu::packed]] TxMessage_t
+  /// spec 2.0B.
+  struct Message_t
   {
-    union {
-      /// TFI - Transmit Frame Information Register - Message frame info
-      uint32_t TFI;
-      struct
-      {
-        /// User definable priority level for a message (0-255)
-        uint8_t tx_priority : 8;
-        uint8_t : 8;
-        /// Data payload length (0-7 bytes)
-        uint8_t data_length : 4;
-        uint16_t : 10;
-        /// Request a data frame from a node
-        uint8_t remote_tx_request : 1;
-        /// 11-bit or 29-bit identifier format
-        uint8_t frame_format : 1;
-      } frame_data;
+    /// The format of the can message
+    enum class Format
+    {
+      /// Use 11-bit ID message
+      kStandard = 0,
+      /// Use 29-bit ID message
+      kExtended = 1,
+      kNumberOfFormats,
     };
-    /// TID - Transmit Identifier Register, CAN message ID
-    uint32_t id;
-    /// TDx - Transmit Data Registers A/B, CAN message data payload
-    Data_t data;
-  };
 
-  /// This struct represents a receive message based on the BOSCH CAN spec 2.0B.
-  /// It is HW mapped to 32-bit registers RFS, RID, RDx (pg. 565).
-  struct [[gnu::packed]] RxMessage_t
-  {
-    union {
-      // RFS - Receive Frame Status Register
-      uint32_t RFS;
-      struct
-      {
-        uint16_t id_index : 10;
-        uint8_t bypass_mode : 1;
-        uint8_t reserved_1 : 5;
-        uint8_t data_length : 4;
-        uint16_t reserved_2 : 10;
-        uint8_t remote_tx_request : 1;
-        uint8_t frame_format : 1;
-      } frame_data;
-    };
-    /// RID - Receive Identifier Register
-    uint32_t id;  // CAN message ID
-    /// RDx - Receive Data Registers A/B
-    Data_t data;  // CAN message data payload
+    /// CAN message ID
+    uint32_t id;
+    /// Length of the payload
+    uint8_t length = 0;
+    /// Container of the payload contents
+    std::array<uint8_t, 8> payload;
+    /// ID format
+    Format format = Format::kStandard;
+    /// Is this message a remote request message. If so the contents of payload
+    /// are ignored. Length shall have the length of requested data to get back
+    /// from the device responsible for message id.
+    bool is_remote_request = false;
   };
 
   // ===========================================================================
@@ -90,32 +57,23 @@ class Can
 
   /// Enables CANBUS and allows communication. Must be called after Initialize()
   /// before using this driver.
-  virtual void EnableBus() const = 0;
-
-  // TODO(#1103): Refactor this such that the user does not need to supply their
-  // own TxMessage_t structure, we handle that on the interface utility method
-  // side.
+  virtual void Enable() const = 0;
 
   /// Send a message via CANBUS to the designated device with the supplied ID
   ///
-  /// @param kMessage - Buffer to contain CANBUS contents. This should be zero
-  ///                   intialized before usage.
-  /// @param id - the ID of the device to send the message to
-  /// @param kPayload - the data to send to the device
-  /// @param length - the number of bytes to transmit
-  /// @return true - on success
-  /// @return false - on failure
-  virtual bool Send(TxMessage_t * const kMessage,
-                    uint32_t id,
-                    const uint8_t * const kPayload,
-                    size_t length) const = 0;
+  /// @param message - Message containing the CANBUS contents.
+  virtual void Send(const Message_t & message) const = 0;
 
   /// Receive data via CANBUS
   ///
-  /// @param kMessage - will contain the received data
-  /// @return true - on success
-  /// @return false - on failure
-  virtual bool Receive(RxMessage_t * const kMessage) const = 0;
+  /// @return retrieved can message. Will return with length field = 0 if no
+  /// messages exist.
+  virtual Message_t Receive() const = 0;
+
+  /// Checks if there is a message available for this channel.
+  ///
+  /// @returns true a message was received.
+  virtual bool HasData() const = 0;
 
   /// Determine if you can communicate over the bus.
   ///
@@ -123,18 +81,11 @@ class Can
   ///             the bus.
   /// @return true - on success
   /// @return false - on failure
-  virtual bool SelfTestBus(uint32_t id) const = 0;
+  virtual bool SelfTest(uint32_t id) const = 0;
 
   /// @return true - if the device is "bus Off"
   /// @return false - if the device is NOT "bus off"
   virtual bool IsBusOff() const = 0;
-
-  /// Returns an error message into the error_message parameter
-  ///
-  /// @param error_message - location to store the error message
-  /// @return true - if an error did occur and the error_message field was
-  ///         populated.
-  virtual bool GetFrameErrorLocation(const char *& error_message) const = 0;
 
   // ===========================================================================
   // Utility Methods
@@ -142,16 +93,18 @@ class Can
 
   /// Send a message via CANBUS to the designated device with the supplied ID
   ///
-  /// @param kMessage - Transmit buffer to hold the CANBUS transmission data
   /// @param id - ID to send the data to.
   /// @param payload - array literal payload to send to the device with ID
   /// @return true - on success
   /// @return false - on failure
-  bool Send(TxMessage_t * const kMessage,
-            uint32_t id,
-            std::initializer_list<uint8_t> payload) const
+  void Send(uint32_t id, std::initializer_list<uint8_t> payload) const
   {
-    return Send(kMessage, id, payload.begin(), payload.size());
+    Message_t message;
+    std::copy_n(payload.begin(),
+                std::min(payload.size(), message.payload.size()),
+                message.payload.begin());
+    message.id = id;
+    Send(message);
   }
 };
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc40xx/dac.hpp
+++ b/library/L1_Peripheral/lpc40xx/dac.hpp
@@ -33,6 +33,7 @@ class Dac final : public sjsu::Dac
     /// about how this bit works.
     static constexpr bit::Mask kBias = bit::CreateMaskFromRange(16);
   };
+
   /// The only DAC output pin on the lpc40xx.
   static constexpr sjsu::lpc40xx::Pin kDacPin = Pin::CreatePin<0, 26>();
   /// Voltage reference for the lpc40xx voltage.

--- a/library/L1_Peripheral/lpc40xx/spi.hpp
+++ b/library/L1_Peripheral/lpc40xx/spi.hpp
@@ -104,7 +104,7 @@ class Spi final : public sjsu::Spi
     /// Pointer to the LPC SSP peripheral in memory
     LPC_SSP_TypeDef * registers;
     /// PeripheralID of the SSP peripheral to power on at initialization
-    sjsu::lpc40xx::SystemController::PeripheralID power_on_bit;
+    sjsu::SystemController::PeripheralID power_on_bit;
     /// Refernce to the M.ASTER-O.UT-S.LAVE-I.N (output from microcontroller)
     /// spi pin.
     const sjsu::Pin & mosi;

--- a/library/L1_Peripheral/lpc40xx/test/can_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/can_test.cpp
@@ -1,15 +1,326 @@
-#include "L0_Platform/lpc40xx/LPC40xx.h"
-// TODO(#357): Fake queue.h functions in rtos.hpp
-// #include "L1_Peripheral/lpc40xx/can.hpp"
+#include <chrono>  // NOLINT
+#include <thread>  // NOLINT
+
+#include "L1_Peripheral/lpc40xx/can.hpp"
 #include "L4_Testing/testing_frameworks.hpp"
+
 
 namespace sjsu::lpc40xx
 {
-// Uncomment this when can class has been created
-// EMIT_ALL_METHODS(Can);
+EMIT_ALL_METHODS(Can);
 
 TEST_CASE("Testing lpc40xx Can", "[lpc40xx-can]")
 {
-  SECTION("Initialize") {}
+  // Simulate local version of LPC_CAN
+  LPC_CAN_TypeDef local_can;
+  // Clear memory locations
+  memset(&local_can, 0, sizeof(local_can));
+  LPC_CANAF_TypeDef local_can_acceptance;
+  memset(&local_can_acceptance, 0, sizeof(local_can_acceptance));
+
+  // Set acceptance filter to the local acceptance filter
+  Can::can_acceptance_filter_register = &local_can_acceptance;
+
+  // Set mock for sjsu::SystemController
+  constexpr units::frequency::hertz_t kDummySystemControllerClockFrequency =
+      12_MHz;
+  Mock<sjsu::SystemController> mock_system_controller;
+  Fake(Method(mock_system_controller, PowerUpPeripheral));
+  When(Method(mock_system_controller, GetSystemFrequency))
+      .AlwaysReturn(kDummySystemControllerClockFrequency);
+  When(Method(mock_system_controller, GetPeripheralClockDivider))
+      .AlwaysReturn(1);
+  sjsu::SystemController::SetPlatformController(&mock_system_controller.get());
+
+  // Set up Mock for Pin
+  Mock<sjsu::Pin> mock_td;
+  Mock<sjsu::Pin> mock_rd;
+
+  Fake(Method(mock_td, SetPinFunction));
+  Fake(Method(mock_rd, SetPinFunction));
+
+  // Set up SSP Bus configuration object
+  const Can::Channel_t kMockCan = {
+    .td_pin           = mock_td.get(),
+    .td_function_code = 2,
+    .rd_pin           = mock_rd.get(),
+    .rd_function_code = 2,
+    .registers        = &local_can,
+    .id               = sjsu::lpc40xx::SystemController::Peripherals::kCan1,
+  };
+
+  Can test_can(kMockCan);
+
+  SECTION("Initialize()")
+  {
+    // Setup
+    auto check_power_up = [](sjsu::SystemController::PeripheralID id) -> bool {
+      return sjsu::lpc40xx::SystemController::Peripherals::kCan1.device_id ==
+             id.device_id;
+    };
+
+    // Exercise
+    test_can.Initialize();
+
+    // Verify
+    // Verify: Peripheral is powered on
+    Verify(Method(mock_system_controller, PowerUpPeripheral)
+               .Matching(check_power_up));
+
+    // Verify: Pins are configured
+    Verify(Method(mock_td, SetPinFunction).Using(kMockCan.td_function_code))
+        .Once();
+    Verify(Method(mock_rd, SetPinFunction).Using(kMockCan.rd_function_code))
+        .Once();
+
+    // Verify: Mode is in reset
+    CHECK(!bit::Read(local_can.MOD, Can::Mode::kReset));
+
+    SECTION("Default Baud rate")
+    {
+      constexpr uint32_t kExpectedPrescalar =
+          (kDummySystemControllerClockFrequency / Can::kStandardBaudRate) - 1;
+      constexpr uint32_t kExpectedSyncJumpWidth = 3;
+      constexpr uint32_t kExpectedTimeSegment1  = 6;
+      constexpr uint32_t kExpectedTimeSegment2  = 1;
+      constexpr uint32_t kExpectedBusSampling   = 0;
+      // Verify: Baud rate is set correctly
+      CHECK(kExpectedPrescalar ==
+            bit::Extract(local_can.BTR, Can::BusTiming::kPrescalar));
+      CHECK(kExpectedSyncJumpWidth ==
+            bit::Extract(local_can.BTR, Can::BusTiming::kSyncJumpWidth));
+      CHECK(kExpectedTimeSegment1 ==
+            bit::Extract(local_can.BTR, Can::BusTiming::kTimeSegment1));
+      CHECK(kExpectedTimeSegment2 ==
+            bit::Extract(local_can.BTR, Can::BusTiming::kTimeSegment2));
+      CHECK(kExpectedBusSampling ==
+            bit::Extract(local_can.BTR, Can::BusTiming::kSampling));
+    }
+
+    SECTION("With non-default BAUD rate")
+    {
+      constexpr units::frequency::hertz_t kDifferentBaudRate = 50'000_Hz;
+      constexpr uint32_t kExpectedPrescalar =
+          (kDummySystemControllerClockFrequency / kDifferentBaudRate) - 1;
+      constexpr uint32_t kExpectedSyncJumpWidth = 3;
+      constexpr uint32_t kExpectedTimeSegment1  = 6;
+      constexpr uint32_t kExpectedTimeSegment2  = 1;
+      constexpr uint32_t kExpectedBusSampling   = 1;
+
+      Can can_with_different_baud(kMockCan, kDifferentBaudRate);
+      can_with_different_baud.Initialize();
+
+      // Verify: Baud rate is set correctly
+      CHECK(kExpectedPrescalar ==
+            bit::Extract(local_can.BTR, Can::BusTiming::kPrescalar));
+      CHECK(kExpectedSyncJumpWidth ==
+            bit::Extract(local_can.BTR, Can::BusTiming::kSyncJumpWidth));
+      CHECK(kExpectedTimeSegment1 ==
+            bit::Extract(local_can.BTR, Can::BusTiming::kTimeSegment1));
+      CHECK(kExpectedTimeSegment2 ==
+            bit::Extract(local_can.BTR, Can::BusTiming::kTimeSegment2));
+      CHECK(kExpectedBusSampling ==
+            bit::Extract(local_can.BTR, Can::BusTiming::kSampling));
+    }
+
+    // Verify: Acceptance filter has been set to accept everything
+    CHECK(Value(Can::Commands::kAcceptAllMessages) ==
+          local_can_acceptance.AFMR);
+  }
+
+  SECTION("Enable()")
+  {
+    // Setup
+    SECTION("CANBUS was in Reset")
+    {
+      // Setup: Set MODE to kReset at the start
+      local_can.MOD = bit::Set(local_can.MOD, Can::Mode::kReset);
+    }
+    SECTION("CANBUS was NOT in Reset")
+    {
+      // Setup: Set MODE to kReset at the start
+      local_can.MOD = bit::Clear(local_can.MOD, Can::Mode::kReset);
+    }
+
+    // Exercise
+    test_can.Enable();
+
+    // Verify: Mode is in reset
+    CHECK(!bit::Read(local_can.MOD, Can::Mode::kReset));
+  }
+
+  SECTION("HasData()")
+  {
+    SECTION("CANBUS has data")
+    {
+      // Setup
+      local_can.GSR =
+          bit::Set(local_can.GSR, Can::GlobalStatus::kReceiveBuffer);
+
+      // Exercise + Verify
+      CHECK(test_can.HasData());
+    }
+    SECTION("CANBUS does NOT have data")
+    {
+      // Setup
+      local_can.GSR =
+          bit::Clear(local_can.GSR, Can::GlobalStatus::kReceiveBuffer);
+
+      // Exercise + Verify
+      CHECK(!test_can.HasData());
+    }
+  }
+
+  SECTION("IsBusOff()")
+  {
+    SECTION("CANBUS is bus off")
+    {
+      // Setup
+      local_can.GSR = bit::Set(local_can.GSR, Can::GlobalStatus::kBusError);
+
+      // Exercise + Verify
+      CHECK(test_can.IsBusOff());
+    }
+    SECTION("CANBUS NOT bus off")
+    {
+      // Setup
+      local_can.GSR = bit::Clear(local_can.GSR, Can::GlobalStatus::kBusError);
+
+      // Exercise + Verify
+      CHECK(!test_can.IsBusOff());
+    }
+  }
+
+  SECTION("Send()")
+  {
+    // Setup
+    Can::Message_t message;
+    message.id                = 0x25;
+    message.format            = Can::Message_t::Format::kStandard;
+    message.is_remote_request = false;
+    message.length            = 5;
+    message.payload           = { 1, 2, 3, 4, 5, 0, 0, 0 };
+
+    uint32_t expected_frame = 0;
+    expected_frame =
+        bit::Insert(expected_frame, message.length, Can::FrameInfo::kLength);
+    expected_frame = bit::Insert(expected_frame, message.is_remote_request,
+                                 Can::FrameInfo::kRemoteRequest);
+    expected_frame = bit::Insert(expected_frame, Value(message.format),
+                                 Can::FrameInfo::kFormat);
+
+    const uint32_t kExpectedDataA =
+        message.payload[0] | message.payload[1] << 8 |
+        message.payload[2] << 16 | message.payload[3] << 24;
+    const uint32_t kExpectedDataB = message.payload[4];
+
+    SECTION("Buffer 1")
+    {
+      local_can.SR = bit::Set(local_can.SR, Can::BufferStatus::kTx1Released);
+
+      // Exercise
+      test_can.Send(message);
+
+      // Verify
+      CHECK(expected_frame == local_can.TFI1);
+      CHECK(message.id == local_can.TID1);
+      CHECK(kExpectedDataA == local_can.TDA1);
+      CHECK(kExpectedDataB == local_can.TDB1);
+      CHECK(Value(Can::Commands::kSendTxBuffer1) == local_can.CMR);
+    }
+
+    SECTION("Buffer 2")
+    {
+      local_can.SR = bit::Set(local_can.SR, Can::BufferStatus::kTx2Released);
+
+      // Exercise
+      test_can.Send(message);
+
+      // Verify
+      CHECK(expected_frame == local_can.TFI2);
+      CHECK(message.id == local_can.TID2);
+      CHECK(kExpectedDataA == local_can.TDA2);
+      CHECK(kExpectedDataB == local_can.TDB2);
+      CHECK(Value(Can::Commands::kSendTxBuffer2) == local_can.CMR);
+    }
+
+    SECTION("Buffer 3")
+    {
+      local_can.SR = bit::Set(local_can.SR, Can::BufferStatus::kTx3Released);
+
+      // Exercise
+      test_can.Send(message);
+
+      // Verify
+      CHECK(expected_frame == local_can.TFI3);
+      CHECK(message.id == local_can.TID3);
+      CHECK(kExpectedDataA == local_can.TDA3);
+      CHECK(kExpectedDataB == local_can.TDB3);
+      CHECK(Value(Can::Commands::kSendTxBuffer3) == local_can.CMR);
+    }
+
+    SECTION("All buffers full, release TX3 after ")
+    {
+      local_can.SR = bit::Clear(local_can.SR, Can::BufferStatus::kTx1Released);
+      local_can.SR = bit::Clear(local_can.SR, Can::BufferStatus::kTx2Released);
+      local_can.SR = bit::Clear(local_can.SR, Can::BufferStatus::kTx3Released);
+
+      std::thread open_up_tx3([&local_can]() {
+        std::this_thread::sleep_for(100ms);
+        local_can.SR = bit::Set(local_can.SR, Can::BufferStatus::kTx3Released);
+      });
+
+      // Exercise
+      test_can.Send(message);
+      open_up_tx3.join();
+
+      // Verify
+      CHECK(expected_frame == local_can.TFI3);
+      CHECK(message.id == local_can.TID3);
+      CHECK(kExpectedDataA == local_can.TDA3);
+      CHECK(kExpectedDataB == local_can.TDB3);
+      CHECK(Value(Can::Commands::kSendTxBuffer3) == local_can.CMR);
+    }
+  }
+
+  SECTION("Receive()")
+  {
+    // Setup
+    Can::Message_t message;
+    message.id                = 0x25;
+    message.format            = Can::Message_t::Format::kStandard;
+    message.is_remote_request = false;
+    message.length            = 5;
+    message.payload           = { 1, 2, 3, 4, 5, 0, 0, 0 };
+
+    uint32_t expected_frame = 0;
+    expected_frame =
+        bit::Insert(expected_frame, message.length, Can::FrameInfo::kLength);
+    expected_frame = bit::Insert(expected_frame, message.is_remote_request,
+                                 Can::FrameInfo::kRemoteRequest);
+    expected_frame = bit::Insert(expected_frame, Value(message.format),
+                                 Can::FrameInfo::kFormat);
+
+    local_can.RFS = expected_frame;
+    local_can.RID = message.id;
+    local_can.RDA = message.payload[0] | message.payload[1] << 8 |
+                    message.payload[2] << 16 | message.payload[3] << 24;
+    local_can.RDB = message.payload[4];
+
+    Can::Message_t actual_message = test_can.Receive();
+
+    CHECK(message.id == actual_message.id);
+    CHECK(message.format == actual_message.format);
+    CHECK(message.is_remote_request == actual_message.is_remote_request);
+    CHECK(message.length == actual_message.length);
+    CHECK(message.payload == actual_message.payload);
+  }
+
+  SECTION("SelfTest()")
+  {
+    // TODO(#): Add unit test for this
+  }
+
+  Can::can_acceptance_filter_register = LPC_CANAF;
 }
 }  // namespace sjsu::lpc40xx

--- a/library/L1_Peripheral/lpc40xx/test/spi_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/spi_test.cpp
@@ -26,7 +26,7 @@ TEST_CASE("Testing lpc40xx SPI", "[lpc40xx-Spi]")
       .AlwaysReturn(1);
   sjsu::SystemController::SetPlatformController(&mock_system_controller.get());
 
-  // Set up Mock for PinCongiure
+  // Set up Mock for Pin
   Mock<sjsu::Pin> mock_mosi;
   Mock<sjsu::Pin> mock_miso;
   Mock<sjsu::Pin> mock_sck;

--- a/library/config.hpp
+++ b/library/config.hpp
@@ -85,7 +85,6 @@ namespace config
 ///    can only be between 1Hz and 100Mhz, then kSystemClockRate should be
 ///    checked if it is within range.
 ///
-/// @{
 
 /// Creates a typed constexpr version of the macro defintion which should be
 /// used rather than using the macro directly.
@@ -239,4 +238,4 @@ SJ2_DECLARE_CONSTANT(DESCRIPTIVE_FUNCTION_NAME, bool, kDescriptiveFunctionName);
 #define PRINTF_DISABLE_SUPPORT_PTRDIFF_T
 #endif
 }  // namespace config
-/// @}
+

--- a/library/utility/enum.hpp
+++ b/library/utility/enum.hpp
@@ -44,6 +44,7 @@ struct EnableBitMaskOperators_t
   /// If true, unlocks the enum bitwise operations on the enum class.
   static constexpr bool kEnable = false;
 };
+
 /// This macro, when used on an enum class type, will create a specialized
 /// version of the "EnableBitMaskOperators_t" that enables that enum class
 /// to use bitwise operators without the need of static_cast.
@@ -63,10 +64,6 @@ struct EnableBitMaskOperators_t
     static constexpr bool kEnable = true; \
   }
 
-//@{
-/// The following is the same for all operators beyond this point.
-///
-///
 /// @tparam Enum is the type used in this operator overload
 /// @tparam class= is used as a select. The compiler will use this
 ///                implementation of the | operator if that type has a
@@ -84,6 +81,14 @@ constexpr Enum operator|(Enum lhs, Enum rhs)
   return static_cast<Enum>(static_cast<underlying>(lhs) |
                            static_cast<underlying>(rhs));
 }
+/// @tparam Enum is the type used in this operator overload
+/// @tparam class= is used as a select. The compiler will use this
+///                implementation of the & operator if that type has a
+///                EnableBitMaskOperators_t<> specialization of the Enum type
+///                or, in other words, the SJ2_ENABLE_BITMASK_OPERATORS was used
+///                on it.
+///
+/// @return an enum class that is the & of the two input enum operators.
 
 template <typename Enum,
           class = typename std::
@@ -95,6 +100,14 @@ constexpr Enum operator&(Enum lhs, Enum rhs)
                            static_cast<underlying>(rhs));
 }
 
+/// @tparam Enum is the type used in this operator overload
+/// @tparam class= is used as a select. The compiler will use this
+///                implementation of the ^ operator if that type has a
+///                EnableBitMaskOperators_t<> specialization of the Enum type
+///                or, in other words, the SJ2_ENABLE_BITMASK_OPERATORS was used
+///                on it.
+///
+/// @return an enum class that is the ^ of the two input enum operators.
 template <typename Enum,
           class = typename std::
               enable_if_t<EnableBitMaskOperators_t<Enum>::kEnable, Enum>>
@@ -105,6 +118,14 @@ constexpr Enum operator^(Enum lhs, Enum rhs)
                            static_cast<underlying>(rhs));
 }
 
+/// @tparam Enum is the type used in this operator overload
+/// @tparam class= is used as a select. The compiler will use this
+///                implementation of the ~ operator if that type has a
+///                EnableBitMaskOperators_t<> specialization of the Enum type
+///                or, in other words, the SJ2_ENABLE_BITMASK_OPERATORS was used
+///                on it.
+///
+/// @return an enum class that is the ~ of the two input enum operators.
 template <typename Enum,
           class = typename std::
               enable_if_t<EnableBitMaskOperators_t<Enum>::kEnable, Enum>>
@@ -114,6 +135,14 @@ constexpr Enum operator~(Enum rhs)
   return static_cast<Enum>(~static_cast<underlying>(rhs));
 }
 
+/// @tparam Enum is the type used in this operator overload
+/// @tparam class= is used as a select. The compiler will use this
+///                implementation of the |= operator if that type has a
+///                EnableBitMaskOperators_t<> specialization of the Enum type
+///                or, in other words, the SJ2_ENABLE_BITMASK_OPERATORS was used
+///                on it.
+///
+/// @return an enum class that is the |= of the two input enum operators.
 template <typename Enum,
           class = typename std::
               enable_if_t<EnableBitMaskOperators_t<Enum>::kEnable, Enum>>
@@ -125,6 +154,14 @@ constexpr Enum & operator|=(Enum & lhs, Enum rhs)
   return lhs;
 }
 
+/// @tparam Enum is the type used in this operator overload
+/// @tparam class= is used as a select. The compiler will use this
+///                implementation of the &= operator if that type has a
+///                EnableBitMaskOperators_t<> specialization of the Enum type
+///                or, in other words, the SJ2_ENABLE_BITMASK_OPERATORS was used
+///                on it.
+///
+/// @return an enum class that is the &= of the two input enum operators.
 template <typename Enum,
           class = typename std::
               enable_if_t<EnableBitMaskOperators_t<Enum>::kEnable, Enum>>
@@ -136,6 +173,14 @@ constexpr Enum & operator&=(Enum & lhs, Enum rhs)
   return lhs;
 }
 
+/// @tparam Enum is the type used in this operator overload
+/// @tparam class= is used as a select. The compiler will use this
+///                implementation of the ^= operator if that type has a
+///                EnableBitMaskOperators_t<> specialization of the Enum type
+///                or, in other words, the SJ2_ENABLE_BITMASK_OPERATORS was used
+///                on it.
+///
+/// @return an enum class that is the ^= of the two input enum operators.
 template <typename Enum,
           class = typename std::
               enable_if_t<EnableBitMaskOperators_t<Enum>::kEnable, Enum>>
@@ -146,5 +191,4 @@ constexpr Enum & operator^=(Enum & lhs, Enum rhs)
                           static_cast<underlying>(rhs));
   return lhs;
 }
-//@}
 }  // namespace sjsu

--- a/tools/cpplint/cpplint.py
+++ b/tools/cpplint/cpplint.py
@@ -6099,7 +6099,7 @@ def FlagCxx11Features(filename, clean_lines, linenum, error):
                                       'fenv.h',
                                       'future',
                                       'mutex',
-                                      'thread',
+                                      # 'thread',
                                       # 'chrono',
                                       'ratio',
                                       'regex',


### PR DESCRIPTION
- Utilize bit API vs bit fields
- Decouple driver from FreeRTOS
- Simplify CAN interface and its primitives

Resolves #359
Resolves #347
Resolves #346
Resolves #345 (there will be no support for this