### PR TITLE
Integrate Error Handling V2

### DIFF
--- a/demos/multiplatform/log_level_print/source/main.cpp
+++ b/demos/multiplatform/log_level_print/source/main.cpp
@@ -19,9 +19,6 @@ void PrintLogDescription(int a)
       "something possibly going wrong in the program.");
   sjsu::LogError(
       "Error messages should alert the user or developer of a possible error.");
-  sjsu::LogError(
-      "Critical messages should always be shown and typically occur when a "
-      "fatal error has occurred during the runtime of the program.");
 }
 
 int main()
@@ -32,7 +29,6 @@ int main()
   sjsu::LogInfo("This is an info message.");
   sjsu::LogWarning("This is an warning message.");
   sjsu::LogError("This is an error message.");
-  sjsu::LogError("This is an critical message.");
 
   PrintLogDescription(5);
   return 0;

--- a/demos/multiplatform/status/makefile
+++ b/demos/multiplatform/status/makefile
@@ -1,0 +1,15 @@
+# sjsu_dev2.mk holds the $(SJSU_DEV2_BASE) variable which holds the location of
+# the SJSU-Dev2 folder.
+include ~/.sjsu_dev2.mk
+
+ifndef SJSU_DEV2_BASE
+$(info +-------------- SJSU-Dev2 Location file not found --------------+)
+$(info |                                                               |)
+$(info |        Run ./setup from within the SJSU-Dev2's folder         |)
+$(info |                                                               |)
+$(info +---------------------------------------------------------------+)
+$(error )
+endif
+
+# Using the directory location, include the project makefile
+include $(SJSU_DEV2_BASE)/makefile

--- a/demos/multiplatform/status/project_config.hpp
+++ b/demos/multiplatform/status/project_config.hpp
@@ -1,0 +1,14 @@
+// This file overrides the default configuration options in the
+// library/config.hpp file. Open library/config.hpp to see which configuration
+// options you can change.
+#pragma once
+#include "log_levels.hpp"
+
+#define SJ2_DESCRIPTIVE_FUNCTION_NAME true
+// Be sure to enable ANSI color for the terminal. Disable this if your terminal
+// application does not support colored text.
+#define SJ2_ENABLE_ANSI_CODES true
+// Setting this to NONESET to allow types of log level message to appear
+#define SJ2_LOG_LEVEL SJ2_LOG_LEVEL_NONESET
+
+#include "config.hpp"

--- a/demos/multiplatform/status/source/main.cpp
+++ b/demos/multiplatform/status/source/main.cpp
@@ -1,0 +1,103 @@
+#include "utility/status.hpp"
+#include "utility/log.hpp"
+
+namespace
+{
+using sjsu::Error;
+using sjsu::Returns;
+using sjsu::Status;
+}  // namespace
+
+// Example code that will return an error if invalid input is given.
+Returns<int> CalculatePllCode(int frequency)
+{
+  int code = 0;
+
+  switch (frequency)
+  {
+    case 1: code = 0b001; break;
+    case 2: code = 0b100; break;
+    case 4: code = 0b011; break;
+    case 8: code = 0b111; break;
+    case 16: code = 0b101; break;
+    case 32: code = 0b010; break;
+    default:
+      // When creating an error give it a reasonable status and a helpful
+      // message to the user.
+      return Error(Status::kInvalidParameters,
+                   "Frequency must be 1, 2, 4, 8, 16, 32 megahertz.");
+  }
+
+  return code * 2;
+}
+
+// Just a demonstration, even though this never returns an error.
+// Refrain from using `Returns<T>` objects if the function never
+// returns an error
+Returns<const char *> GetName()
+{
+  return "this is a test string to demonstrate nesting!";
+}
+
+// A function that returns a void type. In this case you simply need to return
+// an empty object by doing this `return {}`.
+Returns<void> SetPllCode(int code)
+{
+  // Dummy example of setting a register to the correct code
+  int reg = code;
+
+  // this code doesn't do anyting meaningful, but will fail if this code was
+  // detected.
+  if (reg == (0b101 * 2))
+  {
+    return Error(Status::kTimedOut, "CPU speed could not stabilize in time.");
+  }
+
+  return {};
+}
+
+// This function will attempt to set the cpu of a system, but will return
+// early with an error if it detects at any stage there is one. The idea
+// here is that this function does not concern itself with handlling the
+// error, but simply doing its job and reporting problems if they occur. Now
+// its up to the calling function to decide what to do at that stage.
+Returns<int> GetPllCodeForFrequency(int frequency)
+{
+  // Will return early if there is an error resulting from the
+  // CalculatePllCode() function call.
+  int pll_code = SJ2_RETURN_ON_ERROR(CalculatePllCode(frequency));
+
+  // Give result to another function and verify that it complets
+  SJ2_RETURN_ON_ERROR(SetPllCode(pll_code));
+
+  // Can be nested within other statements and still return early if
+  // the function returns an error.
+  sjsu::LogDebug("Nested result = %s", SJ2_RETURN_ON_ERROR(GetName()));
+  sjsu::LogDebug("Successfully Got Pll Code!");
+
+  return pll_code;
+}
+
+int main()
+{
+  // Run a function that could possibly return an error
+  // NOTE: You cannot use `SJ2_RETURN_ON_ERROR()` macro here because `main()`
+  // has an `int` return type but not a `Returns<int>` object, thus using it
+  // here will generate an error.
+
+  // Change the input to 4, to see this work without any errors.
+  // Change the input to 5, to see this application return an error.
+  // Change the input to 16, to see the void function fail.
+  auto result = GetPllCodeForFrequency(5);
+
+  // Check if the result has an error
+  if (!result)
+  {
+    sjsu::LogError("Getting PLL Code Failed!\n");
+    // Error handling would go here...
+    return 111;
+  }
+
+  sjsu::LogInfo("Success! Final PLL Code = %d\n", result.value());
+  return 0;
+}

--- a/demos/sjtwo/i2c/source/main.cpp
+++ b/demos/sjtwo/i2c/source/main.cpp
@@ -41,10 +41,9 @@ int main()
 
     uint8_t id = 0;
 
-    status = i2c.WriteThenRead(
-        kAccelerometerAddress, &kAccelerometerIdRegister, 1, &id, 1);
-    sjsu::LogInfo("I2C transaction Status = 0x%02X",
-                  static_cast<uint8_t>(status));
+    status = i2c.WriteThenRead(kAccelerometerAddress, &kAccelerometerIdRegister,
+                               1, &id, 1);
+    sjsu::LogInfo("I2C transaction Status = 0x%02X", status.code);
     sjsu::LogInfo("Accelerometer ID = 0x%02X", id);
 
     sjsu::LogInfo("Waiting 5s before starting the scan again...");

--- a/library/config.hpp
+++ b/library/config.hpp
@@ -54,7 +54,6 @@
 #include "log_levels.hpp"
 #include "utility/units.hpp"
 
-
 namespace config
 {
 /// @defgroup config_group Configuration
@@ -177,7 +176,10 @@ SJ2_DECLARE_CONSTANT(TASK_SCHEDULER_SIZE, uint8_t, kTaskSchedulerSize);
 /// Delcare Constant ESP8266_BUFFER_SIZE
 SJ2_DECLARE_CONSTANT(ESP8266_BUFFER_SIZE, size_t, kEsp8266BufferSize);
 
-/// Used to define the log level of the build
+/// Used to define the log level of the build. The log level will determine
+/// which logs will show up and which won't. For example, if the log level is
+/// set to "warning" then "info", "debug" will not show up, but "warning" and
+/// above will show up.
 #if !defined(SJ2_LOG_LEVEL)
 #define SJ2_LOG_LEVEL SJ2_LOG_LEVEL_INFO
 #endif  // !defined(SJ2_LOG_LEVEL)
@@ -185,20 +187,32 @@ SJ2_DECLARE_CONSTANT(ESP8266_BUFFER_SIZE, size_t, kEsp8266BufferSize);
 SJ2_DECLARE_CONSTANT(LOG_LEVEL, uint8_t, kLogLevel);
 
 static_assert(kLogLevel == SJ2_LOG_LEVEL_NONESET ||
-              kLogLevel == SJ2_LOG_LEVEL_DEBUG ||
-              kLogLevel == SJ2_LOG_LEVEL_INFO ||
-              kLogLevel == SJ2_LOG_LEVEL_WARNING ||
-              kLogLevel == SJ2_LOG_LEVEL_ERROR,
+                  kLogLevel == SJ2_LOG_LEVEL_DEBUG ||
+                  kLogLevel == SJ2_LOG_LEVEL_INFO ||
+                  kLogLevel == SJ2_LOG_LEVEL_WARNING ||
+                  kLogLevel == SJ2_LOG_LEVEL_ERROR,
               "SJ2_LOG_LEVEL must equal to one of the predefined log levels "
               "such as SJ2_LOG_LEVEL_INFO.");
 
-/// If set to true, will display function name in LOG_* function calls.
-/// Otherwise omit writing function names.
-#if !defined(SJ2_DESCRIPTIVE_FUNCTION_NAME)
-#define SJ2_DESCRIPTIVE_FUNCTION_NAME true
-#endif  // !defined(SJ2_DESCRIPTIVE_FUNCTION_NAME)
-/// Delcare Constant DESCRIPTIVE_FUNCTION_NAME
-SJ2_DECLARE_CONSTANT(DESCRIPTIVE_FUNCTION_NAME, bool, kDescriptiveFunctionName);
+/// If true, will store error messages into error objects. Setting this to false
+/// will reduce your binary size when using any optimization setting above O0,
+/// as the compiler will deduce that the strings are not being used, and remove
+/// them from the binary.
+#if !defined(SJ2_STORE_ERROR_MESSAGE)
+#define SJ2_STORE_ERROR_MESSAGE true
+#endif  // !defined(SJ2_STORE_ERROR_MESSAGE)
+/// Delcare Constant STORE_ERROR_MESSAGE
+SJ2_DECLARE_CONSTANT(STORE_ERROR_MESSAGE, bool, kStoreErrorMessages);
+
+/// If true, will automatically print errors that occur in the system along with
+/// a stacktrace from when the error occurred.
+#if !defined(SJ2_AUTOMATICALLY_PRINT_ON_ERROR)
+#define SJ2_AUTOMATICALLY_PRINT_ON_ERROR true
+#endif  // !defined(SJ2_AUTOMATICALLY_PRINT_ON_ERROR)
+/// Delcare Constant AUTOMATICALLY_PRINT_ON_ERROR
+SJ2_DECLARE_CONSTANT(AUTOMATICALLY_PRINT_ON_ERROR,
+                     bool,
+                     kAutomaticallyPrintOnError);
 
 /// Enable or disable float support in printf statements. Setting to false will
 /// reduce binary size.
@@ -224,7 +238,6 @@ SJ2_DECLARE_CONSTANT(DESCRIPTIVE_FUNCTION_NAME, bool, kDescriptiveFunctionName);
 #define SJ2_PRINTF_SUPPORT_PTRDIFF_T true
 #endif  // !defined(PRINTF_SUPPORT_PTRDIFF_T)
 
-
 /// Enables FLOAT support for the 3rd party printf library.
 #if SJ2_PRINTF_SUPPORT_FLOAT == false
 #define PRINTF_DISABLE_SUPPORT_FLOAT
@@ -238,4 +251,3 @@ SJ2_DECLARE_CONSTANT(DESCRIPTIVE_FUNCTION_NAME, bool, kDescriptiveFunctionName);
 #define PRINTF_DISABLE_SUPPORT_PTRDIFF_T
 #endif
 }  // namespace config
-

--- a/library/third_party/expected/include/tl/expected.hpp
+++ b/library/third_party/expected/include/tl/expected.hpp
@@ -16,6 +16,9 @@
 #ifndef TL_EXPECTED_HPP
 #define TL_EXPECTED_HPP
 
+// SJSU-Dev2: ignore warnings in this file
+#pragma GCC system_header
+
 #define TL_EXPECTED_VERSION_MAJOR 1
 #define TL_EXPECTED_VERSION_MINOR 0
 #define TL_EXPECTED_VERSION_PATCH 1
@@ -400,7 +403,7 @@ using is_copy_assignable_or_void =
 template <class T>
 using is_move_assignable_or_void =
     is_void_or<T, std::is_move_assignable<T>>;
-    
+
 
 } // namespace detail
 
