### PR TITLE
Fixing FreeRTOS example projects

### DIFF
--- a/demos/multiplatform/periodic_scheduler/source/main.cpp
+++ b/demos/multiplatform/periodic_scheduler/source/main.cpp
@@ -12,10 +12,10 @@ sjsu::rtos::PeriodicTaskInterface::TaskFunction task_function_10_hz =
 
 sjsu::rtos::TaskScheduler scheduler;
 sjsu::rtos::PeriodicScheduler periodic_scheduler("PeriodicScheduler");
-sjsu::rtos::PeriodicTask<512> printer_1_hz_task("Print1Hz",
+sjsu::rtos::PeriodicTask<1024> printer_1_hz_task("Print1Hz",
                                                 sjsu::rtos::Priority::kLow,
                                                 &task_function_1_hz);
-sjsu::rtos::PeriodicTask<512> printer_10_hz_task("Print10Hz",
+sjsu::rtos::PeriodicTask<1024> printer_10_hz_task("Print10Hz",
                                                  sjsu::rtos::Priority::kLow,
                                                  &task_function_10_hz);
 }  // namespace

--- a/demos/multiplatform/task_scheduler/source/main.cpp
+++ b/demos/multiplatform/task_scheduler/source/main.cpp
@@ -2,7 +2,7 @@
 #include "utility/log.hpp"
 #include "utility/rtos.hpp"
 
-class PrinterTask final : public sjsu::rtos::Task<512>
+class PrinterTask final : public sjsu::rtos::Task<1024>
 {
  public:
   PrinterTask(const char * task_name,


### PR DESCRIPTION
Increased the task's stack size from 512 bytes to 1024 bytes to allow
enough static memory for printf. Previously, the stack size of 512 did
not provide enough memory which caused a hard fault when printf is
invoked after the FreeRTOS scheduler is started.