### PR TITLE
Integrate Error Handling V2

### DIFF
--- a/library/L0_Platform/lpc40xx/startup.cpp
+++ b/library/L0_Platform/lpc40xx/startup.cpp
@@ -181,7 +181,7 @@ void InitializePlatform()
 
   system_timer.Initialize();
   system_timer.SetTickFrequency(config::kRtosFrequency);
-  sjsu::Status timer_start_status = system_timer.StartTimer();
+  sjsu::Status_t timer_start_status = system_timer.StartTimer();
 
   SJ2_ASSERT_FATAL(timer_start_status == sjsu::Status::kSuccess,
                    "System Timer (used by FreeRTOS) has FAILED to start!");

--- a/library/L1_Peripheral/adc.hpp
+++ b/library/L1_Peripheral/adc.hpp
@@ -14,7 +14,7 @@ class Adc
  public:
   /// Initialize and enable hardware. This must be called before any other
   /// method in this interface is called.
-  virtual Status Initialize() const = 0;
+  virtual Status_t Initialize() const = 0;
   /// Read the analog signal's value.
   /// The number active bits depends on the ADC being used and be known by
   /// running the GetActiveBits().

--- a/library/L1_Peripheral/can.hpp
+++ b/library/L1_Peripheral/can.hpp
@@ -53,7 +53,7 @@ class Can
 
   /// Initialize the CANBUS peripheral. Must be called before calling anything
   /// else in the driver.
-  virtual Status Initialize() const = 0;
+  virtual Status_t Initialize() const = 0;
 
   /// Enables CANBUS and allows communication. Must be called after Initialize()
   /// before using this driver.

--- a/library/L1_Peripheral/cortex/system_timer.hpp
+++ b/library/L1_Peripheral/cortex/system_timer.hpp
@@ -126,9 +126,9 @@ class SystemTimer final : public sjsu::SystemTimer
     callback = isr;
   }
 