@@ -1225,9 +1228,9 @@ class expected : private detail::expected_move_assign_base<T, E>,
   static_assert(!std::is_reference<E>::value, "E must not be a reference");
 
   T *valptr() { return std::addressof(this->m_val); }
-  const T *valptr() const { return std::addressof(this->m_val); }    
+  const T *valptr() const { return std::addressof(this->m_val); }
   unexpected<E> *errptr() { return std::addressof(this->m_unexpect); }
-  const unexpected<E> *errptr() const { return std::addressof(this->m_unexpect); }    
+  const unexpected<E> *errptr() const { return std::addressof(this->m_unexpect); }
 
   template <class U = T,
             detail::enable_if_t<!std::is_void<U>::value> * = nullptr>
@@ -1525,7 +1528,7 @@ public:
     if (rhs.has_value()) {
       this->construct(*rhs);
     } else {
-      this->construct_error(rhs.error());        
+      this->construct_error(rhs.error());
     }
   }
 
@@ -1540,8 +1543,8 @@ public:
     if (rhs.has_value()) {
       this->construct(*rhs);
     } else {
-      this->construct_error(rhs.error());        
-    }      
+      this->construct_error(rhs.error());
+    }
   }
 
   template <
@@ -1554,8 +1557,8 @@ public:
     if (rhs.has_value()) {
       this->construct(std::move(*rhs));
     } else {
-      this->construct_error(std::move(rhs.error()));        
-    }            
+      this->construct_error(std::move(rhs.error()));
+    }
   }
 
     template <
