### PR TITLE
SD Card: Fixed issues with read & initialization

### DIFF
--- a/demos/sjtwo/sd_card_experimental/project_config.hpp
+++ b/demos/sjtwo/sd_card_experimental/project_config.hpp
@@ -2,7 +2,7 @@
 
 // Change the "#if 0" to "#if 1" below to see debug information for every
 // step of the SD card communication
-#if 0
+#if 1
 #define SJ2_LOG_LEVEL SJ2_LOG_LEVEL_DEBUG
 #endif
 


### PR DESCRIPTION
- Added padding clock cycles at the start of a command to add additional
  cycles needed for SanDisk SD cards.
- Read was broken because other SD cards reply with data token
  immediatly after getting a read command. Current SendCommand would
  acquire an extra byte which would cause the data token to be lost.
  This has been fixed.
- Fixed various bugs throughout the code where bits are not interpreted
  correctly.
- Tested on the SJTwo board using
    - PNY 64GB Elite-X V30 MicroSD
    - Samsung 32GB Evo Select 1 MicroSD
    - Kingston 32GB I1
    - SanDisk 64GB Ultra A1
    - SanDisk 8GB Edge