-  Status StartTimer() const override
+  Status_t StartTimer() const override
   {
-    Status status = Status::kInvalidSettings;
+    Status_t status = Status::kInvalidSettings;
 
     if (sys_tick->LOAD != 0)
     {

--- a/library/L1_Peripheral/dac.hpp
+++ b/library/L1_Peripheral/dac.hpp
@@ -14,7 +14,7 @@ class Dac
  public:
   /// Initialize and enable hardware. This must be called before any other
   /// method in this interface is called.
-  virtual Status Initialize() const = 0;
+  virtual Status_t Initialize() const = 0;
   /// Set the DAC output the the value supplied.
   ///
   /// @param output - what value to write to the DAC register.

--- a/library/L1_Peripheral/example.hpp
+++ b/library/L1_Peripheral/example.hpp
@@ -42,7 +42,7 @@ class Example
   /// execute before running any other methods of the peripheral. Initialize
   /// should return a status indicating if it was successful, or if some error
   /// occurred.
-  virtual Status Initialize() const = 0;
+  virtual Status_t Initialize() const = 0;
   /// 7. API for data transfer
   /// If your peripheral is a communication protocol, the standard for sending
   /// and receiving data is to follow the method signature. A write or read that
@@ -54,7 +54,7 @@ class Example
   /// protocol. Example would be something like SPI where the master drives the
   /// read operation. This is useful for something like UART where the event of
   /// receiving data is asynchronous.
-  virtual Status Read(uint8_t * data,
+  virtual Status_t Read(uint8_t * data,
                       size_t length,
                       uint32_t timeout) const = 0;
 
@@ -72,7 +72,7 @@ class Example
   /// actually work.
   virtual uint32_t GetClockRate() const = 0;
 
-  /// 10. Status methods
+  /// 10. Status_t methods
   /// Methods that indicate the status of the peripheral should be prefixed
   /// with the word "Has". These must return bool.
   virtual bool HasCompletedAction() const = 0;
@@ -105,7 +105,7 @@ class Example
   }
 
   /// Overload of Read that waits forever if a timeout was not supplied.
-  Status Read(uint8_t * data, size_t size)
+  Status_t Read(uint8_t * data, size_t size)
   {
     return Read(data, size, UINT32_MAX);
   }

--- a/library/L1_Peripheral/example/example.hpp
+++ b/library/L1_Peripheral/example/example.hpp
@@ -100,7 +100,7 @@ class Example final : public sjsu::Example
 
   // 7. Methods that override the parent's implementation must use the keyword
   // "override".
-  Status Initialize() const override
+  Status_t Initialize() const override
   {
     // Add implementation here.
     // Example implementation where we set the functions of the pins.
@@ -125,7 +125,7 @@ class Example final : public sjsu::Example
     return true;
   }
 
-  Status Read(uint8_t * data, size_t length, uint32_t timeout) const override
+  Status_t Read(uint8_t * data, size_t length, uint32_t timeout) const override
   {
     // This is a trick to make the compiler think we used these variables.
     // Only using this for an example. Otherwise, use the [[maybe_unused]]

--- a/library/L1_Peripheral/i2c.hpp
+++ b/library/L1_Peripheral/i2c.hpp
@@ -79,7 +79,7 @@ class I2c
     std::chrono::milliseconds timeout = kI2cTimeout;
     /// The status of the transaction after it is completed, fails, or times
     /// out.
-    Status status = Status::kSuccess;
+    Status_t status;
   };
 
   // ==============================
@@ -88,7 +88,8 @@ class I2c
 
   /// Initialize and enable hardware. This must be called before any other
   /// method in this interface is called.
-  virtual Status Initialize() const = 0;
+  virtual Status_t Initialize() const = 0;
+
   /// Perform a I2C transaction using the information contained in the
   /// transaction parameter.
   ///
@@ -97,7 +98,7 @@ class I2c
   ///         Status::kDeviceNotFound if external device does not respond to
   ///         address on the bus
   ///         Status::kSuccess if transaction was fulfilled.
-  virtual Status Transaction(Transaction_t transaction) const = 0;
+  virtual Status_t Transaction(Transaction_t transaction) const = 0;
 
   // ==============================
   // Utility Methods
@@ -111,10 +112,10 @@ class I2c
   ///        data buffer
   /// @param timeout - Amount of time to wait for a response by device before
   ///        bailing out.
-  Status Read(uint8_t address,
-              uint8_t * transmit_buffer,
-              size_t transmit_buffer_length,
-              std::chrono::milliseconds timeout = kI2cTimeout) const
+  Status_t Read(uint8_t address,
+                     uint8_t * transmit_buffer,
+                     size_t transmit_buffer_length,
+                     std::chrono::milliseconds timeout = kI2cTimeout) const
   {
     return Transaction({
         .operation  = Operation::kRead,
@@ -138,10 +139,10 @@ class I2c
   /// @param receive_buffer_length - number of bytes to be written to the device
   /// @param timeout - Amount of time to wait for a response by device before
   ///        bailing out.
-  Status Write(uint8_t address,
-               const uint8_t * receive_buffer,
-               size_t receive_buffer_length,
-               std::chrono::milliseconds timeout = kI2cTimeout) const
+  Status_t Write(uint8_t address,
+                      const uint8_t * receive_buffer,
+                      size_t receive_buffer_length,
+                      std::chrono::milliseconds timeout = kI2cTimeout) const
   {
     return Transaction({
         .operation  = Operation::kWrite,
@@ -168,9 +169,9 @@ class I2c
   /// @param transmit - array literal to send to device
   /// @param timeout - Amount of time to wait for a response by device before
   ///        bailing out.
-  Status Write(uint8_t address,
-               std::initializer_list<uint8_t> transmit,
-               std::chrono::milliseconds timeout = kI2cTimeout) const
+  Status_t Write(uint8_t address,
+                      std::initializer_list<uint8_t> transmit,
+                      std::chrono::milliseconds timeout = kI2cTimeout) const
   {
     return Write(address, transmit.begin(), transmit.size(), timeout);
   }
@@ -189,12 +190,13 @@ class I2c
   /// @param receive_buffer_length - number of bytes to be written to the device
   /// @param timeout - Amount of time to wait for a response by device before
   ///        bailing out.
-  Status WriteThenRead(uint8_t address,
-                       const uint8_t * transmit_buffer,
-                       size_t transmit_buffer_length,
-                       uint8_t * receive_buffer,
-                       size_t receive_buffer_length,
-                       std::chrono::milliseconds timeout = kI2cTimeout) const
+  Status_t WriteThenRead(
+      uint8_t address,
+      const uint8_t * transmit_buffer,
+      size_t transmit_buffer_length,
+      uint8_t * receive_buffer,
+      size_t receive_buffer_length,
+      std::chrono::milliseconds timeout = kI2cTimeout) const
   {
     return Transaction({
         .operation  = Operation::kWrite,
@@ -224,11 +226,12 @@ class I2c
   /// @param receive_buffer_length -
   /// @param timeout - Amount of time to wait for a response by device before
   ///        bailing out.
-  Status WriteThenRead(uint8_t address,
-                       std::initializer_list<uint8_t> transmit,
-                       uint8_t * receive_buffer,
-                       size_t receive_buffer_length,
-                       std::chrono::milliseconds timeout = kI2cTimeout) const
+  Status_t WriteThenRead(
+      uint8_t address,
+      std::initializer_list<uint8_t> transmit,
+      uint8_t * receive_buffer,
+      size_t receive_buffer_length,
+      std::chrono::milliseconds timeout = kI2cTimeout) const
   {
     return WriteThenRead(address,
                          transmit.begin(),

--- a/library/L1_Peripheral/inactive.hpp
+++ b/library/L1_Peripheral/inactive.hpp
@@ -73,7 +73,7 @@ inline sjsu::Adc & GetInactive<sjsu::Adc>()
   class InactiveAdc : public sjsu::Adc
   {
    public:
-    sjsu::Status Initialize() const override
+    sjsu::Status_t Initialize() const override
     {
       return sjsu::Status::kNotImplemented;
     }
@@ -98,7 +98,7 @@ inline sjsu::Dac & GetInactive<sjsu::Dac>()
   class InactiveDac : public sjsu::Dac
   {
    public:
-    Status Initialize() const override
+    Status_t Initialize() const override
     {
       return Status::kNotImplemented;
     }
@@ -147,11 +147,11 @@ inline sjsu::I2c & GetInactive<sjsu::I2c>()
   class InactiveI2c : public sjsu::I2c
   {
    public:
-    Status Initialize() const override
+    Status_t Initialize() const override
     {
       return Status::kNotImplemented;
     }
-    Status Transaction(Transaction_t) const override
+    Status_t Transaction(Transaction_t) const override
     {
       return Status::kNotImplemented;
     }
@@ -168,7 +168,7 @@ inline sjsu::Pwm & GetInactive<sjsu::Pwm>()
   class InactivePwm : public sjsu::Pwm
   {
    public:
-    Status Initialize(units::frequency::hertz_t) const override
+    Status_t Initialize(units::frequency::hertz_t) const override
     {
       return Status::kNotImplemented;
     }
@@ -191,7 +191,7 @@ inline sjsu::Spi & GetInactive<sjsu::Spi>()
   class InactiveSpi : public sjsu::Spi
   {
    public:
-    Status Initialize() const override
+    Status_t Initialize() const override
     {
       return Status::kNotImplemented;
     }
@@ -265,7 +265,7 @@ inline sjsu::SystemTimer & GetInactive<sjsu::SystemTimer>()
    public:
     void Initialize() const override {}
     void SetCallback(InterruptCallback) const override {}
-    Status StartTimer() const override
+    Status_t StartTimer() const override
     {
       return Status::kNotImplemented;
     }
@@ -286,9 +286,9 @@ inline sjsu::Timer & GetInactive<sjsu::Timer>()
   class InactiveTimer : public sjsu::Timer
   {
    public:
-    Status Initialize(units::frequency::hertz_t,
-                      InterruptCallback,
-                      int32_t) const override
+    Status_t Initialize(units::frequency::hertz_t,
+                        InterruptCallback,
+                        int32_t) const override
     {
       return Status::kNotImplemented;
     }
@@ -317,7 +317,7 @@ inline sjsu::Uart & GetInactive<sjsu::Uart>()
   class InactiveUart : public sjsu::Uart
   {
    public:
-    Status Initialize(uint32_t) const override
+    Status_t Initialize(uint32_t) const override
     {
       return Status::kNotImplemented;
     }

--- a/library/L1_Peripheral/lpc17xx/system_controller.hpp
+++ b/library/L1_Peripheral/lpc17xx/system_controller.hpp
@@ -147,7 +147,7 @@ class SystemController final : public sjsu::SystemController
     /// PLL Mode control mask
     static constexpr bit::Mask kMode = bit::CreateMaskFromRange(24, 25);
     /// PLL Lock status bit
-    static constexpr bit::Mask kLockStatus = bit::CreateMaskFromRange(26);
+    static constexpr bit::Mask kLockStatus_t = bit::CreateMaskFromRange(26);
   };
 
   /// Bit masks for the USB PLL register
@@ -160,7 +160,7 @@ class SystemController final : public sjsu::SystemController
     /// PLL Mode control mask
     static constexpr bit::Mask kMode = bit::CreateMaskFromRange(8, 9);
     /// PLL Lock status bit
-    static constexpr bit::Mask kLockStatus = bit::CreateMaskFromRange(10);
+    static constexpr bit::Mask kLockStatus_t = bit::CreateMaskFromRange(10);
   };
 
   /// Common bit masks across PLLs
@@ -523,7 +523,7 @@ class SystemController final : public sjsu::SystemController
       &(system_controller->PLL1STAT)
     };
     const bit::Mask kLockStatusMasks[]  = { MainPll::kLockStatus,
-                                           UsbPll::kLockStatus };
+                                           UsbPll::kLockStatus_t };
     volatile uint32_t * status_register = pll_status_registers[Value(pll)];
     const bit::Mask kLockStatusMask     = kLockStatusMasks[Value(pll)];
 

--- a/library/L1_Peripheral/lpc40xx/adc.hpp
+++ b/library/L1_Peripheral/lpc40xx/adc.hpp
@@ -208,7 +208,7 @@ class Adc final : public sjsu::Adc
   /// @param channel: Passed channel descriptor object. See Channel_t and
   ///        Channel documentation for more details about how to use this.
   explicit constexpr Adc(const Channel_t & channel) : channel_(channel) {}
-  Status Initialize() const override
+  Status_t Initialize() const override
   {
     sjsu::SystemController::GetPlatformController().PowerUpPeripheral(
         sjsu::lpc40xx::SystemController::Peripherals::kAdc);

--- a/library/L1_Peripheral/lpc40xx/can.hpp
+++ b/library/L1_Peripheral/lpc40xx/can.hpp
@@ -287,7 +287,7 @@ class Can final : public sjsu::Can
   {
   }
 
-  Status Initialize() const override
+  Status_t Initialize() const override
   {
     /// Power on CANBUS peripheral
     auto & platform = sjsu::SystemController::GetPlatformController();

--- a/library/L1_Peripheral/lpc40xx/dac.hpp
+++ b/library/L1_Peripheral/lpc40xx/dac.hpp
@@ -50,7 +50,7 @@ class Dac final : public sjsu::Dac
   ///        not be changed from its default.
   explicit constexpr Dac(const sjsu::Pin & pin = kDacPin) : dac_pin_(pin) {}
   /// Initialize DAC hardware, enable dac Pin, initial Bias level set to 0.
-  Status Initialize() const override
+  Status_t Initialize() const override
   {
     static constexpr uint8_t kDacMode = 0b010;
     dac_pin_.SetPinFunction(kDacMode);

--- a/library/L1_Peripheral/lpc40xx/eeprom.hpp
+++ b/library/L1_Peripheral/lpc40xx/eeprom.hpp
@@ -27,7 +27,7 @@ class Eeprom final : public sjsu::Storage
   static constexpr bit::Mask kAddressMask = bit::CreateMaskFromRange(0, 1);
 
   /// Masks for the program status bits and read/write status bits
-  struct Status  // NOLINT
+  struct Status_t  // NOLINT
   {
     /// Mask to get value of programming status bit
     static constexpr bit::Mask kProgramStatusMask =
@@ -56,7 +56,7 @@ class Eeprom final : public sjsu::Storage
 
   /// Initializing the EEPROM requires setting the wait state register, setting
   /// the clock divider register, and ensuring that the device is powered on.
-  sjsu::Status Initialize() override
+  sjsu::Status_t Initialize() override
   {
     const float kSystemClock = static_cast<float>(
         sjsu::SystemController::GetPlatformController().GetSystemFrequency());
@@ -91,13 +91,13 @@ class Eeprom final : public sjsu::Storage
     return true;
   }
 
-  sjsu::Status Enable() override
+  sjsu::Status_t Enable() override
   {
     eeprom_register->PWRDWN = 0;
     return sjsu::Status::kSuccess;
   }
 
-  sjsu::Status Disable() override
+  sjsu::Status_t Disable() override
   {
     eeprom_register->PWRDWN = 1;
     return sjsu::Status::kSuccess;
@@ -118,12 +118,12 @@ class Eeprom final : public sjsu::Storage
     return 4_B;
   }
 
-  sjsu::Status Erase(uint32_t, size_t) override
+  sjsu::Status_t Erase(uint32_t, size_t) override
   {
     return sjsu::Status::kSuccess;
   }
 
-  sjsu::Status Write(uint32_t address, const void * data, size_t size) override
+  sjsu::Status_t Write(uint32_t address, const void * data, size_t size) override
   {
     constexpr bit::Mask kLower6Bits = bit::CreateMaskFromRange(0, 5);
     constexpr bit::Mask kUpper6Bits = bit::CreateMaskFromRange(6, 11);
@@ -182,7 +182,7 @@ class Eeprom final : public sjsu::Storage
     return sjsu::Status::kSuccess;
   }
 
-  sjsu::Status Read(uint32_t address, void * data, size_t size) override
+  sjsu::Status_t Read(uint32_t address, void * data, size_t size) override
   {
     address = bit::Insert(address, 0b00, kAddressMask);
 

--- a/library/L1_Peripheral/lpc40xx/pulse_capture.hpp
+++ b/library/L1_Peripheral/lpc40xx/pulse_capture.hpp
@@ -209,7 +209,7 @@ class PulseCapture final : public sjsu::PulseCapture
   /// This METHOD MUST BE EXECUTED before any other method can be called.
   /// Powers on the peripheral, configures the timer pins.
   /// See page 687 of the user manual UM10562 LPC408x/407x for more details.
-  Status Initialize(CaptureCallback callback   = nullptr,
+  Status_t Initialize(CaptureCallback callback   = nullptr,
                     int32_t interrupt_priority = -1) const override
   {
     // NOTE: Same initialization as Timer library's Initialize()

--- a/library/L1_Peripheral/lpc40xx/pwm.hpp
+++ b/library/L1_Peripheral/lpc40xx/pwm.hpp
@@ -179,7 +179,7 @@ class Pwm final : public sjsu::Pwm
   /// @param channel - Reference to a const channel description for this
   ///        instance of the PWM driver.
   explicit constexpr Pwm(const Channel_t & channel) : channel_(channel) {}
-  Status Initialize(units::frequency::hertz_t frequency_hz) const override
+  Status_t Initialize(units::frequency::hertz_t frequency_hz) const override
   {
     SJ2_ASSERT_FATAL(1 <= channel_.channel && channel_.channel <= 6,
                      "Channel must be between 1 and 6 on LPC40xx platforms.");

--- a/library/L1_Peripheral/lpc40xx/spi.hpp
+++ b/library/L1_Peripheral/lpc40xx/spi.hpp
@@ -73,7 +73,7 @@ class Spi final : public sjsu::Spi
     /// Setting this bit to 1 will enable spi slave mode.
     static constexpr bit::Mask kSlaveModeBit = bit::CreateMaskFromRange(2);
   };
-  /// SSPn Status Register
+  /// SSPn Status_t Register
   struct StatusRegister  // NOLINT
   {
     /// This bit is 0 if the SSPn controller is idle, or 1 if it is currently
@@ -181,7 +181,7 @@ class Spi final : public sjsu::Spi
   /// Powers on the peripheral, activates the SSP pins and enables the SSP
   /// peripheral.
   /// See page 601 of user manual UM10562 LPC408x/407x for more details.
-  Status Initialize() const override
+  Status_t Initialize() const override
   {
     constexpr uint8_t kSpiFormatCode = 0b00;
 

--- a/library/L1_Peripheral/lpc40xx/timer.hpp
+++ b/library/L1_Peripheral/lpc40xx/timer.hpp
@@ -82,7 +82,7 @@ class Timer final : public sjsu::Timer
   /// peripheral to be used with this object
   explicit constexpr Timer(const Peripheral_t & timer) : timer_(timer) {}
 
-  Status Initialize(units::frequency::hertz_t frequency,
+  Status_t Initialize(units::frequency::hertz_t frequency,
                     InterruptCallback callback = nullptr,
                     int32_t priority           = -1) const override
   {

--- a/library/L1_Peripheral/lpc40xx/uart.hpp
+++ b/library/L1_Peripheral/lpc40xx/uart.hpp
@@ -291,7 +291,7 @@ class Uart final : public sjsu::Uart
   /// @param port - a reference to a constant lpc40xx::Uart::Port_t definition
   explicit constexpr Uart(const Port_t & port) : port_(port) {}
 
-  Status Initialize(uint32_t baud_rate) const override
+  Status_t Initialize(uint32_t baud_rate) const override
   {
     constexpr uint8_t kFIFOEnableAndReset = 0b111;
     sjsu::SystemController::GetPlatformController().PowerUpPeripheral(

--- a/library/L1_Peripheral/lpc40xx/watchdog.hpp
+++ b/library/L1_Peripheral/lpc40xx/watchdog.hpp
@@ -30,7 +30,7 @@ class Watchdog final : public sjsu::Watchdog
   {
   }
 
-  Status Initialize(std::chrono::seconds duration) const override
+  Status_t Initialize(std::chrono::seconds duration) const override
   {
     constexpr units::frequency::hertz_t kWatchdogClockDivider   = 4_Hz;
     constexpr units::frequency::hertz_t kWatchdogClockFrequency = 500_kHz;

--- a/library/L1_Peripheral/pulse_capture.hpp
+++ b/library/L1_Peripheral/pulse_capture.hpp
@@ -35,7 +35,7 @@ class PulseCapture
   };
 
   /// Initialize timer for capturing
-  virtual Status Initialize(CaptureCallback isr        = nullptr,
+  virtual Status_t Initialize(CaptureCallback isr        = nullptr,
                             int32_t interrupt_priority = -1) const = 0;
 
   /// Select edge type to capture on

--- a/library/L1_Peripheral/pwm.hpp
+++ b/library/L1_Peripheral/pwm.hpp
@@ -21,7 +21,7 @@ class Pwm
   /// method in this interface is called.
   ///
   /// @param frequency - starting frequency of PWM waveform
-  virtual Status Initialize(units::frequency::hertz_t frequency) const = 0;
+  virtual Status_t Initialize(units::frequency::hertz_t frequency) const = 0;
   /// Set output pulse width to following duty cycle.
   ///
   /// @param duty_cycle - duty cycle precent from 0 to 1. Where 0.5 would be a

--- a/library/L1_Peripheral/spi.hpp
+++ b/library/L1_Peripheral/spi.hpp
@@ -42,7 +42,7 @@ class Spi
 
   /// Initialize and enable hardware. This must be called before any other
   /// method in this interface is called.
-  virtual Status Initialize() const = 0;
+  virtual Status_t Initialize() const = 0;
   /// Send a value via SPI and receive a value back from the serial port
   ///
   /// @param data - transfer data to external device via spi port

--- a/library/L1_Peripheral/storage.hpp
+++ b/library/L1_Peripheral/storage.hpp
@@ -41,7 +41,7 @@ class Storage
   /// media possible.
   /// MUST be called before calling any method in this interface with the
   /// exception of `GetMemoryType()`
-  virtual sjsu::Status Initialize() = 0;
+  virtual Status_t Initialize() = 0;
 
   /// @return true if the storage is present. For cases where the memory cannot
   /// be removed or is physically located within a device, this should always
@@ -51,10 +51,10 @@ class Storage
 
   /// Should prepare and configure the storage media for communication such as
   /// Write(), Read(), Erase()
-  virtual sjsu::Status Enable() = 0;
+  virtual Status_t Enable() = 0;
 
   /// Should shutdown the device.
-  virtual sjsu::Status Disable() = 0;
+  virtual Status_t Disable() = 0;
 
   /// @return true if device is not writable.
   virtual bool IsReadOnly() = 0;
@@ -78,7 +78,7 @@ class Storage
   /// @param blocks_count - the number of bytes to erase.
   /// @return Status of if the operation was successful, otherwise, returns an
   /// appropriate status signal.
-  virtual sjsu::Status Erase(uint32_t block_address, size_t blocks_count) = 0;
+  virtual Status_t Erase(uint32_t block_address, size_t blocks_count) = 0;
 
   /// Write data to the storage media in the location block specified. If the
   /// block size for this media is not 1 byte, then single byte is not allowed
@@ -93,7 +93,7 @@ class Storage
   ///               the size of a block.
   /// @return Status of if the operation was successful, otherwise, returns an
   /// appropriate status signal.
-  virtual sjsu::Status Write(uint32_t block_address,
+  virtual Status_t Write(uint32_t block_address,
                              const void * data,
                              size_t size) = 0;
 
@@ -105,7 +105,7 @@ class Storage
   ///               the size of a block.
   /// @return Status of if the operation was successful, otherwise, return an
   /// appropriate status signal.
-  virtual sjsu::Status Read(uint32_t block_address,
+  virtual Status_t Read(uint32_t block_address,
                             void * data,
                             size_t size) = 0;
 };

--- a/library/L1_Peripheral/system_timer.hpp
+++ b/library/L1_Peripheral/system_timer.hpp
@@ -40,6 +40,6 @@ class SystemTimer
   ///
   /// @return Status::kSuccess if the system timer started correctly. Otherwise,
   ///         the exact status is implementation dependent.
-  virtual Status StartTimer() const = 0;
+  virtual Status_t StartTimer() const = 0;
 };
 }  // namespace sjsu

--- a/library/L1_Peripheral/timer.hpp
+++ b/library/L1_Peripheral/timer.hpp
@@ -48,7 +48,7 @@ class Timer
   ///        SetTimer method has occurred.
   /// @param priority - sets the Timer interrupt's priority level, defaults to
   ///        -1 which uses the platforms default priority.
-  virtual Status Initialize(units::frequency::hertz_t counter_frequency,
+  virtual Status_t Initialize(units::frequency::hertz_t counter_frequency,
                             InterruptCallback callback = nullptr,
                             int32_t priority           = -1) const = 0;
 

--- a/library/L1_Peripheral/uart.hpp
+++ b/library/L1_Peripheral/uart.hpp
@@ -23,7 +23,7 @@ class Uart
   /// method in this interface is called.
   ///
   /// @param baud_rate - set the communication speed
-  virtual Status Initialize(uint32_t baud_rate) const = 0;
+  virtual Status_t Initialize(uint32_t baud_rate) const = 0;
 
   /// Set UART baud rate
   ///
@@ -118,7 +118,7 @@ class Uart
   /// @return sjsu::Status::kSuccess if bytes were read before timeout.
   /// @return sjsu::Status::kTimeout if bytes could not be read before before
   ///         timeout.
-  sjsu::Status Read(void * data,
+  sjsu::Status_t Read(void * data,
                     size_t size,
                     std::chrono::nanoseconds timeout) const
   {

--- a/library/L1_Peripheral/watchdog.hpp
+++ b/library/L1_Peripheral/watchdog.hpp
@@ -22,7 +22,7 @@ class Watchdog
   /// @param interval - feeding interval. Not feeding the watch dog in this
   ///        time will result in the system restarting.
   /// @return status indicating the failure type for the watchdog.
-  virtual Status Initialize(std::chrono::seconds interval) const = 0;
+  virtual Status_t Initialize(std::chrono::seconds interval) const = 0;
 
   /// Enables the watchdog. After this point, the watch dog must be feed before
   /// the interval duration is exceeded, otherwise the system will restart.

--- a/library/L2_HAL/communication/esp8266.hpp
+++ b/library/L2_HAL/communication/esp8266.hpp
@@ -48,7 +48,7 @@ class Esp8266 : public InternetSocket, public WiFi
 
   /// Tests that the ESP8266 can respond to commands.
   /// @return Status::kTimeout if it could not.
-  Status TestModule()
+  Status_t TestModule()
   {
     WifiWrite("AT\r\n");
     return ConvertReadUntilToStatus(ReadUntil(kOk));
@@ -65,7 +65,7 @@ class Esp8266 : public InternetSocket, public WiFi
     ReadUntil<1024>("\r\n\r\nready\r\n", kDefaultLongTimeout);
   }
 
-  Status Initialize() override
+  Status_t Initialize() override
   {
     uart_port_.Initialize(baud_rate_);
     uart_port_.Flush();
@@ -83,7 +83,7 @@ class Esp8266 : public InternetSocket, public WiFi
     return TestModule();
   }
 
-  Status ConnectToAccessPoint(
+  Status_t ConnectToAccessPoint(
       std::string_view ssid,
       std::string_view password,
       std::chrono::nanoseconds read_timeout = kDefaultLongTimeout) override
@@ -103,7 +103,7 @@ class Esp8266 : public InternetSocket, public WiFi
         ReadUntil("WIFI GOT IP\r\n\r\nOK\r\n", read_timeout));
   }
 
-  Status DisconnectFromAccessPoint() override
+  Status_t DisconnectFromAccessPoint() override
   {
     WifiWrite("AT+CWQAP\r\n");
     return ConvertReadUntilToStatus(ReadUntil(kOk));
@@ -120,7 +120,7 @@ class Esp8266 : public InternetSocket, public WiFi
   }
 
   /// @param mode - Which mode to put the ESP8266 WiFi module into.
-  Status SetMode(WifiMode mode)
+  Status_t SetMode(WifiMode mode)
   {
     std::array<char, 32> command_buffer;
 
@@ -142,7 +142,7 @@ class Esp8266 : public InternetSocket, public WiFi
   /// @param channel_id - which wifi channel to use
   /// @param security - password security of the access point
   /// @return Status
-  Status ConfigureAccessPoint(std::string_view ssid,
+  Status_t ConfigureAccessPoint(std::string_view ssid,
                               std::string_view password,
                               uint8_t channel_id,
                               AccessPointSecurity security)
@@ -167,7 +167,7 @@ class Esp8266 : public InternetSocket, public WiFi
   struct IpAddress_t
   {
     /// A status indicating if the IP Address is valid.
-    Status status = Status::kDeviceNotFound;
+    Status_t status = Status::kDeviceNotFound;
 
     /// Contains each digit of the IPv4 address
     std::array<uint8_t, 4> data;
@@ -224,7 +224,7 @@ class Esp8266 : public InternetSocket, public WiFi
   // ===========================================================================
   // InternetProtocol
   // ===========================================================================
-  Status Connect(Protocol protocol,
+  Status_t Connect(Protocol protocol,
                  std::string_view address,
                  uint16_t port,
                  std::chrono::nanoseconds timeout) override
@@ -253,7 +253,7 @@ class Esp8266 : public InternetSocket, public WiFi
   /// HTTP requests and send back responses.
   ///
   /// @param port - which port should be used for the server
-  Status Bind(uint16_t port = 333)
+  Status_t Bind(uint16_t port = 333)
   {
     WifiWrite("AT+CIPMUX=1\r\n");
     ReadUntil(kOk);
@@ -274,7 +274,7 @@ class Esp8266 : public InternetSocket, public WiFi
     return false;
   }
 
-  Status Write(const void * data,
+  Status_t Write(const void * data,
                size_t size,
                std::chrono::nanoseconds timeout) override
   {
@@ -326,7 +326,7 @@ class Esp8266 : public InternetSocket, public WiFi
     uint8_t * byte_buffer = reinterpret_cast<uint8_t *>(buffer);
     bytes_to_read         = std::min(size - position, received_bytes);
 
-    Status status = uart_port_.Read(
+    Status_t status = uart_port_.Read(
         &byte_buffer[position], bytes_to_read, timer.GetTimeLeft());
 
     if (!IsOk(status))
@@ -339,7 +339,7 @@ class Esp8266 : public InternetSocket, public WiFi
     return position;
   }
 
-  Status Close() override
+  Status_t Close() override
   {
     WifiWrite("AT+CIPCLOSE\r\n");
     return ConvertReadUntilToStatus(ReadUntil(kOk));
@@ -454,7 +454,7 @@ class Esp8266 : public InternetSocket, public WiFi
     return length;
   }
 
-  Status ConvertReadUntilToStatus(int result)
+  Status_t ConvertReadUntilToStatus(int result)
   {
     if (result != -1)
     {

--- a/library/L2_HAL/communication/infrared_receiver.hpp
+++ b/library/L2_HAL/communication/infrared_receiver.hpp
@@ -18,7 +18,7 @@ class InfraredReceiver
       std::function<void(const infrared::DataFrame_t *)>;
   /// Initialize and enable hardware. This must be called before any other
   /// method in this interface is called.
-  virtual Status Initialize() = 0;
+  virtual Status_t Initialize() = 0;
   /// Sets the callback handler that is invoked when a data frame is received.
   ///
   /// @param handler Callback handler to invoke.

--- a/library/L2_HAL/communication/internet_socket.hpp
+++ b/library/L2_HAL/communication/internet_socket.hpp
@@ -37,7 +37,7 @@ class InternetSocket
   ///         timeout.
   /// @return Status::kSuccess if this function is successful.
   /// @return Can potentially return any other status.
-  virtual Status Connect(Protocol protocol,
+  virtual Status_t Connect(Protocol protocol,
                          std::string_view address,
                          uint16_t port,
                          std::chrono::nanoseconds timeout) = 0;
@@ -52,7 +52,7 @@ class InternetSocket
   ///         timeout.
   /// @return Status::kSuccess if this function is successful.
   /// @return Can potentially return any other status.
-  virtual Status Write(const void * data,
+  virtual Status_t Write(const void * data,
                        size_t size,
                        std::chrono::nanoseconds timeout) = 0;
 
@@ -77,7 +77,7 @@ class InternetSocket
   /// @return Status::kSuccess if this function is successful.
   /// @return Status::kNotReadyYet if this was called before Connect was used.
   /// @return Can potentially return any other status.
-  virtual Status Close() = 0;
+  virtual Status_t Close() = 0;
 };
 
 /// An interface for devices that can communicate wirelessly via the Wifi
@@ -93,7 +93,7 @@ class WiFi
   {
     /// If `status` is Status::kSuccess then the fields below are correct.
     /// Otherwise, this status holds what went wrong.
-    Status status = Status::kNotImplemented;
+    Status_t status = Status::kNotImplemented;
     /// IPv4 IP address
     std::array<uint8_t, 4> ip;
     /// IPv4 IP address netmask
@@ -127,7 +127,7 @@ class WiFi
   /// Initialize the WiFi hardware and necessary peripherals needed to
   /// communicate with it.
   /// @return Any status.
-  virtual Status Initialize() = 0;
+  virtual Status_t Initialize() = 0;
 
   /// @return true - if this Wifi instance is connected to an access point
   /// @return false - it this Wifi instance is not connected to an access point
@@ -140,13 +140,13 @@ class WiFi
   /// @param timeout - Amount of time before this function should gives up.
   /// @return Status - Status::kSuccess if it is successful
   /// @return Status - Status::kTimeout if it is not successful
-  virtual Status ConnectToAccessPoint(std::string_view ssid,
+  virtual Status_t ConnectToAccessPoint(std::string_view ssid,
                                       std::string_view password,
                                       std::chrono::nanoseconds timeout) = 0;
 
   /// Disconnect from the access point.
   /// @return Status
-  virtual Status DisconnectFromAccessPoint() = 0;
+  virtual Status_t DisconnectFromAccessPoint() = 0;
 
   /// @return NetworkConnection_t - Get connection information such as IP
   ///         address.

--- a/library/L2_HAL/communication/tsop752.hpp
+++ b/library/L2_HAL/communication/tsop752.hpp
@@ -33,9 +33,9 @@ class Tsop752 final : public InfraredReceiver
   ///
   /// @return The initialization status. Returns Status::kSuccess if the driver
   ///         has been successfully initialized.
-  Status Initialize() override
+  Status_t Initialize() override
   {
-    Status status = capture_.Initialize(
+    Status_t status = capture_.Initialize(
         [this](auto capture_status) { HandlePulseCaptured(capture_status); });
     if (status != Status::kSuccess)
     {
@@ -68,7 +68,7 @@ class Tsop752 final : public InfraredReceiver
   ///   IR Receiver Output:    |__|   |__|  |__|
   ///   pulse_buffer_length: 0 1  2   3  4  5  6
   ///
-  /// @param status Status of the interrupt.
+  /// @param status Status_t of the interrupt.
   void HandlePulseCaptured(PulseCapture::CaptureStatus_t status)
   {
     timer_.Reset();

--- a/library/L2_HAL/device_memory_map.hpp
+++ b/library/L2_HAL/device_memory_map.hpp
@@ -310,7 +310,7 @@ class I2cDevice : public Device<I2cDevice<kDeviceAddress, endianess, MemoryMap>,
     payload[0] = static_cast<uint8_t>(address);
     memcpy(&payload[1], target, size);
     // Size + 1 to account for the 1-byte register address
-    Status status = i2c->Write(kDeviceAddress, payload, size + 1);
+    Status_t status = i2c->Write(kDeviceAddress, payload, size + 1);
     return (status == Status::kSuccess);
   }
 

--- a/library/L2_HAL/example.hpp
+++ b/library/L2_HAL/example.hpp
@@ -27,12 +27,12 @@ class ExampleHal
   ///    via, I2C, SPI, UART and parallel GPIO. Each implementation can be its
   ///    own implementation of the LCD interface. They would implement the
   ///    Initialize() and Write() methods for their specific peripheral.
-  virtual Status Initialize() = 0;
+  virtual Status_t Initialize() = 0;
   /// Example Write() method.
-  virtual Status Write(const uint8_t * data, size_t size) = 0;
+  virtual Status_t Write(const uint8_t * data, size_t size) = 0;
   /// 3. Define any supporting methods that use the core methods below. These
   ///    must not be virtual.
-  Status Write(std::initializer_list<uint8_t> data)
+  Status_t Write(std::initializer_list<uint8_t> data)
   {
     return Write(data.begin(), data.size());
   }
@@ -76,14 +76,14 @@ class ExampleHalImplementation : public ExampleHal
   /// 5. Implement the methods that are required as an implementaiton of the
   ///    interface. Add additional supporting methods if it makes writting these
   ///    two methods easier.
-  Status Initialize() override
+  Status_t Initialize() override
   {
-    Status example_init_status = example_.Initialize();
+    Status_t example_init_status = example_.Initialize();
     return example_init_status;
   }
-  Status Write(const uint8_t * data, size_t size) override
+  Status_t Write(const uint8_t * data, size_t size) override
   {
-    Status status = Status::kSuccess;
+    Status_t status = Status::kSuccess;
 
     if (!example_.HasCompletedAction())
     {
@@ -116,21 +116,21 @@ class ExampleSingleImplementationHal
   {
   }
   /// Example Initialize() method
-  Status Initialize()
+  Status_t Initialize()
   {
     return Status::kSuccess;
   }
   /// 7. Declare core methods of this HAL, that are used by the other supporting
   ///    methods below as virtual so that testing software can replace or spy on
   ///    this method.
-  virtual Status Write(const uint8_t * data, size_t size)
+  virtual Status_t Write(const uint8_t * data, size_t size)
   {
     example_.Write(data, size);
     return Status::kSuccess;
   }
   /// 8. Utility methods that use the core methods above should not be declare
   ///    as virtual.
-  Status Write(std::initializer_list<uint8_t> data)
+  Status_t Write(std::initializer_list<uint8_t> data)
   {
     return Write(data.begin(), data.size());
   }

--- a/library/L2_HAL/memory/sd.hpp
+++ b/library/L2_HAL/memory/sd.hpp
@@ -103,9 +103,9 @@ class Sd
     kIs18vOk    = 24,    // OCR bit 24: Switching to 1.8V is
                          // accepted (S18A)
     kIsUhs2 = 29,        // OCR bit 29: Card is UHS-II Compatible
-    kCcs    = 30,        // OCR bit 30: Card Capacity Status (used)
+    kCcs    = 30,        // OCR bit 30: Card Capacity Status_t (used)
                          // to determine if a card is SDSC or not
-    kPwrUpComplete = 31  // OCR bit 31: Card Power Up Status (i.e.
+    kPwrUpComplete = 31  // OCR bit 31: Card Power Up Status_t (i.e.
                          // if card has finished the power cycle
                          // process)
   };
@@ -613,7 +613,7 @@ class Sd
                                          sd.response.data.byte,
                                          KeepAlive::kYes);
             sjsu::LogDebug(
-                "Checking Status Register to see cause of Write Error...");
+                "Checking Status_t Register to see cause of Write Error...");
             sjsu::LogDebug("[R2 Response: 0x%04" PRIX32 "]",
                            sd.response.data.dWord.lo);
           }

--- a/library/L2_HAL/sensors/distance/distance_sensor.hpp
+++ b/library/L2_HAL/sensors/distance/distance_sensor.hpp
@@ -19,18 +19,18 @@ class DistanceSensor
  public:
   /// Initialize distance sensor hardware. Must be called before running any
   /// other methods.
-  virtual Status Initialize() = 0;
+  virtual Status_t Initialize() = 0;
 
   /// Trigger a capture of the current distance reading and return it.
   ///
   /// @param distance - output parameter to contain the distance results.
-  virtual Status GetDistance(units::length::millimeter_t * distance) = 0;
+  virtual Status_t GetDistance(units::length::millimeter_t * distance) = 0;
 
   /// Get the signal strength from the distance sensor.
   ///
   /// @param strength - output parameter to contain the strength of the system.
   ///        The exact value
   /// @return Status
-  virtual Status GetSignalStrengthPercent(float * strength) = 0;
+  virtual Status_t GetSignalStrengthPercent(float * strength) = 0;
 };
 }  // namespace sjsu

--- a/library/L2_HAL/sensors/distance/time_of_flight/tfmini.hpp
+++ b/library/L2_HAL/sensors/distance/time_of_flight/tfmini.hpp
@@ -85,10 +85,10 @@ class TFMini final : public DistanceSensor
   ///
   /// @returns Status::kBusError if initialization fails
   /// @returns Status::kSuccess if initialization succeeds
-  Status Initialize() override
+  Status_t Initialize() override
   {
     constexpr uint32_t kBaudRate = 115200;
-    Status init_success          = uart_pin_.Initialize(kBaudRate);
+    Status_t init_success          = uart_pin_.Initialize(kBaudRate);
 
     if (IsOk(init_success))
     {
@@ -114,7 +114,7 @@ class TFMini final : public DistanceSensor
   /// @returns Status::kDeviceNotFound if device is not recognized
   /// @returns Status::kBusError if data read from device is inconsistent
   /// @returns Status::kSuccess if device is successfully read from
-  Status GetDistance(units::length::millimeter_t * distance) override
+  Status_t GetDistance(units::length::millimeter_t * distance) override
   {
     std::array<uint8_t, kDeviceDataLength> device_data = { 0 };
 
@@ -151,7 +151,7 @@ class TFMini final : public DistanceSensor
   /// @returns Status::kDeviceNotFound if device is not recognized
   /// @returns Status::kBusError if data read from device is inconsistent
   /// @returns Status::kSuccess if device is successfully read from
-  Status GetSignalStrengthPercent(float * strength) override
+  Status_t GetSignalStrengthPercent(float * strength) override
   {
     std::array<uint8_t, kDeviceDataLength> device_data = { 0 };
 
@@ -188,7 +188,7 @@ class TFMini final : public DistanceSensor
   ///
   /// @returns Status::kBusError if updating the TFMini fails
   /// @returns Status::kSuccess if device is successfully updated
-  Status SetMinSignalThreshhold(uint8_t lower_threshold = 20)
+  Status_t SetMinSignalThreshhold(uint8_t lower_threshold = 20)
   {
     constexpr uint8_t kUpdateMinThresholdCommand[kCommandLength] = {
       0x42, 0x57, 0x02, 0x00, 0xEE, 0x00, 0x00, 0x20

--- a/library/L2_HAL/sensors/environment/light/temt6000x01.hpp
+++ b/library/L2_HAL/sensors/environment/light/temt6000x01.hpp
@@ -30,7 +30,7 @@ class Temt6000x01 final : public LightSensor
   /// Initializes the ADC driver.
   ///
   /// @return The initialization status.
-  Status Initialize() const override
+  Status_t Initialize() const override
   {
     return adc_.Initialize();
   }

--- a/library/L2_HAL/sensors/environment/light_sensor.hpp
+++ b/library/L2_HAL/sensors/environment/light_sensor.hpp
@@ -13,7 +13,7 @@ class LightSensor
   /// method in this interface is called.
   ///
   /// @return The initialization status.
-  virtual Status Initialize() const = 0;
+  virtual Status_t Initialize() const = 0;
   /// @return The sensor reading in units of lux.
   virtual units::illuminance::lux_t GetIlluminance() const = 0;
   /// @return The maximum illuminance reading supported by the device.

--- a/library/L2_HAL/sensors/environment/temperature/si7060.hpp
+++ b/library/L2_HAL/sensors/environment/temperature/si7060.hpp
@@ -45,9 +45,9 @@ class Si7060 final : public TemperatureSensor
   /// Initializes the I2C peripheral to enable the device for use.
   ///
   /// @return The initialization status.
-  Status Initialize() const override
+  Status_t Initialize() const override
   {
-    Status status;
+    Status_t status;
 
     status = i2c_.Initialize();
     if (status != Status::kSuccess)
@@ -73,7 +73,7 @@ class Si7060 final : public TemperatureSensor
   /// @param temperature Output parameter.
   /// @return Returns Status::kSuccess if the temperature measurement was
   ///         successfully obtained.
-  Status GetTemperature(
+  Status_t GetTemperature(
       units::temperature::celsius_t * temperature) const override
   {
     // Note that: 1 << 14 = 2^14 = 16384

--- a/library/L2_HAL/sensors/environment/temperature/tmp102.hpp
+++ b/library/L2_HAL/sensors/environment/temperature/tmp102.hpp
@@ -54,7 +54,7 @@ class Tmp102 final : public TemperatureSensor
   /// Initializes the I2C peripheral to enable the device for use.
   ///
   /// @return The initialization status.
-  Status Initialize() const override
+  Status_t Initialize() const override
   {
     return i2c_.Initialize();
   }
@@ -63,7 +63,7 @@ class Tmp102 final : public TemperatureSensor
   /// @param temperature Output parameter.
   /// @return Returns Status::kSuccess if the temperature measurement was
   ///         successfully obtained.
-  Status GetTemperature(
+  Status_t GetTemperature(
       units::temperature::celsius_t * temperature) const override
   {
     OneShotShutdown();

--- a/library/L2_HAL/sensors/environment/temperature_sensor.hpp
+++ b/library/L2_HAL/sensors/environment/temperature_sensor.hpp
@@ -13,14 +13,14 @@ class TemperatureSensor
   /// method in this interface is called.
   ///
   /// @return The initialization status.
-  virtual Status Initialize() const = 0;
+  virtual Status_t Initialize() const = 0;
   /// Retrieves the temperature reading and writes the value to the designated
   /// memory address.
   ///
   /// @param temperature Output parameter.
   /// @return Returns Status::kSuccess if the temperature measurement was
   ///         successfully obtained.
-  virtual Status GetTemperature(
+  virtual Status_t GetTemperature(
       units::temperature::celsius_t * temperature) const = 0;
 };
 }  // namespace sjsu

--- a/library/L2_HAL/sensors/movement/accelerometer/mma8452q.hpp
+++ b/library/L2_HAL/sensors/movement/accelerometer/mma8452q.hpp
@@ -15,7 +15,7 @@ class Mma8452q : public Accelerometer
   enum RegisterAddress : uint8_t
   {
     /// Device status register address
-    kStatus = 0x00,
+    kStatus_t = 0x00,
     /// Register address of the the first byte of the X axis
     kX = 0x01,
     /// Register address of the the first byte of the Y axis

--- a/library/utility/log.hpp
+++ b/library/utility/log.hpp
@@ -252,7 +252,7 @@ LogError(const char * format, Params...)->LogError<Params...>;
 #define LOG_ON_FAILURE(expression)                              \
   do                                                            \
   {                                                             \
-    sjsu::Status log_on_failure_status = (expression);          \
+    sjsu::Status_t log_on_failure_status = (expression);          \
     if (log_on_failure_status != sjsu::Status::kSuccess)        \
     {                                                           \
       ::sjsu::LogWarning("Expression Failed: %s", #expression); \

--- a/library/utility/status.hpp
+++ b/library/utility/status.hpp
@@ -1,45 +1,210 @@
 #pragma once
 
+#include <cinttypes>
+#include <limits>
+#include <string_view>
+
+#if defined(__clang_analyzer__)
+#include "utility/dummy/source_location"
+#else
+#include <experimental/source_location>
+#endif
+
+#include "utility/debug.hpp"
+#include "third_party/expected/include/tl/expected.hpp"
+
+#define SJ2_RETURN_ON_ERROR(expression)       \
+  ({                                          \
+    auto _result = (expression);              \
+    if (!_result)                             \
+    {                                         \
+      return tl::unexpected(_result.error()); \
+    }                                         \
+    _result.value();                          \
+  })
+
+#define SJ2_RETURN_ON_ERROR_VOID(expression)  \
+  {                                           \
+    auto _result = (expression);              \
+    if (!_result)                             \
+    {                                         \
+      return tl::unexpected(_result.error()); \
+    }                                         \
+  }
+
 namespace sjsu
 {
-/// Status error codes returned by functions throughout the SJSU-Dev2 code base.
-enum class Status
+/// Status_t error codes returned by functions throughout the SJSU-Dev2 code
+/// base.
+struct Status_t
 {
-  kSuccess,
-  kTimedOut,
-  kBusError,
-  kDeviceNotFound,
-  kInvalidSettings,
-  kNotImplemented,
-  kNotReadyYet,
-  kInvalidParameters,
-  kUnfinished,
-  kUnknown,
-};
-/// @param status - the status code to convert to a string
-/// @return a string representation of the status code.
-constexpr const char * Stringify(Status status)
-{
-  const char * result = "Unsupported Status";
-  switch (status)
+  /// The status code number
+  int code = std::numeric_limits<int>::max();
+  /// The string representation of the status.
+  std::string_view name = "Unknown";
+
+  bool operator!() const
   {
-    case Status::kSuccess: result = "Success"; break;
-    case Status::kTimedOut: result = "Timed Out"; break;
-    case Status::kBusError: result = "Bus Error"; break;
-    case Status::kDeviceNotFound: result = "Device Not Found"; break;
-    case Status::kNotImplemented: result = "Not Implemented"; break;
-    case Status::kInvalidSettings: result = "Invalid Settings"; break;
-    case Status::kUnfinished: result = "Unfinished"; break;
-    case Status::kUnknown: result = "Unknown"; break;
-    default: break;
+    return code != 0;
   }
-  return result;
+
+  bool operator==(const Status_t & status) const
+  {
+    return status.code == code;
+  }
+
+  bool operator!=(const Status_t & status) const
+  {
+    return status.code == code;
+  }
+};
+
+/// Factory object that is used to simplify the creation of status objects.
+///
+/// @tparam kCode - The status code
+template <size_t kCode>
+class CreateStatus : public Status_t
+{
+ public:
+  /// Constructs the Status_t parent with the status_name as its name and the
+  /// kCode template parameter as its status code.
+  ///
+  /// @param status_name - string to represent the name of the status.
+  constexpr CreateStatus(std::string_view status_name)
+  {
+    code = kCode;
+    name = status_name;
+  }
+
+  bool operator!() const
+  {
+    return code != 0;
+  }
+
+  bool operator==(const Status_t & status) const
+  {
+    return status.code == code;
+  }
+
+  bool operator!=(const Status_t & status) const
+  {
+    return status.code == code;
+  }
+};
+
+namespace Status
+{
+/// [[deprecated]] A status indicating that the operation was successful.
+/// This is deprecated in ErrorHandling v2 as there is no longer a need for a
+/// non-error like status code.
+constexpr auto kSuccess = CreateStatus<0>("Success");
+
+/// Used to indicate that a particular operation could not be accomplished in
+/// the time given.
+constexpr auto kTimedOut = CreateStatus<1>("Timed Out");
+
+/// A problem in communicate over a communication channel occurred, resulting in
+/// an operation failing.
+constexpr auto kBusError = CreateStatus<2>("Bus Error");
+
+/// Failure occurred because an operation required a device to be present, and
+/// it was not.
+constexpr auto kDeviceNotFound = CreateStatus<3>("Device Not Found");
+
+/// A system or object failed to perform an operation due to the fact that the
+/// settings are not correct. An example of this could be setting the clock
+/// speed of a system to 0 Hz, and then attempting to use that system for
+/// communication or generating a signal.
+constexpr auto kInvalidSettings = CreateStatus<4>("Invalid Settings");
+
+/// This is returned when the implementation of a particular aspect of an
+/// interface was purposefully kept unimplemented. This can happen in cases
+/// where a particular implementation, does not have the capability to perform
+constexpr auto kNotImplemented = CreateStatus<5>("Not Implemented");
+
+/// This is returned if a system is currently busy and cannot take new
+/// operations or requests.
+constexpr auto kNotReadyYet = CreateStatus<6>("Not Ready Yet");
+
+/// Failure to perform an operation because the input parameters were not
+/// acceptable for the function or method being called.
+constexpr auto kInvalidParameters = CreateStatus<7>("Invalid Parameters");
+
+/// Unfinished is returned when a particular aspect of an implementation of a
+/// system, class or object is unfinished, but is planned to be finished. This
+/// is different from kNotImplemented, where there is no plan to ever implement
+/// a particular feature.
+constexpr auto kUnfinished = CreateStatus<8>("Unfinished");
+};  // namespace Status
+
+// TODO(): Remove this once full migration has occurred.
+/// @return true - if the status is a successful one.
+constexpr bool IsOk(const Status_t & status)
+{
+  return status.code == Status::kSuccess.code;
 }
 
-/// @param status - status to check
-/// @return true if the status is equal to kSuccess.
-constexpr bool IsOk(Status status)
+struct Error_t
 {
-  return status == Status::kSuccess;
+  /// Represents an empty string
+  constexpr static std::string_view kEmptyMessage = "";
+
+  /// Constructs the Error_t object
+  ///
+  /// @param status   - status code to go with this error object
+  /// @param message  - message to go with error to describe exactly why the
+  ///                   error occurred.
+  /// @param location - the location in the source code where the Error_t was
+  ///                   created.
+  constexpr Error_t(Status_t status,
+                    std::string_view message = kEmptyMessage,
+                    const std::experimental::source_location & location =
+                        std::experimental::source_location::current())
+      : status_(status), message_(message), location_(location)
+  {
+    // TODO(): BRING THESE BACK
+    // if constexpr (config::kStoreMessage)
+    // {
+    //   message_ = message;
+    // }
+    // if constexpr (config::kAutoExceptionPrint)
+    // {
+    //   print();
+    // }
+    print();
+  }
+
+  void print()
+  {
+    printf(SJ2_BOLD_YELLOW "Error:" SJ2_HI_BOLD_RED "%s(%d)" SJ2_HI_BOLD_WHITE
+                           ":%s:%" PRIuLEAST32 ":%s(): " SJ2_COLOR_RESET,
+           status_.name.data(), status_.code, location_.file_name(),
+           location_.line(), location_.function_name());
+    if (kEmptyMessage != message_)
+    {
+      printf("%s", message_.data());
+    }
+    printf(SJ2_HI_BOLD_WHITE "\nBacktrace:" SJ2_COLOR_RESET);
+    int depth = 0;
+    _Unwind_Backtrace(&debug::PrintAddressInRow, &depth);
+    puts("");
+  }
+
+  Status_t status_;
+  std::string_view message_ = kEmptyMessage;
+  const std::experimental::source_location location_;
+};
+
+constexpr tl::unexpected<Error_t> Error(
+    Status_t status,
+    std::string_view message = Error_t::kEmptyMessage,
+    const std::experimental::source_location & location =
+        std::experimental::source_location::current())
+{
+  return tl::unexpected(Error_t{ status, message, location });
 }
+
+template <typename T>
+using Returns = tl::expected<T, Error_t>;
+
 }  // namespace sjsu

--- a/library/utility/time.hpp
+++ b/library/utility/time.hpp
@@ -46,8 +46,8 @@ inline void SetUptimeFunction(UptimeFunction uptime_function)
 ///        return true.
 /// @param is_done will be run in a tight loop until it returns true or the
 ///        timeout time has elapsed.
-inline Status Wait(std::chrono::nanoseconds timeout,
-                   std::function<bool()> is_done)
+inline Status_t Wait(std::chrono::nanoseconds timeout,
+                          std::function<bool()> is_done)
 {
   std::chrono::nanoseconds timeout_time;
   if (timeout == std::chrono::nanoseconds::max())
@@ -77,23 +77,22 @@ inline Status Wait(std::chrono::nanoseconds timeout,
     }
   }
 
-  Status status = Status::kTimedOut;
   while (Uptime() <= timeout_time)
   {
     if (is_done())
     {
-      status = Status::kSuccess;
-      break;
+      return {};
     }
   }
-  return status;
+
+  return Status::kTimedOut;
 }
 
 /// Overload of `Wait` that merely takes a timeout.
 ///
 /// @param timeout - the amount of time to wait.
 /// @return always returns Status::kTimedOut
-inline Status Wait(std::chrono::nanoseconds timeout)
+inline Status_t Wait(std::chrono::nanoseconds timeout)
 {
   return Wait(timeout, []() -> bool { return false; });
 }

--- a/library/utility/timeout_timer.hpp
+++ b/library/utility/timeout_timer.hpp
@@ -12,7 +12,7 @@ namespace sjsu
 ///
 /// Example Usage:
 ///
-///   Status GetWaterLevel(std::chrono::nanoseconds timeout)
+///   Status_t GetWaterLevel(std::chrono::nanoseconds timeout)
 ///   {
 ///     // Construct TimeoutTimer with the given timeout above. Lets assume it
 ///     // is 1 second.
@@ -20,7 +20,7 @@ namespace sjsu
 ///     // An example device that takes time to perform its operations.
 ///     WaterLevelDevice water_level;
 ///     // Reusable status variable
-///     Status status;
+///     Status_t status;
 ///
 ///     // In this case, we give the remaining time left for calibration
 ///     // operation. Lets assume that the time is still around 1 second. The


### PR DESCRIPTION
Integrates the latest implementation of error handling into SJSU-Dev2
and refactored all files to use the flexible Status_t object rather
than the old Status enum class.

The code is somewhat reverse compatible besides the fact that the
Status object is now named Status_t. Migration to the Returns<> method
of error handling will happen in phases through out the code base.

Resolves #1120