@@ -1568,8 +1571,8 @@ public:
     if (rhs.has_value()) {
       this->construct(std::move(*rhs));
     } else {
-      this->construct_error(std::move(rhs.error()));        
-    }                  
+      this->construct_error(std::move(rhs.error()));
+    }
   }
 
   template <
@@ -1991,7 +1994,7 @@ constexpr auto and_then_impl(Exp &&exp, F &&f) -> Ret {
 
 #ifdef TL_EXPECTED_CXX14
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,          
+          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>(),
                                               *std::declval<Exp>())),
           detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
@@ -2003,7 +2006,7 @@ constexpr auto expected_map_impl(Exp &&exp, F &&f) {
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,          
+          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>(),
                                               *std::declval<Exp>())),
           detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
@@ -2028,7 +2031,7 @@ constexpr auto expected_map_impl(Exp &&exp, F &&f) {
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,          
+          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>())),
           detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
 auto expected_map_impl(Exp &&exp, F &&f) {
@@ -2039,10 +2042,10 @@ auto expected_map_impl(Exp &&exp, F &&f) {
   }
 
   return result(unexpect, std::forward<Exp>(exp).error());
-}    
+}
 #else
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,          
+          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>(),
                                               *std::declval<Exp>())),
           detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
@@ -2057,7 +2060,7 @@ constexpr auto expected_map_impl(Exp &&exp, F &&f)
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,                    
+          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>(),
                                               *std::declval<Exp>())),
           detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
@@ -2072,7 +2075,7 @@ auto expected_map_impl(Exp &&exp, F &&f) -> expected<void, err_t<Exp>> {
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,                              
+          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>())),
           detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
 
@@ -2085,7 +2088,7 @@ constexpr auto expected_map_impl(Exp &&exp, F &&f)
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,                                        
+          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>())),
           detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
 
@@ -2096,13 +2099,13 @@ auto expected_map_impl(Exp &&exp, F &&f) -> expected<void, err_t<Exp>> {
   }
 
   return unexpected<err_t<Exp>>(std::forward<Exp>(exp).error());
-}    
+}
 #endif
 
 #if defined(TL_EXPECTED_CXX14) && !defined(TL_EXPECTED_GCC49) &&               \
     !defined(TL_EXPECTED_GCC54) && !defined(TL_EXPECTED_GCC55)
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,          
+          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>(),
                                               std::declval<Exp>().error())),
           detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
@@ -2114,7 +2117,7 @@ constexpr auto map_error_impl(Exp &&exp, F &&f) {
                                                std::forward<Exp>(exp).error()));
 }
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,                    
+          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>(),
                                               std::declval<Exp>().error())),
           detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
@@ -2128,7 +2131,7 @@ auto map_error_impl(Exp &&exp, F &&f) {
   return result(unexpect, monostate{});
 }
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,          
+          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>(),
                                               std::declval<Exp>().error())),
           detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
@@ -2140,7 +2143,7 @@ constexpr auto map_error_impl(Exp &&exp, F &&f) {
                                                std::forward<Exp>(exp).error()));
 }
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,                    
+          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>(),
                                               std::declval<Exp>().error())),
           detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
@@ -2152,10 +2155,10 @@ auto map_error_impl(Exp &&exp, F &&f) {
 
   detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
   return result(unexpect, monostate{});
-}    
+}
 #else
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,                              
+          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>(),
                                               std::declval<Exp>().error())),
           detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
@@ -2170,7 +2173,7 @@ constexpr auto map_error_impl(Exp &&exp, F &&f)
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,                                        
+          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>(),
                                               std::declval<Exp>().error())),
           detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
@@ -2185,7 +2188,7 @@ auto map_error_impl(Exp &&exp, F &&f) -> expected<exp_t<Exp>, monostate> {
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,                              
+          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>(),
                                               std::declval<Exp>().error())),
           detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
@@ -2200,7 +2203,7 @@ constexpr auto map_error_impl(Exp &&exp, F &&f)
 }
 
 template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,                                        
+          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(detail::invoke(std::declval<F>(),
                                               std::declval<Exp>().error())),
           detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
@@ -2212,7 +2215,7 @@ auto map_error_impl(Exp &&exp, F &&f) -> expected<exp_t<Exp>, monostate> {
 
   detail::invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
   return result(unexpect, monostate{});
-}    
+}
 #endif
 
 #ifdef TL_EXPECTED_CXX14

--- a/library/third_party/printf/printf.h
+++ b/library/third_party/printf/printf.h
@@ -32,7 +32,7 @@
 #ifndef _PRINTF_H_
 #define _PRINTF_H_
 
-// SJSU-Dev2:
+// SJSU-Dev2: ignore warnings in this file
 #pragma GCC system_header
 
 #include <stdarg.h>

--- a/library/utility/dummy/source_location
+++ b/library/utility/dummy/source_location
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 
 namespace std::experimental

--- a/library/utility/status.hpp
+++ b/library/utility/status.hpp
@@ -1,45 +1,291 @@
 #pragma once
 
+#include <cinttypes>
+#include <limits>
+#include <string_view>
+
+#if defined(__clang_analyzer__)
+#include "utility/dummy/source_location"
+#else
+#include <experimental/source_location>
+#endif
+
+#include "utility/debug.hpp"
+#include "third_party/expected/include/tl/expected.hpp"
+
 namespace sjsu
 {
-/// Status error codes returned by functions throughout the SJSU-Dev2 code base.
-enum class Status
+struct Status;
+
+struct Status_t
 {
-  kSuccess,
-  kTimedOut,
-  kBusError,
-  kDeviceNotFound,
-  kInvalidSettings,
-  kNotImplemented,
-  kNotReadyYet,
-  kInvalidParameters,
-  kUnfinished,
-  kUnknown,
-};
-/// @param status - the status code to convert to a string
-/// @return a string representation of the status code.
-constexpr const char * Stringify(Status status)
-{
-  const char * result = "Unsupported Status";
-  switch (status)
+  /// The status code number
+  int code = -1;
+  /// The string representation of the status.
+  std::string_view name = "Unknown";
+  constexpr Status_t(int status_code, std::string_view status_name)
+      : code(status_code), name(status_name)
   {
-    case Status::kSuccess: result = "Success"; break;
-    case Status::kTimedOut: result = "Timed Out"; break;
-    case Status::kBusError: result = "Bus Error"; break;
-    case Status::kDeviceNotFound: result = "Device Not Found"; break;
-    case Status::kNotImplemented: result = "Not Implemented"; break;
-    case Status::kInvalidSettings: result = "Invalid Settings"; break;
-    case Status::kUnfinished: result = "Unfinished"; break;
-    case Status::kUnknown: result = "Unknown"; break;
-    default: break;
   }
-  return result;
+
+  bool operator!() const
+  {
+    return code != 0;
+  }
+};
+
+constexpr Status_t CreateStatus(int status_code, std::string_view status_name)
+{
+  return Status_t{ status_code, status_name };
 }
 
-/// @param status - status to check
-/// @return true if the status is equal to kSuccess.
-constexpr bool IsOk(Status status)
+/// Status error codes returned by functions throughout the SJSU-Dev2 code
+/// base.
+struct Status
 {
-  return status == Status::kSuccess;
+  /// The status code number
+  int code = -1;
+  /// The string representation of the status.
+  std::string_view name = "Unknown";
+
+  constexpr Status() {}
+  /// Factory object that is used to simplify the creation of status objects.
+  ///
+  /// @param code - The status code
+  /// @param status_name - string to represent the name of the status.
+  constexpr Status(int status_code, std::string_view status_name)
+      : code(status_code), name(status_name)
+  {
+  }
+
+  /// Factory object that is used to simplify the creation of status objects.
+  ///
+  /// @param code - The status code
+  /// @param status_name - string to represent the name of the status.
+  constexpr Status(const Status_t & status)  // NOLINT
+      : code(status.code), name(status.name)
+  {
+  }
+  constexpr Status(const Status_t && status)  // NOLINT
+      : code(status.code), name(status.name)
+  {
+  }
+
+  constexpr Status operator=(const Status_t & status)
+  {
+    code = status.code;
+    name = status.name;
+    return *this;
+  }
+  constexpr Status operator=(const Status_t && status)
+  {
+    code = status.code;
+    name = status.name;
+    return *this;
+  }
+
+  bool operator!() const
+  {
+    return code != 0;
+  }
+
+  explicit operator int() const
+  {
+    return static_cast<int>(code);
+  }
+  explicit operator uint8_t() const
+  {
+    return static_cast<uint8_t>(code);
+  }
+  explicit operator uint16_t() const
+  {
+    return static_cast<uint16_t>(code);
+  }
+  explicit operator uint32_t() const
+  {
+    return static_cast<uint32_t>(code);
+  }
+
+  /// [[deprecated]] A status indicating that the operation was successful.
+  /// This is deprecated in ErrorHandling v2 as there is no longer a need for a
+  /// non-error like status code.
+  static constexpr auto kSuccess = CreateStatus(0, "Success");
+
+  /// Used to indicate that a particular operation could not be accomplished in
+  /// the time given.
+  static constexpr auto kTimedOut = CreateStatus(1, "Timed Out");
+
+  /// A problem in communicate over a communication channel occurred, resulting
+  /// in an operation failing.
+  static constexpr auto kBusError = CreateStatus(2, "Bus Error");
+
+  /// Failure occurred because an operation required a device to be present, and
+  /// it was not.
+  static constexpr auto kDeviceNotFound = CreateStatus(3, "Device Not Found");
+
+  /// A system or object failed to perform an operation due to the fact that the
+  /// settings are not correct. An example of this could be setting the clock
+  /// speed of a system to 0 Hz, and then attempting to use that system for
+  /// communication or generating a signal.
+  static constexpr auto kInvalidSettings = CreateStatus(4, "Invalid Settings");
+
+  /// This is returned when the implementation of a particular aspect of an
+  /// interface was purposefully kept unimplemented. This can happen in cases
+  /// where a particular implementation, does not have the capability to perform
+  static constexpr auto kNotImplemented = CreateStatus(5, "Not Implemented");
+
+  /// This is returned if a system is currently busy and cannot take new
+  /// operations or requests.
+  static constexpr auto kNotReadyYet = CreateStatus(6, "Not Ready Yet");
+
+  /// Failure to perform an operation because the input parameters were not
+  /// acceptable for the function or method being called.
+  static constexpr auto kInvalidParameters =
+      CreateStatus(7, "Invalid Parameters");
+
+  /// Unfinished is returned when a particular aspect of an implementation of a
+  /// system, class or object is unfinished, but is planned to be finished. This
+  /// is different from kNotImplemented, where there is no plan to ever
+  /// implement a particular feature.
+  static constexpr auto kUnfinished = CreateStatus(8, "Unfinished");
+};
+
+constexpr bool operator==(const Status & rhs, const Status & lhs)
+{
+  return rhs.code == lhs.code;
 }
+
+constexpr bool operator!=(const Status & rhs, const Status & lhs)
+{
+  return rhs.code != lhs.code;
+}
+
+constexpr bool operator==(const Status_t & rhs, const Status & lhs)
+{
+  return rhs.code == lhs.code;
+}
+
+constexpr bool operator!=(const Status_t & rhs, const Status & lhs)
+{
+  return rhs.code != lhs.code;
+}
+
+// TODO(): Remove this once full migration has occurred.
+/// @return true - if the status is a successful one.
+constexpr bool IsOk(const Status & status)
+{
+  return status.code == Status::kSuccess.code;
+}
+
+constexpr int Value(const Status & status)
+{
+  return status.code;
+}
+
+constexpr const char * Stringify(const Status & status)
+{
+  return status.name.data();
+}
+
+struct Error_t
+{
+  /// Represents an empty string
+  constexpr static std::string_view kEmptyMessage = "";
+
+  /// Constructs the Error_t object
+  ///
+  /// @param status   - status code to go with this error object
+  /// @param message  - message to go with error to describe exactly why the
+  ///                   error occurred.
+  /// @param location - the location in the source code where the Error_t was
+  ///                   created.
+  constexpr Error_t(Status error_status,
+                    std::string_view error_message = kEmptyMessage,
+                    const std::experimental::source_location & source_location =
+                        std::experimental::source_location::current())
+      : status(error_status), message(error_message), location(source_location)
+  {
+    // TODO(): BRING THESE BACK
+    // if constexpr (config::kStoreMessage)
+    // {
+    //   message_ = message;
+    // }
+    // if constexpr (config::kAutoExceptionPrint)
+    // {
+    //   print();
+    // }
+  }
+
+  void Print()
+  {
+    printf(SJ2_BOLD_YELLOW "Error:" SJ2_HI_BOLD_RED "%s(%d)" SJ2_HI_BOLD_WHITE
+                           ":%s:%" PRIuLEAST32 ":%s(): " SJ2_COLOR_RESET,
+           status.name.data(), status.code, location.file_name(),
+           location.line(), location.function_name());
+    if (kEmptyMessage != message)
+    {
+      printf("%s", message.data());
+    }
+    printf(SJ2_HI_BOLD_WHITE "\nBacktrace:" SJ2_COLOR_RESET);
+    int depth = 0;
+    _Unwind_Backtrace(&debug::PrintAddressInRow, &depth);
+    puts("");
+  }
+
+  Status status;
+  std::string_view message = kEmptyMessage;
+  std::experimental::source_location location;
+};
+
+constexpr tl::unexpected<Error_t> Error(
+    Status status,
+    std::string_view message = Error_t::kEmptyMessage,
+    const std::experimental::source_location & location =
+        std::experimental::source_location::current())
+{
+  return tl::unexpected(Error_t{ status, message, location });
+}
+
+template <typename T>
+using Returns = tl::expected<T, Error_t>;
+
+///
+///
+/// @tparam T
+/// @param a
+/// @return T
+template <typename T>
+constexpr T GetReturnValue(Returns<T> & a)
+{
+  return a.value();
+}
+
+///
+///
+/// @tparam T
+/// @param a
+/// @return const T
+template <typename T>
+constexpr const T GetReturnValue(const Returns<T> & a)
+{
+  return a.value();
+}
+
+/// In the special case where the return value is void, we return an int 0
+/// to allow the SJ2_RETURN_ON_ERROR() macro to continue to work.
+constexpr int GetReturnValue(Returns<void> &)
+{
+  return 0;
+}
+
+#define SJ2_RETURN_ON_ERROR(expression)       \
+  ({                                          \
+    auto _result = (expression);              \
+    if (!_result)                             \
+    {                                         \
+      return tl::unexpected(_result.error()); \
+    }                                         \
+    GetValue(_result);                        \
+  })
+
 }  // namespace sjsu

--- a/library/utility/status.hpp
+++ b/library/utility/status.hpp
@@ -1,3 +1,7 @@
+/// For information on how to use this library please see:
+///
+///     demos/multiplatform/status
+///
 #pragma once
 
 #include <cinttypes>
@@ -15,68 +19,89 @@
 
 namespace sjsu
 {
-struct Status;
-
+/// Parent structure of the `Status` object containing the status code as well
+/// as the status' name.
 struct Status_t
 {
   /// The status code number
-  int code = -1;
+  int code = std::numeric_limits<int>::max();
+
   /// The string representation of the status.
   std::string_view name = "Unknown";
-  constexpr Status_t(int status_code, std::string_view status_name)
-      : code(status_code), name(status_name)
-  {
-  }
 
-  bool operator!() const
+  /// Allows explicit static_cast<> conversion from Status_t to int
+  /// @return int - the error code as this type
+  explicit operator int() const
   {
-    return code != 0;
+    return code;
   }
 };
 
+/// Helper factory function for creating a Status_t at compile time. If you
+/// want to create your own status types you can do so by using this function
+/// and supplying your own status_code and status_name. It is recommend to use
+/// positive numbers for user supplied status' as the SJSU-Dev2's status's are
+/// all negative.
+///
+/// @param status_code - Number associated with the status code.
+/// @param status_name - String to represent the name of the status.
+/// @return constexpr Status_t - resulting Status_t
 constexpr Status_t CreateStatus(int status_code, std::string_view status_name)
 {
-  return Status_t{ status_code, status_name };
+  return Status_t{ .code = status_code, .name = status_name };
 }
 
-/// Status error codes returned by functions throughout the SJSU-Dev2 code
-/// base.
-struct Status
+/// A status object that indicates the type of error or exception that has
+/// occurred within the code. This object is also a container/namespace for
+/// the standard set of status's defined for SJSU-Dev2.
+struct Status : public Status_t  // NOLINT
 {
-  /// The status code number
-  int code = -1;
-  /// The string representation of the status.
-  std::string_view name = "Unknown";
-
+  /// Allows the creation of a default Status object
   constexpr Status() {}
+
   /// Factory object that is used to simplify the creation of status objects.
   ///
-  /// @param code - The status code
-  /// @param status_name - string to represent the name of the status.
+  /// @param status_code - Number associated with the status code.
+  /// @param status_name - String to represent the name of the status.
   constexpr Status(int status_code, std::string_view status_name)
-      : code(status_code), name(status_name)
   {
+    code = status_code;
+    name = status_name;
   }
 
-  /// Factory object that is used to simplify the creation of status objects.
+  /// Implicit conversion from Status_t& -> Status
   ///
-  /// @param code - The status code
-  /// @param status_name - string to represent the name of the status.
+  /// @param status - the status to copy
   constexpr Status(const Status_t & status)  // NOLINT
-      : code(status.code), name(status.name)
   {
-  }
-  constexpr Status(const Status_t && status)  // NOLINT
-      : code(status.code), name(status.name)
-  {
+    code = status.code;
+    name = status.name;
   }
 
+  /// Implicit conversion from Status_t&& -> Status
+  ///
+  /// @param status - the status to copy
+  constexpr Status(const Status_t && status)  // NOLINT
+  {
+    code = status.code;
+    name = status.name;
+  }
+
+  /// Implicit assignment from Status_t& -> Status
+  ///
+  /// @param status
+  /// @return constexpr Status
   constexpr Status operator=(const Status_t & status)
   {
     code = status.code;
     name = status.name;
     return *this;
   }
+
+  /// Implicit assignment from Status_t&& -> Status
+  ///
+  /// @param status
+  /// @return constexpr Status
   constexpr Status operator=(const Status_t && status)
   {
     code = status.code;
@@ -84,159 +109,177 @@ struct Status
     return *this;
   }
 
-  bool operator!() const
-  {
-    return code != 0;
-  }
-
-  explicit operator int() const
-  {
-    return static_cast<int>(code);
-  }
-  explicit operator uint8_t() const
-  {
-    return static_cast<uint8_t>(code);
-  }
-  explicit operator uint16_t() const
-  {
-    return static_cast<uint16_t>(code);
-  }
-  explicit operator uint32_t() const
-  {
-    return static_cast<uint32_t>(code);
-  }
-
-  /// [[deprecated]] A status indicating that the operation was successful.
-  /// This is deprecated in ErrorHandling v2 as there is no longer a need for a
-  /// non-error like status code.
+  /// A status indicating that the operation was successful.
+  /// This is deprecated in ErrorHandling v2 as there is no longer a need for
+  /// a non-error like status code.
   static constexpr auto kSuccess = CreateStatus(0, "Success");
 
-  /// Used to indicate that a particular operation could not be accomplished in
-  /// the time given.
-  static constexpr auto kTimedOut = CreateStatus(1, "Timed Out");
+  /// Used to indicate that a particular operation could not be accomplished
+  /// in the time given.
+  static constexpr auto kTimedOut = CreateStatus(-1, "Timed Out");
 
-  /// A problem in communicate over a communication channel occurred, resulting
-  /// in an operation failing.
-  static constexpr auto kBusError = CreateStatus(2, "Bus Error");
+  /// A problem in communicate over a communication channel occurred,
+  /// resulting in an operation failing.
+  static constexpr auto kBusError = CreateStatus(-2, "Bus Error");
 
-  /// Failure occurred because an operation required a device to be present, and
-  /// it was not.
-  static constexpr auto kDeviceNotFound = CreateStatus(3, "Device Not Found");
+  /// Failure occurred because an operation required a device to be present,
+  /// and it was not.
+  static constexpr auto kDeviceNotFound = CreateStatus(-3, "Device Not Found");
 
-  /// A system or object failed to perform an operation due to the fact that the
-  /// settings are not correct. An example of this could be setting the clock
-  /// speed of a system to 0 Hz, and then attempting to use that system for
-  /// communication or generating a signal.
-  static constexpr auto kInvalidSettings = CreateStatus(4, "Invalid Settings");
+  /// A system or object failed to perform an operation due to the fact that
+  /// the settings are not correct. An example of this could be setting the
+  /// clock speed of a system to 0 Hz, and then attempting to use that system
+  /// for communication or generating a signal.
+  static constexpr auto kInvalidSettings = CreateStatus(-4, "Invalid Settings");
 
   /// This is returned when the implementation of a particular aspect of an
   /// interface was purposefully kept unimplemented. This can happen in cases
-  /// where a particular implementation, does not have the capability to perform
-  static constexpr auto kNotImplemented = CreateStatus(5, "Not Implemented");
+  /// where a particular implementation, does not have the capability to
+  /// perform
+  static constexpr auto kNotImplemented = CreateStatus(-5, "Not Implemented");
 
   /// This is returned if a system is currently busy and cannot take new
   /// operations or requests.
-  static constexpr auto kNotReadyYet = CreateStatus(6, "Not Ready Yet");
+  static constexpr auto kNotReadyYet = CreateStatus(-6, "Not Ready Yet");
 
   /// Failure to perform an operation because the input parameters were not
   /// acceptable for the function or method being called.
   static constexpr auto kInvalidParameters =
-      CreateStatus(7, "Invalid Parameters");
+      CreateStatus(-7, "Invalid Parameters");
 
-  /// Unfinished is returned when a particular aspect of an implementation of a
-  /// system, class or object is unfinished, but is planned to be finished. This
-  /// is different from kNotImplemented, where there is no plan to ever
+  /// Unfinished is returned when a particular aspect of an implementation of
+  /// a system, class or object is unfinished, but is planned to be finished.
+  /// This is different from kNotImplemented, where there is no plan to ever
   /// implement a particular feature.
-  static constexpr auto kUnfinished = CreateStatus(8, "Unfinished");
+  static constexpr auto kUnfinished = CreateStatus(-8, "Unfinished");
 };
 
+/// Operator == definitions between Status_t and Status objects.
+///
+/// @param rhs Status to compare
+/// @param lhs Status to compare
+/// @return true - if the error codes are the same.
 constexpr bool operator==(const Status & rhs, const Status & lhs)
 {
   return rhs.code == lhs.code;
 }
 
+/// Operator != definitions between Status_t and Status objects.
+///
+/// @param rhs Status to compare
+/// @param lhs Status to compare
+/// @return true - if the error codes are the same.
 constexpr bool operator!=(const Status & rhs, const Status & lhs)
 {
   return rhs.code != lhs.code;
 }
 
-constexpr bool operator==(const Status_t & rhs, const Status & lhs)
-{
-  return rhs.code == lhs.code;
-}
-
-constexpr bool operator!=(const Status_t & rhs, const Status & lhs)
-{
-  return rhs.code != lhs.code;
-}
-
-// TODO(): Remove this once full migration has occurred.
+/// Backwards compability for IsOK(enum) for when Status was a enum type
+///
+/// @param status - The status to check. If the code is 0, then it is ok.
 /// @return true - if the status is a successful one.
 constexpr bool IsOk(const Status & status)
 {
   return status.code == Status::kSuccess.code;
 }
 
+/// Backwards compability for Value(enum) for when Status. was a enum type
+///
+/// @param status -
+/// @return constexpr int - return the status.code
 constexpr int Value(const Status & status)
 {
   return status.code;
 }
 
-constexpr const char * Stringify(const Status & status)
+/// Backwards compatibility for Stringify(enum) for when Status. was a enum
+/// type
+///
+/// @param status
+/// @return constexpr const char*
+constexpr const char * Stringify(const Status_t & status)
 {
   return status.name.data();
 }
 
+/// Error object that contains the Status code, message and location of where an
+/// error occurred. This is the underlying error type of SJSU-Dev2.
 struct Error_t
 {
   /// Represents an empty string
   constexpr static std::string_view kEmptyMessage = "";
 
-  /// Constructs the Error_t object
-  ///
-  /// @param status   - status code to go with this error object
-  /// @param message  - message to go with error to describe exactly why the
-  ///                   error occurred.
-  /// @param location - the location in the source code where the Error_t was
-  ///                   created.
+  /// @param error_status   - status code to go with this error object
+  /// @param error_message  - message to go with error to describe exactly why
+  ///                         the error occurred.
+  /// @param source_location - the location in the source code where the Error_t
+  ///                          was created.
   constexpr Error_t(Status error_status,
                     std::string_view error_message = kEmptyMessage,
                     const std::experimental::source_location & source_location =
                         std::experimental::source_location::current())
-      : status(error_status), message(error_message), location(source_location)
+      : status(error_status), message(kEmptyMessage), location(source_location)
   {
-    // TODO(): BRING THESE BACK
-    // if constexpr (config::kStoreMessage)
-    // {
-    //   message_ = message;
-    // }
-    // if constexpr (config::kAutoExceptionPrint)
-    // {
-    //   print();
-    // }
+    if constexpr (config::kStoreErrorMessages)
+    {
+      message = error_message;
+    }
+    if constexpr (config::kAutomaticallyPrintOnError)
+    {
+      Print();
+      printf(SJ2_HI_BOLD_WHITE "\nBacktrace:" SJ2_COLOR_RESET);
+      int depth = 0;
+      _Unwind_Backtrace(&debug::PrintAddressInRow, &depth);
+      puts("");
+    }
   }
 
+  /// Print the error message to STDOUT
   void Print()
   {
+    /// Print the colored error text to STDOUT
     printf(SJ2_BOLD_YELLOW "Error:" SJ2_HI_BOLD_RED "%s(%d)" SJ2_HI_BOLD_WHITE
                            ":%s:%" PRIuLEAST32 ":%s(): " SJ2_COLOR_RESET,
            status.name.data(), status.code, location.file_name(),
            location.line(), location.function_name());
+
     if (kEmptyMessage != message)
     {
       printf("%s", message.data());
     }
-    printf(SJ2_HI_BOLD_WHITE "\nBacktrace:" SJ2_COLOR_RESET);
-    int depth = 0;
-    _Unwind_Backtrace(&debug::PrintAddressInRow, &depth);
-    puts("");
   }
 
+  /// The status associated with this error
   Status status;
+  /// Custom message describing the error
   std::string_view message = kEmptyMessage;
+  /// Location of where the error occurred.
   std::experimental::source_location location;
 };
 
+/// Compile time factory function for cleanly creating
+/// std::unexpected<Error_t> objects. Library code shall use this function to
+/// generate std::unexpected objects and shall not use std::unexpected
+/// directly to keep the code style consistent.
+///
+/// Usage:
+///
+///     return Error(Status::kTimeout, "Couldn't find resource in time");
+///
+/// Without this function:
+///
+///     return std::unexpected(
+///               Error_t{Status::kTimeout, "Couldn't find resource in
+///               time"});
+///
+/// @param status - The status associated with this error
+/// @param message - The custom message to go with the status
+/// @param location - Default initialized and should almost never be supplied
+/// by
+///                   the user. Will be defaulted to the location in which
+///                   this
+///                   ///                   function was called.
+/// @return constexpr tl::unexpected<Error_t>
 constexpr tl::unexpected<Error_t> Error(
     Status status,
     std::string_view message = Error_t::kEmptyMessage,
@@ -246,38 +289,50 @@ constexpr tl::unexpected<Error_t> Error(
   return tl::unexpected(Error_t{ status, message, location });
 }
 
+/// Alias for the more complex tl::expected definitions. Using
+/// std::expected<T, Error_t> should never be used in order to conform to the
+/// SJSU-Dev2 standard.
+///
+/// @tparam T - the actual, non-error, result to return from the function
 template <typename T>
 using Returns = tl::expected<T, Error_t>;
 
+/// This is a helper function for the `SJ2_RETURN_ON_ERROR()` macro to help it
+/// return the results of a `Returns<>` object.
 ///
+/// std::expected has a special case where the `value()` does not exist for
+/// void types, meaning that in that specific case, we cannot call that
+/// method. So in the place of running `value()` we return a throw away value,
+/// in this case int 0.
 ///
-/// @tparam T
-/// @param a
-/// @return T
+/// @tparam T - deduced type of the `Returns<T>` object. This value should not
+/// be
+///             supplied.
+/// @param result - the result of an expression that returns a `Returns<T>`
+///                 object.
+/// @return constexpr auto - returns 0 if the type is void, otherwise this
+/// will
+///         return the value held within the result object.
 template <typename T>
-constexpr T GetReturnValue(Returns<T> & a)
+constexpr auto GetReturnValue(Returns<T> & result)
 {
-  return a.value();
+  if constexpr (std::is_void_v<T>)
+  {
+    return 0;
+  }
+  else
+  {
+    return result.value();
+  }
 }
 
+/// A macro for simplifying the boiler plate of evaluating an expression that
+/// returns a Returns<> object. This will handle evaluating the function that
+/// returns a Returns<> object and if it is an error, it will return/bubble up
+/// the error code rather than continuing through the code. Otherwise, this
+/// macro will return the value of the result.
 ///
-///
-/// @tparam T
-/// @param a
-/// @return const T
-template <typename T>
-constexpr const T GetReturnValue(const Returns<T> & a)
-{
-  return a.value();
-}
-
-/// In the special case where the return value is void, we return an int 0
-/// to allow the SJ2_RETURN_ON_ERROR() macro to continue to work.
-constexpr int GetReturnValue(Returns<void> &)
-{
-  return 0;
-}
-
+/// Usage examples can be shown at the top of the file.
 #define SJ2_RETURN_ON_ERROR(expression)       \
   ({                                          \
     auto _result = (expression);              \
@@ -285,7 +340,6 @@ constexpr int GetReturnValue(Returns<void> &)
     {                                         \
       return tl::unexpected(_result.error()); \
     }                                         \
-    GetValue(_result);                        \
+    GetReturnValue(_result);                  \
   })
-
 }  // namespace sjsu


### PR DESCRIPTION
Integrates the latest implementation of error handling into SJSU-Dev2
and refactored all files to use the flexible Status_t object rather
than the old Status enum class.

The code is somewhat reverse compatible besides the fact that the
Status object is now named Status_t. Migration to the Returns<> method
of error handling will happen in phases through out the code base.

Resolves #1120