### PR TITLE
Refactoring LPC17xx System Controller

### DIFF
--- a/demos/arm_cortex/system_timer/source/main.cpp
+++ b/demos/arm_cortex/system_timer/source/main.cpp
@@ -19,7 +19,7 @@ sjsu::SystemController::PeripheralID GetSystemTimerID()
 {
   if constexpr (sjsu::build::IsPlatform(sjsu::build::Platform::lpc17xx))
   {
-    return sjsu::lpc17xx::SystemController::Peripherals::kCpu;
+    return sjsu::lpc17xx::SystemController::Clocks::kCpu;
   }
   else if constexpr (sjsu::build::IsPlatform(sjsu::build::Platform::lpc40xx))
   {

--- a/demos/sjone/light_sensor/source/main.cpp
+++ b/demos/sjone/light_sensor/source/main.cpp
@@ -7,19 +7,16 @@ int main()
 {
   sjsu::LogInfo("Starting LPC176x/5x Light Sensor Example...");
 
-  sjsu::lpc17xx::SystemController system_controller;
-  system_controller.SetPeripheralClockDivider(
-      sjsu::lpc17xx::SystemController::Peripherals::kAdc, 8);
-  sjsu::SystemController::SetPlatformController(&system_controller);
   // The LPC176x/5x ADC has a reference voltage of 3.3V.
   constexpr units::voltage::volt_t kAdcReferenceVoltage = 3.3_V;
   // A 10kOhm pull-down resistor is used on the SJOne board.
   constexpr units::impedance::ohm_t kPullDownResistance = 10'000_Ohm;
+
   // The SJOne board uses ADC Channel 0.2, P0.25 for the light sensor
   sjsu::lpc17xx::Adc adc2(sjsu::lpc17xx::AdcChannel::kChannel2);
 
-  sjsu::Temt6000x01 light_sensor(
-      adc2, kAdcReferenceVoltage, kPullDownResistance);
+  sjsu::Temt6000x01 light_sensor(adc2, kAdcReferenceVoltage,
+                                 kPullDownResistance);
   SJ2_ASSERT_FATAL(light_sensor.Initialize() == sjsu::Status::kSuccess,
                    "Failed to initialized light sensor!");
 

--- a/demos/sjone/temperature_sensor/source/main.cpp
+++ b/demos/sjone/temperature_sensor/source/main.cpp
@@ -7,13 +7,8 @@ int main()
 {
   sjsu::LogInfo("Starting LPC176x/5x Temperature Sensor Example...");
 
-  sjsu::lpc17xx::SystemController system_controller;
-  system_controller.SetPeripheralClockDivider(
-      sjsu::lpc17xx::SystemController::Peripherals::kI2c2, 4);
-  sjsu::SystemController::SetPlatformController(&system_controller);
-
   sjsu::lpc17xx::I2c i2c2(sjsu::lpc17xx::I2cBus::kI2c2);
-  sjsu::Tmp102 temperature_sensor(i2c2, sjsu::Tmp102::DeviceAddress::kGround);
+  sjsu::Tmp102 temperature_sensor(i2c2);
   units::temperature::celsius_t temperature;
 
   SJ2_ASSERT_FATAL(temperature_sensor.Initialize() == sjsu::Status::kSuccess,

--- a/library/L1_Peripheral/lpc17xx/system_controller.hpp
+++ b/library/L1_Peripheral/lpc17xx/system_controller.hpp
@@ -1,7 +1,3 @@
-// System Controller for the LPC176x/5x series MCUs.
-// The controller allows configuration of the cpu clock speed as well as the
-// configuration of various peripheral power controls and peripheral clock
-// speeds.
 #pragma once
 
 #include "project_config.hpp"
@@ -16,70 +12,10 @@ namespace sjsu
 {
 namespace lpc17xx
 {
-/// System controller for the LPC40xx series of MCUs.
+/// System controller for the LPC17xx series of MCUs.
 class SystemController final : public sjsu::SystemController
 {
  public:
-  /// System input oscillator source select contants
-  enum class OscillatorSource : uint8_t
-  {
-    /// Internal RC oscillator as main. Not very precise oscillator cannot be
-    /// used for USB or high speed CAN.
-    kIrc = 0b00,
-    /// Use external oscillator (typically a crystal). See PllInput for options
-    /// that can be used for the oscillator.
-    kExternal = 0b01,
-    /// Use the RTC oscillator as the main oscillator, approximate 32kHz.
-    kRtc = 0b10,
-  };
-
-  /// PLL codes for selecting the PLL to be connected to a clock input
-  enum class PllSelect : uint8_t
-  {
-    /// PLL0, Main PLL code
-    kMainPll = 0,
-    /// PLL1: USB PLL code
-    kUsbPll,
-  };
-
-  /// Available frequencies of the external oscillator for use by PLL1 to
-  /// produce the required USB clock.
-  enum class UsbPllInputFrequency : uint8_t
-  {
-    kF12MHz = 0,
-    kF16MHz,
-    kF24MHz,
-  };
-
-  /// USB PLL Multiplier codes
-  enum class UsbPllMultiplier : uint8_t
-  {
-    kMultiplyBy4 = 0b0'0011,
-    kMultiplyBy3 = 0b0'0010,
-    kMultiplyBy2 = 0b0'0001,
-  };
-
-  /// USB PLL Divider codes
-  enum class UsbPllDivider : uint8_t
-  {
-    kDivideBy1 = 0b00,
-    kDivideBy2 = 0b01,
-    kDivideBy4 = 0b10,
-    kDivideBy8 = 0b11,
-  };
-
-  /// Used to hold calculated PLL settings
-  struct PllSettings_t
-  {
-    /// Multiplies the input oscillator by this amount
-    uint16_t multiplier;
-    /// Pre-divide the input source to drive the multiplier even higher.
-    uint8_t pre_divider;
-    /// Final output divider to bring the frequency down to a reasonable level
-    /// for the system.
-    uint8_t cpu_divider;
-  };
-
   /// LPC17xx Peripheral Power On Values:
   /// The kDeviceId of each peripheral corresponds to the peripheral's power on
   /// bit position within the LPC17xx System Controller's PCONP register.
@@ -117,306 +53,466 @@ class SystemController final : public sjsu::SystemController
     static constexpr auto kGpdma             = PeripheralID::Define<29>();
     static constexpr auto kEthernet          = PeripheralID::Define<30>();
     static constexpr auto kUsb               = PeripheralID::Define<31>();
-    static constexpr auto kCpu               = PeripheralID::Define<32>();
     //! @endcond
   };
 
-  /// Namespace of Oscillator register bitmasks
-  struct Oscillator  // NOLINT
+  /// LPC17xx Peripheral Clock Selection Values:
+  /// The `device_id` of each peripheral clock corresponds to the peripheral's
+  /// clock selection bit position within the LPC17xx System Controller's
+  /// PCLKSEL registers.
+  class Clocks
   {
-    /// IRC, main, or RTC oscillator select bits
-    static constexpr bit::Mask kSelect = bit::CreateMaskFromRange(0, 1);
+   public:
+    //! @cond Doxygen_Suppress
+    static constexpr auto kWdt                = PeripheralID::Define<0>();
+    static constexpr auto kTimer0             = PeripheralID::Define<1>();
+    static constexpr auto kTimer1             = PeripheralID::Define<2>();
+    static constexpr auto kUart0              = PeripheralID::Define<3>();
+    static constexpr auto kUart1              = PeripheralID::Define<4>();
+    static constexpr auto kPwm1               = PeripheralID::Define<6>();
+    static constexpr auto kI2c0               = PeripheralID::Define<7>();
+    static constexpr auto kSpi                = PeripheralID::Define<8>();
+    static constexpr auto kSsp1               = PeripheralID::Define<10>();
+    static constexpr auto kDac                = PeripheralID::Define<11>();
+    static constexpr auto kAdc                = PeripheralID::Define<12>();
+    static constexpr auto kCan1               = PeripheralID::Define<13>();
+    static constexpr auto kCan2               = PeripheralID::Define<14>();
+    static constexpr auto kAcf                = PeripheralID::Define<15>();
+    static constexpr auto kQuadratureEncoder  = PeripheralID::Define<16>();
+    static constexpr auto kGpioInt            = PeripheralID::Define<17>();
+    static constexpr auto kPowerControlBlock  = PeripheralID::Define<18>();
+    static constexpr auto kI2c1               = PeripheralID::Define<19>();
+    static constexpr auto kSsp0               = PeripheralID::Define<21>();
+    static constexpr auto kTimer2             = PeripheralID::Define<22>();
+    static constexpr auto kTimer3             = PeripheralID::Define<23>();
+    static constexpr auto kUart2              = PeripheralID::Define<24>();
+    static constexpr auto kUart3              = PeripheralID::Define<25>();
+    static constexpr auto kI2c2               = PeripheralID::Define<26>();
+    static constexpr auto kI2s                = PeripheralID::Define<27>();
+    static constexpr auto kRit                = PeripheralID::Define<29>();
+    static constexpr auto kSystemControlBlock = PeripheralID::Define<30>();
+    static constexpr auto kMotorControlPwm    = PeripheralID::Define<31>();
+    // Definitions not associated with a specific peripheral.
+    static constexpr auto kCpu = PeripheralID::Define<32>();
+    static constexpr auto kUsb = PeripheralID::Define<33>();
+    //! @endcond
   };
 
-  /// Namespace of Clock register bitmasks
-  struct CpuClock  // NOLINT
+  /// The available oscillators that can be used to drive the system clock and
+  /// subsequently the CPU clock.
+  ///
+  /// @see 4.4.1 Clock Source Select register
+  ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=36
+  enum class Oscillator : uint8_t
   {
-    /// CPU clock divider amount bitmask
-    static constexpr bit::Mask kDivider = bit::CreateMaskFromRange(0, 7);
+    /// Internal RC oscillator as main.
+    ///
+    /// @warning This oscillator is not a very precise oscillator and cannot
+    ///          be used for USB or high speed CAN > 100 kBits/s.
+    kIrc = 0b00,
+    /// The main oscillator (typically a crystal). This oscillator is connected
+    /// externally and can have a frequency raning between 1 MHz to 25 MHz.
+    kMain = 0b01,
+    /// The RTC oscillator which has a frequency of approximately 32kHz.
+    kRtc = 0b10,
   };
 
-  /// Bit masks for the Main PLL register
-  struct MainPll  // NOLINT
+  /// The available CPU clock sources.
+  enum class CpuClockSource : uint8_t
   {
-    // The following bit masks apply to the PLL0STAT and PLL0CFG registers
-    /// PLL multiplier mask
-    static constexpr bit::Mask kMultiplier = bit::CreateMaskFromRange(0, 14);
-    /// PLL Pre-divider mask
-    static constexpr bit::Mask kPreDivider = bit::CreateMaskFromRange(16, 23);
-
-    // The following bit masks only apply to the PLL0STAT register
-    /// PLL Mode control mask
-    static constexpr bit::Mask kMode = bit::CreateMaskFromRange(24, 25);
-    /// PLL Lock status bit
-    static constexpr bit::Mask kLockStatus = bit::CreateMaskFromRange(26);
+    /// Uses the system clock.
+    kSystemClock = 0b0,
+    /// Uses the PLL0 clock.
+    kPll0 = 0b1,
   };
 
-  /// Bit masks for the USB PLL register
-  struct UsbPll  // NOLINT
+  /// The available USB subsystem clock sources.
+  ///
+  /// @warning PLL0 should not be used as a source if PLL0 is driven by the
+  ///          internal oscillator as the clock signal will not be precise
+  ///          enough for the USB subsystem.
+  enum class UsbClockSource : uint8_t
   {
-    /// PLL multiplier mask
-    static constexpr bit::Mask kMultiplier = bit::CreateMaskFromRange(0, 4);
-    /// PLL Pre-divider mask
-    static constexpr bit::Mask kDivider = bit::CreateMaskFromRange(5, 6);
-    /// PLL Mode control mask
-    static constexpr bit::Mask kMode = bit::CreateMaskFromRange(8, 9);
-    /// PLL Lock status bit
-    static constexpr bit::Mask kLockStatus = bit::CreateMaskFromRange(10);
+    kPll0 = 0b0,
+    kPll1 = 0b1,
   };
 
-  /// Common bit masks across PLLs
-  struct Pll  // NOLINT
+  /// The available USB clock dividers that can be selected when the USB clock
+  /// is driven by PLL0. Since PLL0 has an output between 275 MHz to 550 MHz,
+  /// only dividers values of 6, 8, and 10 are available in order to obtain a
+  /// 48 MHz USB clock.
+  enum class UsbClockDivider : uint8_t
   {
-    /// PLL enable bit
-    static constexpr bit::Mask kEnableBit = bit::CreateMaskFromRange(0);
-    /// PLL connect/disconnect bit
-    static constexpr bit::Mask kConnectBit = bit::CreateMaskFromRange(1);
+    /// The divider to use when PLL0 is configured to output 288 MHz.
+    kDivideBy6 = 0b0101,
+    /// The divider to use when PLL0 is configured to output 384 MHz.
+    kDivideBy8 = 0b0111,
+    /// The divider to use when PLL0 is configured to output 480 MHz.
+    kDivideBy10 = 0b1001,
   };
 
-  /// Fixed IRC frequency
-  static constexpr units::frequency::hertz_t kDefaultIRCFrequency = 4_MHz;
+  /// Namespace for the Clock Source Select register (CLKSRCSEL) bit masks. The
+  /// CLKSRCSEL register is used to select the oscillator used to drive the
+  /// system clock and PLL0.
+  struct ClockSourceSelectRegister  // NOLINT
+  {
+    /// Clock source select bit mask.
+    static constexpr auto kSelectMask = bit::CreateMaskFromRange(0, 1);
+  };
 
-  /// Required frequency for the USB clock
-  static constexpr units::frequency::hertz_t kUsbClockFrequency = 48_MHz;
+  /// Namespace containing the bit masks for the System Controls and Status
+  /// register (SCS) used to configure the main oscillator.
+  struct SystemControlsRegister  // NOLINT
+  {
+    /// Main oscillator frequency range select bit mask.
+    static constexpr auto kOscillatorRangeMask = bit::CreateMaskFromRange(4);
+    /// Main oscillator enable bit mask.
+    static constexpr auto kOscillatorEnableMask = bit::CreateMaskFromRange(5);
+    /// Main oscillator status bit mask.
+    static constexpr auto kOscillatorStatusMask = bit::CreateMaskFromRange(6);
+  };
 
-  /// Fixed RTC frequency
+  /// Namespace containing definitions for PLL0 (Main PLL).
+  struct Pll0  // NOLINT
+  {
+    /// Namespace containing the bit masks for the PLL0 Configuration register
+    /// (PLL0CFG).
+    struct ConfigurationRegister  // NOLINT
+    {
+      /// PLL0 multiplier bit mask.
+      static constexpr auto kMultiplierMask = bit::CreateMaskFromRange(0, 14);
+      /// PLL0 pre-divider bit mask.
+      static constexpr auto kPreDividerMask = bit::CreateMaskFromRange(16, 23);
+    };
+
+    /// Namespace containing the bit masks for the PLL0 Status register
+    /// (PLL0STAT).
+    struct StatusRegister  // NOLINT
+    {
+      /// PLL0 multiplier bit mask.
+      static constexpr auto kMultiplierMask = bit::CreateMaskFromRange(0, 14);
+      /// PLL0 pre-divider bit mask.
+      static constexpr auto kPreDividerMask = bit::CreateMaskFromRange(16, 23);
+      /// PLL0 enable status bit mask.
+      static constexpr auto kEnableMask = bit::CreateMaskFromRange(24);
+      /// PLL0 connection status bit mask.
+      static constexpr auto kConnectMask = bit::CreateMaskFromRange(25);
+      /// PLL0 lock status bit mask.
+      static constexpr auto kLockStatusMask = bit::CreateMaskFromRange(26);
+    };
+  };
+
+  /// Namespace containing definitions for PLL1 (USB PLL).
+  struct Pll1  // NOLINT
+  {
+    /// The available PLL1 multipliers.
+    enum class Multiplier : uint8_t
+    {
+      /// The multiplier to use when the main oscillator is 12 MHz.
+      kMultiplyBy4 = 0b0'0011,
+      /// The multiplier to use when the main oscillator is 16 MHz.
+      kMultiplyBy3 = 0b0'0010,
+      /// The multiplier to use when the main oscillator is 24 MHz.
+      kMultiplyBy2 = 0b0'0001,
+    };
+
+    /// Namespace containing the bit masks for the PLL1 Configuration register
+    /// (PLL1CFG).
+    struct ConfigurationRegister  // NOLINT
+    {
+      /// PLL1 multiplier bit mask
+      static constexpr auto kMultiplierMask = bit::CreateMaskFromRange(0, 4);
+      /// PLL1 pre-divider bit mask
+      static constexpr auto kDividerMask = bit::CreateMaskFromRange(5, 6);
+    };
+
+    /// Namespace containing the bit masks for the PLL1 Status register
+    /// (PLL1STAT).
+    struct StatusRegister  // NOLINT
+    {
+      /// PLL1 multiplier bit mask
+      static constexpr auto kMultiplierMask = bit::CreateMaskFromRange(0, 4);
+      /// PLL1 pre-divider bit mask
+      static constexpr auto kDividerMask = bit::CreateMaskFromRange(5, 6);
+      /// PLL1 enable status bit mask.
+      static constexpr auto kEnableMask = bit::CreateMaskFromRange(8);
+      /// PLL1 connection status bit mask.
+      static constexpr auto kConnectMask = bit::CreateMaskFromRange(9);
+      /// PLL1 lock status bit
+      static constexpr auto kLockStatusMask = bit::CreateMaskFromRange(10);
+    };
+  };
+
+  /// Namespace containing the common bit masks for the PLL Control registers
+  /// (PLL0CON and PLL1CON).
+  struct PllControlRegister  // NOLINT
+  {
+    /// PLL enable bit mask.
+    static constexpr auto kEnableMask = bit::CreateMaskFromRange(0);
+    /// PLL connect/disconnect bit mask.
+    static constexpr auto kConnectMask = bit::CreateMaskFromRange(1);
+  };
+
+  /// Namespace containing the bit masks for the CPU Clock Configuration
+  /// register (CCLKCFG).
+  struct CpuClockRegister  // NOLINT
+  {
+    /// The 8-bit CPU clock divider bitmask.
+    static constexpr auto kDividerMask = bit::CreateMaskFromRange(0, 7);
+  };
+
+  /// Namespace containing the bit masks for the USB Clock Configuration
+  /// register (USBCLKCFG).
+  struct UsbClockRegister  // NOLINT
+  {
+    /// The 4-bit USB clock divider bitmask.
+    static constexpr auto kDividerMask = bit::CreateMaskFromRange(0, 3);
+  };
+
+  /// @see 4.1 Summary of clocking and power control functions
+  ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=31
+  struct ClockConfiguration_t
+  {
+    /// Configurations for the main oscillator. This oscillator can be used as a
+    /// clock source to drive the system clock or PLL1.
+    struct
+    {
+      /// Frequency of the main oscillator ranging between 1 MHz to 25 MHz.
+      ///
+      /// @note This value will vary and should be set based on the external
+      ///       oscillator that is being used.
+      units::frequency::hertz_t frequency = 0_MHz;
+    } main_oscillator = {};
+
+    /// Configurations for the system clock. This clock is used to drive the CPU
+    /// clock directly or as an input to PLL0 which subsequently drives the CPU
+    /// clock.
+    struct
+    {
+      /// Clock source for the system clock.
+      Oscillator clock_source = Oscillator::kIrc;
+    } system = {};
+
+    /// Configurations for PLL0 (Main PLL). The default configuration uses the
+    /// 4 MHz internal RC as the system clock source to produce a current
+    /// controlled oscillator frequency of 288 MHz.
+    struct
+    {
+      /// The 15-bit PLL0 multiplier value ranging from 6 to 512.
+      uint16_t multiplier = 36;
+      /// The 8-bit PLL0 pre-divider value ranging from 1 to 32.
+      uint8_t pre_divider = 1;
+    } pll0 = {};
+
+    /// Configurations for Pll1 (USB PLL).
+    ///
+    /// @see 4.6.9 Procedure for determining PLL1 settings
+    ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=52
+    struct
+    {
+      /// The PLL1 multiplier select.
+      Pll1::Multiplier multiplier = Pll1::Multiplier::kMultiplyBy4;
+    } pll1 = {};
+
+    /// Configurations for the CPU clock.
+    struct
+    {
+      /// Maximum allowed CPU speed. This value will be 100 MHz or 120 MHz
+      /// depending on the MCU in use.
+      ///
+      /// @see To determine the max CPU speed, see 1.4.1 Part options summary
+      ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=7
+      units::frequency::hertz_t max_cpu_clock_rate = 100_MHz;
+      /// Clock source for the CPU clock.
+      CpuClockSource clock_source = CpuClockSource::kPll0;
+      /// The 8-bit CPU clock divider. By default, the divider is set to 6 to
+      /// obtain a CPU clock of 48 MHz using the default PLL0 configurations.
+      uint8_t divider = 6;
+    } cpu = {};
+
+    /// Configurations for the USB subsystem clock.
+    struct
+    {
+      /// Clock source for the USB subsystem clock.
+      UsbClockSource clock_source = UsbClockSource::kPll0;
+      /// Clock divider for the USB clock.
+      ///
+      /// @note This value is only used if the PLL0 output is used to drive the
+      ///       USB subsystem.
+      UsbClockDivider divider = UsbClockDivider::kDivideBy6;
+    } usb = {};
+  };
+
+  /// Fixed Internal RC frequency.
+  static constexpr units::frequency::hertz_t kIrcFrequency = 4_MHz;
+
+  /// Fixed RTC frequency.
   static constexpr units::frequency::hertz_t kRTCFrequency = 32'768_Hz;
 
-  /// Pointer to the system controller peripheral in memory.
+  /// The required frequency for the USB clock.
+  static constexpr units::frequency::hertz_t kUsbClockFrequency = 48_MHz;
+
+  /// Pointer reference to the system controller peripheral in memory.
   inline static LPC_SC_TypeDef * system_controller = LPC_SC;
 
-  // TODO(#1140): Migrate to SystemController V2.0
+  /// @param clock_configuration The desired clock configurations for the
+  ///                            system.
+  explicit constexpr SystemController(
+      ClockConfiguration_t & clock_configuration)
+      : clock_configuration_(clock_configuration)
+  {
+  }
+
   void Initialize() override
   {
-    return;
+    units::frequency::hertz_t osc_clk =
+        clock_configuration_.main_oscillator.frequency;
+    units::frequency::hertz_t sys_clk = 0_MHz;
+    units::frequency::hertz_t pll_clk = 0_MHz;
+    units::frequency::hertz_t usb_clk = 0_MHz;
+    uint8_t cpu_clock_divider         = clock_configuration_.cpu.divider;
+
+    // =========================================================================
+    // Step 1. Set the internal RC as the clock source for all clocks.
+    // =========================================================================
+    // Disabling and disconnecting the PLLs sets the CPU and USB clock source to
+    // be the system clock.
+    DisableAndDisconnectPll(&system_controller->PLL0CON,
+                            &system_controller->PLL0FEED);
+    DisableAndDisconnectPll(&system_controller->PLL1CON,
+                            &system_controller->PLL1FEED);
+    // Disable the main oscillator.
+    system_controller->SCS = bit::Clear(
+        system_controller->SCS, SystemControlsRegister::kOscillatorEnableMask);
+    SetSystemClockSource(Oscillator::kIrc);
+
+    // =========================================================================
+    // Step 2. Enable the main oscillator if it is used to drive the system
+    //         clock and/or PLL1.
+    // =========================================================================
+    if ((clock_configuration_.usb.clock_source == UsbClockSource::kPll1) ||
+        (clock_configuration_.system.clock_source == Oscillator::kMain))
+    {
+      EnableMainOscillator();
+    }
+
+    // =========================================================================
+    // Step 3. Determine the running system clock rate based on the selected
+    //         oscillator.
+    // =========================================================================
+    switch (clock_configuration_.system.clock_source)
+    {
+      case Oscillator::kIrc: sys_clk = kIrcFrequency; break;
+      case Oscillator::kMain: sys_clk = osc_clk; break;
+      case Oscillator::kRtc: sys_clk = kRTCFrequency; break;
+    }
+
+    // =========================================================================
+    // Step 4. Configure the CPU clock by configuring and enabling PLL0 if
+    //         necessary.
+    // =========================================================================
+    switch (clock_configuration_.cpu.clock_source)
+    {
+      case SystemController::CpuClockSource::kSystemClock:
+      {
+        SetSystemClockSource(clock_configuration_.system.clock_source);
+        SetCpuClockDivider(cpu_clock_divider);
+        pll_clk = sys_clk;
+        break;
+      }
+      case SystemController::CpuClockSource::kPll0:
+      {
+        // Before configuring PLL0, verify the PLL0 configurations by checking
+        // whether the expected PLL0 current controlled oscillator frequency and
+        // the expected CPU frequency are within the valid frequency ranges.
+
+        // Minimum / maximum current controlled oscillator frequencies of PLL0.
+        constexpr units::frequency::hertz_t kMinFcco = 275_MHz;
+        constexpr units::frequency::hertz_t kMaxFcco = 550_MHz;
+
+        uint16_t multiplier = clock_configuration_.pll0.multiplier;
+        uint8_t pre_divider = clock_configuration_.pll0.pre_divider;
+        // Determine the running current controlled oscillator frequency based
+        // on the configurations.
+        pll_clk = (2 * sys_clk * multiplier) / pre_divider;
+
+        SJ2_ASSERT_FATAL(
+            (kMinFcco < pll_clk) && (pll_clk < kMaxFcco),
+            "Invalid PLL0 multiplier and pre-divider configurations. The "
+            "target current controlled oscillator frequency must be between "
+            "275 MHz and 550 MHz.");
+
+        auto max_cpu_clock_rate = clock_configuration_.cpu.max_cpu_clock_rate;
+
+        SJ2_ASSERT_FATAL((pll_clk / cpu_clock_divider) < max_cpu_clock_rate,
+                         "The configured CPU divider produces a CPU clock that "
+                         "exceeds the maximum allowed CPU clock rate.");
+
+        ConfigurePll0();
+        break;
+      }
+    }
+
+    // =========================================================================
+    // Step 5. Configure the USB clock by configuring and enabling PLL1 if
+    //         necessary.
+    // =========================================================================
+    switch (clock_configuration_.usb.clock_source)
+    {
+      case UsbClockSource::kPll0:
+      {
+        SJ2_ASSERT_FATAL(
+            clock_configuration_.cpu.clock_source == CpuClockSource::kPll0,
+            "The CPU clock source must be PLL0 in order to use PLL0 as a clock "
+            "source for the USB clock.");
+
+        uint8_t usb_clock_divider_select =
+            Value(clock_configuration_.usb.divider);
+        uint32_t usb_clock_divider = usb_clock_divider_select + 1;
+        usb_clk                    = pll_clk / usb_clock_divider;
+
+        SJ2_ASSERT_FATAL(usb_clk == kUsbClockFrequency,
+                         "Attempting to use PLL0 to drive the USB clock, but "
+                         "the PLL0 configuration and USB clock divider are not "
+                         "configured to produce a frequency of 48 MHz.");
+
+        system_controller->USBCLKCFG =
+            bit::Insert(system_controller->USBCLKCFG, usb_clock_divider_select,
+                        UsbClockRegister::kDividerMask);
+        break;
+      }
+      case UsbClockSource::kPll1:
+      {
+        uint32_t multiplier = Value(clock_configuration_.pll1.multiplier) + 1;
+        usb_clk             = osc_clk * multiplier;
+
+        ConfigurePll1();
+        break;
+      }
+    }
+
+    // =========================================================================
+    // Step 6. Set all peripheral clock dividers to 1.
+    // =========================================================================
+    // SEE: 4.7.3 Peripheral Clock Selection registers 0 and 1
+    //      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=58
+    //
+    // NOTE: The reserved bits are left as 0b00.
+    system_controller->PCLKSEL0 = 0x5551'5155;
+    system_controller->PCLKSEL0 = 0x5455'5455;
+
+    // =========================================================================
+    // Step 7. Determine the running CPU and USB clock rates.
+    // =========================================================================
+    cpu_clock_rate_ = pll_clk / cpu_clock_divider;
+    usb_clock_rate_ = usb_clk;
   }
 
-  /// @return the a pointer to the clock configuration object used to configure
-  /// this system controller.
   void * GetClockConfiguration() override
   {
-    return nullptr;
+    return &clock_configuration_;
   }
 
-  /// @return the clock rate frequency of a peripheral
-  units::frequency::hertz_t GetClockRate(PeripheralID peripheral) const override
-  {
-    return GetSystemFrequency() / GetPeripheralClockDivider(peripheral);
-  }
-
-  /// Sets a desired CPU speed by using the internal RC as the oscillator source
-  /// and configuring PLL0.
-  ///
-  /// @note The USB subsystem should be configured to obtain its input clock
-  ///       from the USB PLL. The internal RC is used for PLL0 and will not
-  ///       generate a precise enough clock to be used by the USB subsystem.
-  ///
-  /// @param frequency The desired CPU Clock frequency in megahertz.
-  void SetSystemClockFrequency(units::frequency::megahertz_t frequency) const
-  {
-    // The following sequence is specified in the LPC176x/5x User Manual
-    // Section 4.5.13 and must be followed step by step in order to have PLL0
-    // initialized and running.
-
-    // NOTE: It is very important not to merge any steps. For example, do not
-    //       update the PLL0CFG and enable PLL0 simultaneously with the same
-    //       feed sequence.
-
-    // 1. Disconnect PLL0 with one feed sequence if PLL0 is already connected.
-    system_controller->PLL0CON =
-        bit::Clear(system_controller->PLL0CON, Pll::kConnectBit);
-    WritePllFeedSequence(PllSelect::kMainPll);
-    // 2. Disable PLL0 with one feed sequence.
-    system_controller->PLL0CON =
-        bit::Clear(system_controller->PLL0CON, Pll::kEnableBit);
-    WritePllFeedSequence(PllSelect::kMainPll);
-    // 3. Change the CPU Clock Divider setting to speed up operation without
-    //    PLL0, if desired.
-    SetCpuClockDivider(0);
-    // 4. Write to the Clock Source Selection Control register to change the
-    //    clock source if needed.
-    //    The 4 MHz internal RC will be used until PLL0 achieves a lock and is
-    //    connected.
-    SelectOscillatorSource(OscillatorSource::kIrc);
-    // 5. Write to the PLL0CFG and make it effective with one feed sequence.
-    //    The PLL0CFG can only be updated when PLL0 is disabled.
-    const PllSettings_t kPll0Settings =
-        CalculatePll0(kDefaultIRCFrequency, frequency);
-    system_controller->PLL0CFG =
-        bit::Insert(system_controller->PLL0CFG, kPll0Settings.multiplier,
-                    MainPll::kMultiplier);
-    system_controller->PLL0CFG =
-        bit::Insert(system_controller->PLL0CFG, kPll0Settings.pre_divider,
-                    MainPll::kPreDivider);
-    WritePllFeedSequence(PllSelect::kMainPll);
-    // 6. Enable PLL0 with one feed sequence.
-    system_controller->PLL0CON =
-        bit::Set(system_controller->PLL0CON, Pll::kEnableBit);
-    WritePllFeedSequence(PllSelect::kMainPll);
-    // 7. Change the CPU Clock Divider setting for the operation with PLL0.
-    //    It is critical to do this before connecting PLL0.
-    SetCpuClockDivider(kPll0Settings.cpu_divider);
-    // 8. Wait for PLL0 to achieve lock by monitoring the PLOCK0 bit in the
-    //    PLL0STAT register, or using the PLOCK0 interrupt, or wait for a fixed
-    //    time when the input clock to PLL0 is slow (i.e. 32 kHz).
-    SJ2_ASSERT_FATAL(WaitForPllLockStatus(PllSelect::kMainPll),
-                     "PLL0 lock could not be established before timeout");
-    // 9. Connect PLL0 with one feed sequence.
-    system_controller->PLL0CON =
-        bit::Set(system_controller->PLL0CON, Pll::kConnectBit);
-    WritePllFeedSequence(PllSelect::kMainPll);
-
-    SJ2_ASSERT_FATAL(WaitForPllConnectionStatus(PllSelect::kMainPll),
-                     "Failed to connect PLL0.");
-
-    speed_in_hertz = frequency;
-  }
-  /// Configures the USB PLL (PLL1) to produce the required 48 MHz clock based
-  /// on the input frequency provided to the PLL.
-  ///
-  /// @param frequency Frequency of the external oscillator used to drive PLL1.
-  void SetUsbPllInputFrequency(UsbPllInputFrequency frequency)
-  {
-    // NOTE:  It is very important not to merge any steps below. For example, do
-    //        not update the PLL1CFG and enable PLL1 simultaneously with the
-    //        same feed sequence.
-
-    // 1. Disconnect PLL1 with one feed sequence if PLL1 is already connected.
-    system_controller->PLL1CON =
-        bit::Clear(system_controller->PLL1CON, Pll::kConnectBit);
-    WritePllFeedSequence(PllSelect::kUsbPll);
-    // 2. Disable PLL1 with one feed sequence.
-    system_controller->PLL1CON =
-        bit::Clear(system_controller->PLL1CON, Pll::kEnableBit);
-    WritePllFeedSequence(PllSelect::kUsbPll);
-    // 3. Write to the PLL1CFG and make it effective with one feed sequence.
-    constexpr uint8_t kDivider = Value(UsbPllDivider::kDivideBy1);
-    // depending on the input frequency, the multiplier value will always be
-    // either 2, 3, or 4
-    const uint8_t kMultiplier[] = {
-      Value(UsbPllMultiplier::kMultiplyBy4),
-      Value(UsbPllMultiplier::kMultiplyBy3),
-      Value(UsbPllMultiplier::kMultiplyBy2),
-    };
-    system_controller->PLL1CFG =
-        bit::Insert(system_controller->PLL1CFG, kMultiplier[Value(frequency)],
-                    UsbPll::kMultiplier);
-    system_controller->PLL1CFG =
-        bit::Insert(system_controller->PLL1CFG, kDivider, UsbPll::kDivider);
-    WritePllFeedSequence(PllSelect::kUsbPll);
-    // 4. Enable PLL1 with one feed sequence.
-    system_controller->PLL1CON =
-        bit::Set(system_controller->PLL1CON, Pll::kEnableBit);
-    WritePllFeedSequence(PllSelect::kUsbPll);
-    // 5. Configurations to the PLL must be locked before it can be connected.
-    SJ2_ASSERT_FATAL(WaitForPllLockStatus(PllSelect::kUsbPll),
-                     "PLL1 lock could not be established before timeout");
-    // 6. Connect PLL1 with one feed sequence.
-    system_controller->PLL1CON =
-        bit::Set(system_controller->PLL1CON, Pll::kConnectBit);
-    WritePllFeedSequence(PllSelect::kUsbPll);
-
-    SJ2_ASSERT_FATAL(WaitForPllConnectionStatus(PllSelect::kUsbPll),
-                     "Failed to connect PLL1.");
-  }
-  /// Sets the divider to control the desired peripheral clock rate (PCLK) for a
-  /// specified peripheral where PCLK = CCLK / divider.
-  ///
-  /// The following dividers are supported for non-CAN peripherals: 1, 2, 4, 8.
-  /// For CAN the following dividers are supported: 1, 2, 4, 6.
-  ///
-  /// @param peripheral_select  Peripheral to configure.
-  /// @param peripheral_divider Peripheral clock divider value.
-  void SetPeripheralClockDivider(PeripheralID peripheral_select,
-                                 uint8_t peripheral_divider) const
-  {
-    const bool kIsCanPeripheral =
-        peripheral_select.device_id == Peripherals::kCan1.device_id ||
-        peripheral_select.device_id == Peripherals::kCan2.device_id;
-    // Convert the divider value to corresponding 2-bit select value
-    // The list of divider select values can be found in the LPC176x/5x User
-    // Manual Table 42.
-    uint8_t divider_select;
-    switch (peripheral_divider)
-    {
-      case 1: divider_select = 0b01; break;
-      case 2: divider_select = 0b10; break;
-      case 4: divider_select = 0b00; break;
-      case 6:
-      {
-        SJ2_ASSERT_FATAL(
-            kIsCanPeripheral,
-            "The divider value of 6 is only supported for CAN peripherals.");
-        divider_select = 0b11;
-      }
-      break;
-      case 8:
-      {
-        SJ2_ASSERT_FATAL(
-            !kIsCanPeripheral,
-            "The divider value of 8 is not supported for CAN peripherals.");
-        divider_select = 0b11;
-      }
-      break;
-      default:
-        SJ2_ASSERT_FATAL(
-            false,
-            "Only the following peripheral divider values are supported: 1, 2, "
-            "4, 8. The divider value of 6 is supported for CAN peripherals.");
-        divider_select = -1;
-    }
-    volatile uint32_t * pclk_sel =
-        GetPeripheralClockSelectRegister(peripheral_select);
-    const bit::Mask kDividerMask =
-        CalculatePeripheralClockDividerMask(peripheral_select);
-    *pclk_sel = bit::Insert(*pclk_sel, divider_select, kDividerMask);
-  }
-
-  /// @returns The clock divider for the specified peripheral.
-  uint32_t GetPeripheralClockDivider(
-      PeripheralID peripheral_select) const
-  {
-    volatile uint32_t * pclk_sel =
-        GetPeripheralClockSelectRegister(peripheral_select);
-    const bit::Mask kDividerMask =
-        CalculatePeripheralClockDividerMask(peripheral_select);
-    const uint8_t kDividerSelect =
-        static_cast<uint8_t>(bit::Extract(*pclk_sel, kDividerMask));
-
-    uint8_t peripheral_clock_divider;
-    // convert and return the actual peripheral divider value based on the 2-bit
-    // divider select value
-    switch (kDividerSelect)
-    {
-      case 0b00: peripheral_clock_divider = 4; break;
-      case 0b01: peripheral_clock_divider = 1; break;
-      case 0b10: peripheral_clock_divider = 2; break;
-      case 0b11:
-      {
-        // 0b11 for CAN peripiherals use a divider of 6 while all others use a
-        // divider of 8
-        switch (peripheral_select.device_id)
-        {
-          case Peripherals::kCan1.device_id: [[fallthrough]];
-          case Peripherals::kCan2.device_id:
-            peripheral_clock_divider = 6;
-            break;
-          default: peripheral_clock_divider = 8; break;
-        }
-      }
-    }
-    return peripheral_clock_divider;
-  }
-
-  /// Returns the last set frequency of the system
-  units::frequency::hertz_t GetSystemFrequency() const
-  {
-    return speed_in_hertz;
-  }
-
-  /// Check if a peripheral is powered up by checking the power connection
-  /// register. Should typically only be used for unit testing code and
-  /// debugging.
   bool IsPeripheralPoweredUp(PeripheralID peripheral_select) const override
   {
     return bit::Read(system_controller->PCONP, peripheral_select.device_id);
@@ -434,192 +530,307 @@ class SystemController final : public sjsu::SystemController
         bit::Clear(system_controller->PCONP, peripheral_select.device_id);
   }
 
- private:
-  inline static units::frequency::hertz_t speed_in_hertz = kDefaultIRCFrequency;
-
-  void SelectOscillatorSource(OscillatorSource source) const
+  units::frequency::hertz_t GetClockRate(PeripheralID peripheral) const override
   {
-    system_controller->CLKSRCSEL =
-        bit::Insert(system_controller->CLKSRCSEL, static_cast<uint32_t>(source),
-                    Oscillator::kSelect);
+    switch (peripheral.device_id)
+    {
+      case Clocks::kCpu.device_id:
+      {
+        return cpu_clock_rate_;
+      }
+      case Clocks::kUsb.device_id:
+      {
+        return usb_clock_rate_;
+      }
+      default:  // All other peripherals
+      {
+        return cpu_clock_rate_;
+      }
+    }
   }
 
-  /// Calculates the multiplier. pre-divider, and CPU clock divider required to
-  /// generated the desired CPU clock with PLL0 based on the specified input
-  /// frequency.
+ private:
+  /// Configures the system clock source.
   ///
-  /// @param input_frequency Input of PLL0 should be 32 kHz to 50 MHz.
-  /// @param desired_speed   Desired CPU clock to achieve. Should not
-  ///                        exceed the maximum allowed CPU clock.
-  PllSettings_t CalculatePll0(units::frequency::hertz_t input_frequency,
-                              units::frequency::hertz_t desired_speed) const
+  /// @param source The oscillator used to drive the system clock.
+  void SetSystemClockSource(Oscillator source) const
   {
-    // minimum/maximum input and output frequencies of PLL0 in kHz
-    constexpr units::frequency::hertz_t kMinimumPll0InputFrequency = 32_kHz;
-    constexpr units::frequency::hertz_t kMaximumPll0InputFrequency = 50_MHz;
-    constexpr units::frequency::hertz_t kMinimumPll0OuputFrequency = 275_MHz;
-    constexpr units::frequency::hertz_t kMaximumPll0OuputFrequency = 550_MHz;
+    system_controller->CLKSRCSEL =
+        bit::Insert(system_controller->CLKSRCSEL, Value(source),
+                    ClockSourceSelectRegister::kSelectMask);
+  }
 
-    // Maximum allowed CPU speed in kHz.
-    // This value will be 100 MHz or 120 MHz depending on the MCU in use
-    // For the SJOne, the max CPU speed for LPC1758 is 100 MHz.
-    constexpr units::frequency::hertz_t kMaxCPUSpeed = 100_MHz;
+  /// Configures the System Controls register (SCS) to enable the use of the
+  /// main oscillator.
+  ///
+  /// @see https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=30
+  void EnableMainOscillator() const
+  {
+    uint32_t system_controls = system_controller->SCS;
+    auto frequency           = clock_configuration_.main_oscillator.frequency;
 
+    constexpr units::frequency::hertz_t kMinFrequency = 1_MHz;
+    constexpr units::frequency::hertz_t kMaxFrequency = 25_MHz;
     SJ2_ASSERT_FATAL(
-        input_frequency > kMinimumPll0InputFrequency &&
-            input_frequency < kMaximumPll0InputFrequency,
-        "The input PLL0 frequency must be between 32kHz and 50MHz");
-    SJ2_ASSERT_FATAL(
-        desired_speed < kMaxCPUSpeed,
-        "The desired CPU speed cannot exceed the maximum allow CPU speed.");
-    // The supported pre-divider values ranges from 1 to 32 while the supported
-    // multiplier values ranges from 6 to 512.
-    // Since a small value for the pre-divider, n, is desired, we will iterate
-    // through n starting from the lowest possible value of 1 in order to find a
-    // suitable multiplier, m. The values of m and n are inversely proportional;
-    // therefore, we start looking for the multiplier from its largest possible
-    // value of 512.
-    for (uint8_t n = 0; n < 32; n++)
+        (kMinFrequency <= frequency) && (frequency <= kMaxFrequency),
+        "The frequency of the main oscillator must be between 1 "
+        "MHz and 25 MHz.");
+
+    if (1_MHz <= frequency && frequency <= 15_MHz)
     {
-      for (uint16_t m = 511; m >= 6; m--)
-      {
-        // Current calculated controlled oscillator frequency, fcco, output of
-        // PLL0 in kilohertz
-        // Dividing by 1000 to scale down kFcco, as the multiplier for is
-        // internally scaled by 1000.
-        const units::frequency::hertz_t kFcco =
-            (2 * (m + 1) * input_frequency) / (n + 1);
-        if (kMinimumPll0OuputFrequency < kFcco &&
-            kFcco < kMaximumPll0OuputFrequency)
-        {
-          // since PLL0 is in use, the cpu_divider values of 0 and 1 are not
-          // allowed as the resulting CPU clock will always be above the maximum
-          // allowed CPU speed
-          for (uint16_t cpu_divider = 2; cpu_divider < 256; cpu_divider++)
-          {
-            // Get resulting CPU clock
-            // Requires that we scale kFcco back to a proper frequency.
-            const units::frequency::hertz_t kCpuClock =
-                kFcco / (cpu_divider + 1);
-            if (kCpuClock == desired_speed)
-            {
-              return PllSettings_t{ .multiplier  = m,
-                                    .pre_divider = n,
-                                    .cpu_divider =
-                                        static_cast<uint8_t>(cpu_divider) };
-            }
-          }  // cpu_divider loop
-        }
-      }  // m for loop
-    }    // n for loop
-    SJ2_ASSERT_FATAL(
-        false,
-        "Failed to calculate the PLL0 settings for the desired frequency.");
-    return PllSettings_t{ .multiplier = 0, .pre_divider = 0, .cpu_divider = 0 };
+      system_controls = bit::Clear(
+          system_controls, SystemControlsRegister::kOscillatorRangeMask);
+    }
+    else if (15_MHz <= frequency && frequency <= 25_MHz)
+    {
+      system_controls = bit::Set(system_controls,
+                                 SystemControlsRegister::kOscillatorRangeMask);
+    }
+    system_controls = bit::Set(system_controls,
+                               SystemControlsRegister::kOscillatorEnableMask);
+
+    system_controller->SCS = system_controls;
+
+    // Wait for the main oscillator to become stable before proceeding with any
+    // other operations.
+    while (!bit::Read(system_controller->SCS,
+                      SystemControlsRegister::kOscillatorStatusMask))
+    {
+      continue;
+    }
+  }
+
+  /// Disconnect and then disable the specified PLL.
+  ///
+  /// @param pll_control_register Address of the PLL control register.
+  /// @param pll_feed_register Address of the PLL feed register.
+  void DisableAndDisconnectPll(volatile uint32_t * pll_control_register,
+                               volatile uint32_t * pll_feed_register) const
+  {
+    // NOTE: It is very important not to merge any steps.
+
+    // =========================================================================
+    // Step 1. Disconnect PLL0 with one feed sequence.
+    // =========================================================================
+    *pll_control_register =
+        bit::Clear(*pll_control_register, PllControlRegister::kConnectMask);
+    WritePllFeedSequence(pll_feed_register);
+
+    // =========================================================================
+    // Step 2. Disable PLL0 with one feed sequence.
+    // =========================================================================
+    *pll_control_register =
+        bit::Clear(*pll_control_register, PllControlRegister::kEnableMask);
+    WritePllFeedSequence(pll_feed_register);
   }
 
   /// Writes the feed sequence that is necessary to lock in any changes to the
   /// PLLCON and PLLCGG registers.
-  void WritePllFeedSequence(PllSelect pll) const
+  ///
+  /// @param pll_feed_register Address of the PLL feed register to write to.
+  void WritePllFeedSequence(volatile uint32_t * pll_feed_register) const
   {
-    volatile uint32_t * pll_feed_registers[] = {
-      &(system_controller->PLL0FEED),
-      &(system_controller->PLL1FEED),
-    };
-    *(pll_feed_registers[Value(pll)]) = 0xAA;
-    *(pll_feed_registers[Value(pll)]) = 0x55;
+    *pll_feed_register = 0xAA;
+    *pll_feed_register = 0x55;
   }
 
-  bool WaitForPllLockStatus(PllSelect pll) const
+  /// Waits for the PLL to achieve a locked status by checking the specified PLL
+  /// status register.
+  ///
+  /// @param pll_status_register Address of the PLL status register to write to.
+  /// @param pll_lock_status_mask The PLL lock status mask to check.
+  void WaitForPllLockStatus(volatile uint32_t * pll_status_register,
+                            bit::Mask pll_lock_status_mask) const
   {
-    // Skip waiting for PLLSTAT register to update if running a host unit test
-    if constexpr (build::kPlatform == build::Platform::host)
-    {
-      return true;
-    }
-
-    volatile uint32_t * pll_status_registers[] = {
-      &(system_controller->PLL0STAT),  // NOLINT
-      &(system_controller->PLL1STAT)
-    };
-    const bit::Mask kLockStatusMasks[]  = { MainPll::kLockStatus,
-                                           UsbPll::kLockStatus };
-    volatile uint32_t * status_register = pll_status_registers[Value(pll)];
-    const bit::Mask kLockStatusMask     = kLockStatusMasks[Value(pll)];
-
-    while (!bit::Read(*status_register, kLockStatusMask.position))
+    while (!bit::Read(*pll_status_register, pll_lock_status_mask))
     {
       continue;
     }
-
-    return true;
   }
 
-  /// @returns Returns true if the enable and connect status bits in the PLL
-  ///          status register are both 1.
-  bool WaitForPllConnectionStatus(PllSelect pll) const
+  /// Waits for the PLL to become enabled and connected by checking the
+  /// specified PLL status register.
+  ///
+  /// @param pll_status_register Address of the PLL status register.
+  /// @param pll_enable_status_mask The PLL enable status mask to check.
+  /// @param pll_connection_status_mask The PLL connection status mask to check.
+  void WaitForPllConnectionStatus(volatile uint32_t * pll_status_register,
+                                  bit::Mask pll_enable_status_mask,
+                                  bit::Mask pll_connection_status_mask) const
   {
-    // Skip waiting for PLLSTAT register to update if running a host unit test
-    if constexpr (build::kPlatform == build::Platform::host)
-    {
-      return true;
-    }
-
-    volatile uint32_t * pll_status_registers[] = {
-      &(system_controller->PLL0STAT),  // NOLINT
-      &(system_controller->PLL1STAT)
-    };
-    const bit::Mask kMasks[]            = { MainPll::kMode, UsbPll::kMode };
-    volatile uint32_t * status_register = pll_status_registers[Value(pll)];
-    const bit::Mask kPllModeMask        = kMasks[Value(pll)];
-
-    while (!bit::Read(*status_register, kPllModeMask.position))
+    while (!bit::Read(*pll_status_register, pll_enable_status_mask) &&
+           !bit::Read(*pll_status_register, pll_connection_status_mask))
     {
       continue;
     }
-
-    return true;
   }
 
-  /// Sets divider used for the CPU clock (CCLK). The PLL0 clock (pllclk) will
-  /// be divided by the cpu_divider + 1.
-  /// For example, if cpu_divider = 1, then CCLK = pllclk / 2.
-  ///              if cpu_divider = 255, then CCLK = pllclk / 256.
+  /// Configures PLL0 (Main PLL) to produce a desired current conttolled
+  /// oscillator frequency ranging from 275 MHz to 550 MHz.
   ///
-  /// @note If PLL0 is connected, divider values 0 and 1 are not allowed
-  ///       since the the produced clock rate must not exceed the maximum
-  ///       allowed CPU clock.
+  /// @see 4.5.13 PLL0 setup sequence
+  ///      https://www.nxp.com/docs/en/user-guide/UM10360.pdf#page=48
+  void ConfigurePll0() const
+  {
+    volatile uint32_t * pll_feed_register   = &system_controller->PLL0FEED;
+    volatile uint32_t * pll_status_register = &system_controller->PLL0STAT;
+
+    // The following sequence is specified in the LPC176x/5x User Manual
+    // Section 4.5.13 and must be followed step by step in order to have PLL0
+    // initialized and running.
+
+    // NOTE: It is very important not to merge any steps. For example, do not
+    //       update the PLL0CFG and enable PLL0 simultaneously with the same
+    //       feed sequence.
+
+    // =========================================================================
+    // Step 1. Disconnect PLL0 with one feed sequence if PLL0 is already
+    //         connected.
+    //
+    // Step 2. Disable PLL0 with one feed sequence.
+    // =========================================================================
+    // NOTE: DisableAndDisconnectPll performs Steps 1 and 2.
+    DisableAndDisconnectPll(&system_controller->PLL0CON, pll_feed_register);
+
+    // =========================================================================
+    // Step 3. Change the CPU Clock Divider setting to speed up operation
+    //         without PLL0, if desired.
+    // =========================================================================
+    SetCpuClockDivider(1);
+
+    // =========================================================================
+    // Step 4. Write to the Clock Source Selection Control register to change
+    //         the clock source if needed.
+    // =========================================================================
+    SetSystemClockSource(clock_configuration_.system.clock_source);
+
+    // =========================================================================
+    // Step 5. Write to the PLL0CFG and make it effective with one feed
+    //         sequence. The PLL0CFG can only be updated when PLL0 is disabled.
+    // =========================================================================
+    uint16_t multiplier = clock_configuration_.pll0.multiplier;
+    uint8_t pre_divider = clock_configuration_.pll0.pre_divider;
+    system_controller->PLL0CFG =
+        bit::Insert(system_controller->PLL0CFG, (multiplier - 1),
+                    Pll0::ConfigurationRegister::kMultiplierMask);
+    system_controller->PLL0CFG =
+        bit::Insert(system_controller->PLL0CFG, (pre_divider - 1),
+                    Pll0::ConfigurationRegister::kPreDividerMask);
+    WritePllFeedSequence(pll_feed_register);
+
+    // =========================================================================
+    // Step 6. Enable PLL0 with one feed sequence.
+    // =========================================================================
+    system_controller->PLL0CON =
+        bit::Set(system_controller->PLL0CON, PllControlRegister::kEnableMask);
+    WritePllFeedSequence(pll_feed_register);
+
+    // =========================================================================
+    // Step 7. Change the CPU Clock Divider setting for the operation with PLL0.
+    //         It is critical to do this before connecting PLL0.
+    // =========================================================================
+    SetCpuClockDivider(clock_configuration_.cpu.divider);
+
+    // =========================================================================
+    // Step 8. Wait for PLL0 to achieve lock by monitoring the PLOCK0 bit in the
+    //         PLL0STAT register, or using the PLOCK0 interrupt, or wait for a
+    //         fixed time when the input clock to PLL0 is slow (i.e. 32 kHz).
+    // =========================================================================
+    WaitForPllLockStatus(pll_status_register,
+                         Pll0::StatusRegister::kLockStatusMask);
+
+    // =========================================================================
+    // Step 9. Connect PLL0 with one feed sequence.
+    // =========================================================================
+    system_controller->PLL0CON =
+        bit::Set(system_controller->PLL0CON, PllControlRegister::kConnectMask);
+    WritePllFeedSequence(pll_feed_register);
+
+    WaitForPllConnectionStatus(pll_status_register,
+                               Pll0::StatusRegister::kEnableMask,
+                               Pll0::StatusRegister::kConnectMask);
+  }
+
+  /// Configures PLL1 (USB PLL) to produce the required 40 MHz clock to drive
+  /// the USB subsystem.
+  void ConfigurePll1() const
+  {
+    // NOTE: It is very important not to merge any steps below. For example, do
+    //       not update the PLL1CFG and enable PLL1 simultaneously with the
+    //       same feed sequence.
+
+    volatile uint32_t * pll_feed_register   = &system_controller->PLL1FEED;
+    volatile uint32_t * pll_status_register = &system_controller->PLL1STAT;
+
+    // =========================================================================
+    // Step 1. Disconnect PLL0 with one feed sequence if PLL0 is already
+    //         connected.
+    //
+    // Step 2. Disable PLL0 with one feed sequence.
+    // =========================================================================
+    // NOTE: DisableAndDisconnectPll performs Steps 1 and 2.
+    DisableAndDisconnectPll(&system_controller->PLL1CON, pll_feed_register);
+
+    // =========================================================================
+    // Step 3. Write to the PLL1CFG and make it effective with one feed
+    //         sequence.
+    // =========================================================================
+    uint8_t multiplier = Value(clock_configuration_.pll1.multiplier);
+    constexpr uint8_t kDividerSelect = 0b01;
+    system_controller->PLL1CFG =
+        bit::Insert(system_controller->PLL1CFG, multiplier,
+                    Pll1::ConfigurationRegister::kMultiplierMask);
+    system_controller->PLL1CFG =
+        bit::Insert(system_controller->PLL1CFG, kDividerSelect,
+                    Pll1::ConfigurationRegister::kDividerMask);
+    WritePllFeedSequence(pll_feed_register);
+
+    // =========================================================================
+    // Step 4. Enable PLL1 with one feed sequence.
+    // =========================================================================
+    system_controller->PLL1CON =
+        bit::Set(system_controller->PLL1CON, PllControlRegister::kEnableMask);
+    WritePllFeedSequence(pll_feed_register);
+
+    // =========================================================================
+    // Step 5. Configurations to the PLL must be locked before it can be
+    //         connected.
+    // =========================================================================
+    WaitForPllLockStatus(pll_status_register,
+                         Pll1::StatusRegister::kLockStatusMask);
+
+    // =========================================================================
+    // Step 6. Connect PLL1 with one feed sequence.
+    // =========================================================================
+    system_controller->PLL1CON =
+        bit::Set(system_controller->PLL1CON, PllControlRegister::kConnectMask);
+    WritePllFeedSequence(pll_feed_register);
+
+    WaitForPllConnectionStatus(pll_status_register,
+                               Pll1::StatusRegister::kEnableMask,
+                               Pll1::StatusRegister::kConnectMask);
+  }
+
+  /// Sets divider used for the CPU clock (CCLK).
   ///
-  /// @param cpu_divider 8-bit divider ranging from 0 - 255.
+  /// @note If PLL0 is connected, a divider value of 1 is not allowed since the
+  ///       produced clock rate must not exceed the maximum allowed CPU clock.
+  ///
+  /// @param cpu_divider 8-bit divider ranging from 1 to 255.
   void SetCpuClockDivider(uint8_t cpu_divider) const
   {
-    system_controller->CCLKCFG = bit::Insert(system_controller->CCLKCFG,
-                                             cpu_divider, CpuClock::kDivider);
+    SJ2_ASSERT_FATAL(cpu_divider != 0, "The CPU clock cannot be divided by 0.");
+    system_controller->CCLKCFG =
+        bit::Insert(system_controller->CCLKCFG, (cpu_divider - 1),
+                    CpuClockRegister::kDividerMask);
   }
 
-  /// @returns  Pointer to the PCLKSEL0 or PCLKSEL1 register based on the
-  ///           peripheral's device_id.
-  volatile uint32_t * GetPeripheralClockSelectRegister(
-      PeripheralID peripheral_select) const
-  {
-    if (peripheral_select.device_id > 15)
-    {
-      return &(system_controller->PCLKSEL1);
-    }
-    return &(system_controller->PCLKSEL0);
-  }
-
-  /// @returns  The bit mask for the 2-bit position of the specified
-  ///           peripheral's divider select in the PCLKSEL0 or PCLKSEL1
-  ///           register.
-  bit::Mask CalculatePeripheralClockDividerMask(
-      PeripheralID peripheral_select) const
-  {
-    constexpr uint8_t kMaxBitWidth = 32;
-    const uint8_t kLowBit  = (peripheral_select.device_id * 2) % kMaxBitWidth;
-    const uint8_t kHighBit = static_cast<uint8_t>(kLowBit + 1);
-    return bit::CreateMaskFromRange(kLowBit, kHighBit);
-  }
+  /// Clock system configurations.
+  ClockConfiguration_t & clock_configuration_;
+  /// The running clock rate of the CPU clock.
+  units::frequency::hertz_t cpu_clock_rate_ = 0_MHz;
+  /// The running clock rate of the USB subsystem clock.
+  units::frequency::hertz_t usb_clock_rate_ = 0_MHz;
 };
 }  // namespace lpc17xx
 }  // namespace sjsu

--- a/library/L1_Peripheral/lpc17xx/test/system_controller_test.cpp
+++ b/library/L1_Peripheral/lpc17xx/test/system_controller_test.cpp
@@ -1,4 +1,6 @@
-// Tests for the LPC176x/5x System Controller.
+#include <bitset>
+#include <thread>
+
 #include "L1_Peripheral/lpc17xx/system_controller.hpp"
 #include "L4_Testing/testing_frameworks.hpp"
 
@@ -13,188 +15,419 @@ TEST_CASE("Testing LPC176x/5x System Controller", "[lpc17xx-SystemController]")
   memset(&local_sc, 0, sizeof(local_sc));
   SystemController::system_controller = &local_sc;
 
-  constexpr SystemController::PeripheralID kPeripherals[] = {
-    SystemController::Peripherals::kTimer0,
-    SystemController::Peripherals::kTimer1,
-    SystemController::Peripherals::kUart0,
-    SystemController::Peripherals::kUart1,
-    SystemController::Peripherals::kPwm1,
-    SystemController::Peripherals::kI2c0,
-    SystemController::Peripherals::kSpi,
-    SystemController::Peripherals::kRtc,
-    SystemController::Peripherals::kSsp1,
-    SystemController::Peripherals::kAdc,
-    SystemController::Peripherals::kCan1,
-    SystemController::Peripherals::kCan2,
-    SystemController::Peripherals::kGpio,
-    SystemController::Peripherals::kRit,
-    SystemController::Peripherals::kMotorControlPwm,
-    SystemController::Peripherals::kQuadratureEncoder,
-    SystemController::Peripherals::kI2c1,
-    SystemController::Peripherals::kSsp0,
-    SystemController::Peripherals::kTimer2,
-    SystemController::Peripherals::kTimer3,
-    SystemController::Peripherals::kUart2,
-    SystemController::Peripherals::kUart3,
-    SystemController::Peripherals::kI2c2,
-    SystemController::Peripherals::kI2s,
-    SystemController::Peripherals::kGpdma,
-    SystemController::Peripherals::kEthernet,
-    SystemController::Peripherals::kUsb,
+  SystemController::ClockConfiguration_t clock_configuration;
+  SystemController system_controller(clock_configuration);
+
+  auto main_oscillator_becomes_available = [&local_sc]() {
+    std::this_thread::sleep_for(1ms);
+
+    local_sc.SCS = bit::Set(
+        local_sc.SCS,
+        SystemController::SystemControlsRegister::kOscillatorStatusMask);
   };
 
-  SystemController system_controller;
+  auto pll0_becomes_available = [&local_sc]() {
+    std::this_thread::sleep_for(1ms);
 
-  SECTION("Set CPU Clock Frequency")
+    local_sc.PLL0STAT =
+        bit::Set(local_sc.PLL0STAT,
+                 SystemController::Pll0::StatusRegister::kLockStatusMask);
+    local_sc.PLL0STAT = bit::Set(
+        local_sc.PLL0STAT, SystemController::Pll0::StatusRegister::kEnableMask);
+    local_sc.PLL0STAT =
+        bit::Set(local_sc.PLL0STAT,
+                 SystemController::Pll0::StatusRegister::kConnectMask);
+  };
+
+  auto pll1_becomes_available = [&local_sc]() {
+    std::this_thread::sleep_for(1ms);
+
+    local_sc.PLL1STAT =
+        bit::Set(local_sc.PLL1STAT,
+                 SystemController::Pll1::StatusRegister::kLockStatusMask);
+    local_sc.PLL1STAT = bit::Set(
+        local_sc.PLL1STAT, SystemController::Pll1::StatusRegister::kEnableMask);
+    local_sc.PLL1STAT =
+        bit::Set(local_sc.PLL1STAT,
+                 SystemController::Pll1::StatusRegister::kConnectMask);
+  };
+
+  SECTION("GetClockConfiguration()")
   {
-    constexpr units::frequency::hertz_t kDefaultIRCFrequency = 4_MHz;
-    constexpr units::frequency::hertz_t kExpectedFrequency   = 48_MHz;
-
-    system_controller.SetSystemClockFrequency(kExpectedFrequency);
-
-    CHECK(bit::Read(local_sc.PLL0CON, SystemController::Pll::kEnableBit) ==
-          0b1);
-    CHECK(bit::Read(local_sc.PLL0CON, SystemController::Pll::kConnectBit) ==
-          0b1);
-    // Reading the multiplier, pre-divider, and cpu clock dividers from their
-    // corrensponding registers to re-calculate the desired cpu frequency to
-    // check at the correct values were written
-    const uint32_t kMultiplier =
-        bit::Extract(local_sc.PLL0CFG, SystemController::MainPll::kMultiplier) +
-        1;
-    const uint32_t kPreDivider =
-        bit::Extract(local_sc.PLL0CFG, SystemController::MainPll::kPreDivider) +
-        1;
-    const uint32_t kCpuDivider =
-        bit::Extract(local_sc.CCLKCFG, SystemController::CpuClock::kDivider) +
-        1;
-    const uint32_t kCalculatedClockFrequency =
-        ((2 * kMultiplier * kDefaultIRCFrequency.to<uint32_t>()) /
-         kPreDivider) /
-        kCpuDivider;
-
-    CHECK(bit::Extract(local_sc.CLKSRCSEL,
-                       SystemController::Oscillator::kSelect) == 0b00);
-    CHECK(kCalculatedClockFrequency == kExpectedFrequency.to<uint32_t>());
-    CHECK(system_controller.GetSystemFrequency() == kExpectedFrequency);
+    CHECK(&clock_configuration == system_controller.GetClockConfiguration());
   }
 
-  SECTION("Set USB PLL Input Frequency")
+  SECTION("Initialize")
   {
-    const SystemController::UsbPllInputFrequency kInputFrequencies[] = {
-      SystemController::UsbPllInputFrequency::kF12MHz,
-      SystemController::UsbPllInputFrequency::kF16MHz,
-      SystemController::UsbPllInputFrequency::kF24MHz
-    };
-    const uint8_t kExpectedMultiplier[] = {
-      Value(SystemController::UsbPllMultiplier::kMultiplyBy4),
-      Value(SystemController::UsbPllMultiplier::kMultiplyBy3),
-      Value(SystemController::UsbPllMultiplier::kMultiplyBy2),
-    };
-    constexpr uint8_t kExpectedDivider =
-        Value(SystemController::UsbPllDivider::kDivideBy1);
+    // Setup
+    units::frequency::hertz_t expected_system_clock_rate =
+        SystemController::kIrcFrequency;
+    units::frequency::hertz_t expected_cpu_clock_rate = 48_MHz;
 
-    for (uint8_t i = 0; i > std::size(kInputFrequencies); i++)
+    SECTION("Configure system clock to drive CPU clock")
     {
-      system_controller.SetUsbPllInputFrequency(kInputFrequencies[i]);
+      clock_configuration.cpu.clock_source =
+          SystemController::CpuClockSource::kSystemClock;
+      clock_configuration.cpu.divider = 1;
 
-      const uint32_t kMultiplier =
-          bit::Extract(local_sc.PLL1CFG, SystemController::UsbPll::kMultiplier);
-      const uint32_t kDivider =
-          bit::Extract(local_sc.PLL1CFG, SystemController::UsbPll::kDivider);
-
-      CHECK(bit::Read(local_sc.PLL1CON, SystemController::Pll::kEnableBit));
-      CHECK(bit::Read(local_sc.PLL1CON, SystemController::Pll::kConnectBit));
-      CHECK(kMultiplier == kExpectedMultiplier[i]);
-      CHECK(kDivider == kExpectedDivider);
-    }
-  }
-
-  // TODO(#1140): Bring this test section back after the update is complete.
-  /*
-  SECTION("Set and Get Peripheral Clock Divider")
-  {
-    // In the kPeripherals array, all the peripheral clock select for
-    // peripherals starting from kRit (index = 13) are in the PCLKSEL1 register
-    // while all the clock selects for peripherals before kRit are in the
-    // PCLKSEL0 register.
-    constexpr uint8_t kPclkSel1StartIndex = 13;
-
-    using Peripherals                     = SystemController::Peripherals;
-
-    const uint8_t kPeripheralDividers[] = { 4, 1, 2, 8 };
-    constexpr uint8_t kDividerBitWidth  = 2;
-    volatile uint32_t * local_pclksel0  = &(local_sc.PCLKSEL0);
-    volatile uint32_t * local_pclksel1  = &(local_sc.PCLKSEL1);
-
-    constexpr auto kSystemFrequency = 48_MHz;
-    system_controller.SetSystemClockFrequency(kSystemFrequency);
-
-    // Test for peripherals in PCLKSEL0
-    for (uint8_t i = 0; i < kPclkSel1StartIndex; i++)
-    {
-      for (uint8_t divider_select = 0; divider_select < 4; divider_select++)
+      SECTION("Using internal RC oscillator (default configuration)")
       {
-        // PCLKSEL0 has two CAN peripherals. For these two peripherals, when the
-        // divider select is 0b11, the divider value used should be 6.
-        const bool kIsCanPeripheral =
-            (kPeripherals[i].device_id == Peripherals::kCan1.device_id ||
-             kPeripherals[i].device_id == Peripherals::kCan2.device_id);
-        uint8_t divider = kPeripheralDividers[divider_select];
-        if (kIsCanPeripheral && (divider_select == 0b11))
+        // Setup
+        expected_cpu_clock_rate = SystemController::kIrcFrequency;
+
+        // Exercise
+        system_controller.Initialize();
+      }
+
+      SECTION("Using main oscillator")
+      {
+        // Setup
+        constexpr auto kClockRate = 12_MHz;
+        std::thread simulated_main_oscillator_is_ready(
+            main_oscillator_becomes_available);
+
+        expected_cpu_clock_rate = kClockRate;
+        clock_configuration.system.clock_source =
+            SystemController::Oscillator::kMain;
+        clock_configuration.main_oscillator.frequency = kClockRate;
+
+        // Exercise
+        system_controller.Initialize();
+        simulated_main_oscillator_is_ready.join();
+      }
+
+      SECTION("Using RTC oscillator")
+      {
+        // Setup
+        expected_cpu_clock_rate = SystemController::kRTCFrequency;
+        clock_configuration.system.clock_source =
+            SystemController::Oscillator::kRtc;
+
+        // Exercise
+        system_controller.Initialize();
+      }
+    }  // Configure system clock to drive CPU clock
+
+    SECTION("Configure CPU clock with PLL0")
+    {
+      std::thread simulated_pll0_is_ready(pll0_becomes_available);
+
+      SECTION("Using internal RC oscillator")
+      {
+        // Setup
+        expected_system_clock_rate = SystemController::kIrcFrequency;
+
+        // Exercise
+        system_controller.Initialize();
+        simulated_pll0_is_ready.join();
+      }
+
+      SECTION("Using main oscillator")
+      {
+        // Setup
+        std::thread simulated_main_oscillator_is_ready(
+            main_oscillator_becomes_available);
+
+        expected_system_clock_rate = 12_MHz;
+
+        clock_configuration.system.clock_source =
+            SystemController::Oscillator::kMain;
+        clock_configuration.main_oscillator.frequency =
+            expected_system_clock_rate;
+        clock_configuration.pll0.multiplier  = 12;
+        clock_configuration.pll0.pre_divider = 1;
+
+        // Exercise
+        system_controller.Initialize();
+        simulated_main_oscillator_is_ready.join();
+        simulated_pll0_is_ready.join();
+      }
+
+      SECTION("Using RTC oscillator")
+      {
+        expected_system_clock_rate = SystemController::kRTCFrequency;
+
+        clock_configuration.system.clock_source =
+            SystemController::Oscillator::kRtc;
+        clock_configuration.pll0.multiplier  = 4395;
+        clock_configuration.pll0.pre_divider = 1;
+
+        // Exercise
+        system_controller.Initialize();
+        simulated_pll0_is_ready.join();
+      }
+    }  // Configure CPU clock with PLL0
+
+    SECTION("Configure USB clock")
+    {
+      // Setup
+      std::thread simulated_main_oscillator_is_ready(
+          main_oscillator_becomes_available);
+      std::thread simulated_pll0_is_ready(pll0_becomes_available);
+
+      SECTION("Using PLL0")
+      {
+        // Setup
+        expected_system_clock_rate = 12_MHz;
+
+        clock_configuration.main_oscillator.frequency =
+            expected_system_clock_rate;
+        clock_configuration.system.clock_source =
+            SystemController::Oscillator::kMain;
+        clock_configuration.usb.clock_source =
+            SystemController::UsbClockSource::kPll0;
+
+        SECTION("when PLL0 outputs 288 MHz")
         {
-          divider = 6;
+          clock_configuration.pll0.multiplier  = 12;
+          clock_configuration.pll0.pre_divider = 1;
+          clock_configuration.usb.divider =
+              SystemController::UsbClockDivider::kDivideBy6;
         }
-        system_controller.SetPeripheralClockDivider(kPeripherals[i], divider);
 
-        const uint32_t kDividerSelect = bit::Extract(
-            *local_pclksel0, kPeripherals[i].device_id * 2, kDividerBitWidth);
-        CHECK(kDividerSelect == divider_select);
-        CHECK(system_controller.GetPeripheralClockDivider(kPeripherals[i]) ==
-              divider);
-        CHECK(system_controller.GetPeripheralFrequency(kPeripherals[i]) ==
-              kSystemFrequency / divider);
-      }
-    }
-    // Test for peripherals in PCLKSEL1
-    for (uint8_t i = kPclkSel1StartIndex; i < std::size(kPeripherals); i++)
-    {
-      for (uint8_t divider_select = 0; divider_select < 4; divider_select++)
+        SECTION("when PLL0 outputs 384 MHz")
+        {
+          clock_configuration.pll0.multiplier  = 16;
+          clock_configuration.pll0.pre_divider = 1;
+          clock_configuration.cpu.divider      = 8;
+          clock_configuration.usb.divider =
+              SystemController::UsbClockDivider::kDivideBy8;
+        }
+
+        SECTION("when PLL0 outputs 480 MHz")
+        {
+          clock_configuration.pll0.multiplier  = 20;
+          clock_configuration.pll0.pre_divider = 1;
+          clock_configuration.cpu.divider      = 10;
+          clock_configuration.usb.divider =
+              SystemController::UsbClockDivider::kDivideBy10;
+        }
+
+        // Exercise
+        system_controller.Initialize();
+        simulated_main_oscillator_is_ready.join();
+        simulated_pll0_is_ready.join();
+
+        // Verify: USB clock configuration
+        uint32_t actual_usb_clock_divider_select =
+            bit::Extract(local_sc.USBCLKCFG,
+                         SystemController::UsbClockRegister::kDividerMask);
+
+        CHECK(actual_usb_clock_divider_select ==
+              Value(clock_configuration.usb.divider));
+      }  // Using PLL0
+
+      SECTION("Using PLL1")
       {
-        const uint8_t kDivider = kPeripheralDividers[divider_select];
-        system_controller.SetPeripheralClockDivider(kPeripherals[i], kDivider);
+        // Setup
+        std::thread simulated_pll1_is_ready(pll1_becomes_available);
 
-        const uint32_t kDividerSelect = bit::Extract(
-            *local_pclksel1, kPeripherals[i].device_id * 2, kDividerBitWidth);
-        CHECK(kDividerSelect == divider_select);
-        CHECK(system_controller.GetPeripheralClockDivider(kPeripherals[i]) ==
-              kDivider);
-        CHECK(system_controller.GetPeripheralFrequency(kPeripherals[i]) ==
-              kSystemFrequency / kDivider);
-      }
+        constexpr std::array<units::frequency::hertz_t, 3>
+            kOscillatorClockRates             = { 12_MHz, 16_MHz, 24_MHz };
+        constexpr std::array kPll1Multipliers = {
+          SystemController::Pll1::Multiplier::kMultiplyBy4,
+          SystemController::Pll1::Multiplier::kMultiplyBy3,
+          SystemController::Pll1::Multiplier::kMultiplyBy2,
+        };
+        constexpr uint8_t kDefaultPll1Divider = 2;
+
+        // Generate a test case for each of the main oscillator frequencies.
+        size_t oscillator_index = GENERATE(0, 1, 2);
+
+        clock_configuration.main_oscillator.frequency =
+            kOscillatorClockRates[oscillator_index];
+        clock_configuration.pll1.multiplier =
+            kPll1Multipliers[oscillator_index];
+        clock_configuration.usb.clock_source =
+            SystemController::UsbClockSource::kPll1;
+
+        // Exercise
+        system_controller.Initialize();
+        simulated_main_oscillator_is_ready.join();
+        simulated_pll0_is_ready.join();
+        simulated_pll1_is_ready.join();
+
+        // Verify: PLL1 configuration
+        uint8_t actual_pll1_multiplier = bit::Extract(
+            local_sc.PLL1CFG,
+            SystemController::Pll1::ConfigurationRegister::kMultiplierMask);
+        uint8_t actual_pll1_divider = bit::Extract(
+            local_sc.PLL1CFG,
+            SystemController::Pll1::ConfigurationRegister::kDividerMask);
+
+        CHECK(actual_pll1_multiplier ==
+              Value(clock_configuration.pll1.multiplier));
+        CHECK(actual_pll1_divider == (kDefaultPll1Divider - 1));
+      }  // Using PLL1
+
+      // Verify: USB clock configuration
+      units::frequency::hertz_t expected_usb_clock_rate = 48_MHz;
+
+      uint8_t actual_usb_clock_select =
+          bit::Read(local_sc.PLL1STAT,
+                    SystemController::Pll1::StatusRegister::kConnectMask);
+      auto actual_usb_clock_rate =
+          system_controller.GetClockRate(SystemController::Clocks::kUsb);
+
+      CHECK(actual_usb_clock_select ==
+            Value(clock_configuration.usb.clock_source));
+      CHECK(actual_usb_clock_rate == expected_usb_clock_rate);
+    }  // Configure USB clock
+
+    // Verify: PLL0 configuration if it is enabled
+    if (clock_configuration.cpu.clock_source ==
+        SystemController::CpuClockSource::kPll0)
+    {
+      // Calculate expected CPU clock rate:
+      //   cpu_clk = (2 * sys_clk * multiplier) / (pre-divider * cpu_divider)
+      expected_cpu_clock_rate = (2 * expected_system_clock_rate *
+                                 clock_configuration.pll0.multiplier) /
+                                clock_configuration.pll0.pre_divider;
+      expected_cpu_clock_rate /= clock_configuration.cpu.divider;
+
+      uint16_t actual_pll0_multiplier = bit::Extract(
+          local_sc.PLL0CFG,
+          SystemController::Pll0::ConfigurationRegister::kMultiplierMask);
+      uint8_t actual_pll0_pre_divider = bit::Extract(
+          local_sc.PLL0CFG,
+          SystemController::Pll0::ConfigurationRegister::kPreDividerMask);
+
+      CHECK(actual_pll0_multiplier ==
+            (clock_configuration.pll0.multiplier - 1));
+      CHECK(actual_pll0_pre_divider ==
+            (clock_configuration.pll0.pre_divider - 1));
     }
-  }
-  */
+
+    // Verify: PLL0 is set to be enabled and connected if it is used a s clock
+    //         source for the CPU clock.
+    CHECK(bit::Read(local_sc.PLL0CON,
+                    SystemController::PllControlRegister::kEnableMask) ==
+          Value(clock_configuration.cpu.clock_source));
+    CHECK(bit::Read(local_sc.PLL0CON,
+                    SystemController::PllControlRegister::kConnectMask) ==
+          Value(clock_configuration.cpu.clock_source));
+
+    // Verify: PLL1 is set to be enabled and connected if it is used a s clock
+    //         source for the USB clock.
+    CHECK(bit::Read(local_sc.PLL1CON,
+                    SystemController::PllControlRegister::kEnableMask) ==
+          Value(clock_configuration.usb.clock_source));
+    CHECK(bit::Read(local_sc.PLL1CON,
+                    SystemController::PllControlRegister::kConnectMask) ==
+          Value(clock_configuration.usb.clock_source));
+
+    // Verify: System clock configuration
+    uint8_t actual_system_clock_select =
+        bit::Extract(local_sc.CLKSRCSEL,
+                     SystemController::ClockSourceSelectRegister::kSelectMask);
+
+    CHECK(actual_system_clock_select ==
+          Value(clock_configuration.system.clock_source));
+
+    // Verify: CPU clock configuration
+    uint8_t actual_cpu_clock_select = bit::Extract(
+        local_sc.PLL0CFG, SystemController::PllControlRegister::kConnectMask);
+    auto actual_cpu_clock_rate =
+        system_controller.GetClockRate(SystemController::Clocks::kCpu);
+    uint8_t actual_cpu_clock_divider = bit::Extract(
+        local_sc.CCLKCFG, SystemController::CpuClockRegister::kDividerMask);
+
+    CHECK(actual_cpu_clock_select ==
+          Value(clock_configuration.cpu.clock_source));
+    CHECK(actual_cpu_clock_rate == expected_cpu_clock_rate);
+    CHECK((actual_cpu_clock_divider + 1) == clock_configuration.cpu.divider);
+
+    // Verify: Peripheral clock rates
+    constexpr uint32_t kPeripheralCount = 32;
+    for (uint32_t i = 0; i < kPeripheralCount; i++)
+    {
+      SystemController::PeripheralID peripheral = { .device_id = i };
+      CHECK(system_controller.GetClockRate(peripheral) ==
+            expected_cpu_clock_rate);
+    }
+  }  // Initialize
 
   SECTION("Peripheral Power Control")
   {
-    volatile uint32_t * pconp_register = &(local_sc.PCONP);
-    // set all peripherals to be initially off
-    *pconp_register = 0;
-    for (uint8_t i = 0; i < std::size(kPeripherals); i++)
+    // Generate a test cases for each peripheral.
+    auto peripheral =
+        GENERATE(SystemController::Peripherals::kTimer0,
+                 SystemController::Peripherals::kTimer1,
+                 SystemController::Peripherals::kUart0,
+                 SystemController::Peripherals::kUart1,
+                 SystemController::Peripherals::kPwm1,
+                 SystemController::Peripherals::kI2c0,
+                 SystemController::Peripherals::kSpi,
+                 SystemController::Peripherals::kRtc,
+                 SystemController::Peripherals::kSsp1,
+                 SystemController::Peripherals::kAdc,
+                 SystemController::Peripherals::kCan1,
+                 SystemController::Peripherals::kCan2,
+                 SystemController::Peripherals::kGpio,
+                 SystemController::Peripherals::kRit,
+                 SystemController::Peripherals::kMotorControlPwm,
+                 SystemController::Peripherals::kQuadratureEncoder,
+                 SystemController::Peripherals::kI2c1,
+                 SystemController::Peripherals::kSsp0,
+                 SystemController::Peripherals::kTimer2,
+                 SystemController::Peripherals::kTimer3,
+                 SystemController::Peripherals::kUart2,
+                 SystemController::Peripherals::kUart3,
+                 SystemController::Peripherals::kI2c2,
+                 SystemController::Peripherals::kI2s);
+
+    INFO("device id: " << peripheral.device_id);
+
+    SECTION("IsPeripheralPoweredUp")
     {
-      CHECK(system_controller.IsPeripheralPoweredUp(kPeripherals[i]) == false);
+      SECTION("Peripheral is on")
+      {
+        // Setup: Set all peripheral power bits to be off except for the
+        //        peripheral to test
+        local_sc.PCONP = 0;
+        local_sc.PCONP = (1 << peripheral.device_id);
 
-      system_controller.PowerUpPeripheral(kPeripherals[i]);
-      CHECK(bit::Read(*pconp_register, kPeripherals[i].device_id) == true);
-      CHECK(system_controller.IsPeripheralPoweredUp(kPeripherals[i]) == true);
+        // Exercise + Verify
+        CHECK(system_controller.IsPeripheralPoweredUp(peripheral) == true);
+      }
 
-      system_controller.PowerDownPeripheral(kPeripherals[i]);
-      CHECK(bit::Read(*pconp_register, kPeripherals[i].device_id) == false);
-      CHECK(system_controller.IsPeripheralPoweredUp(kPeripherals[i]) == false);
+      SECTION("Peripheral is off")
+      {
+        // Setup: Set all peripheral power bits to be on except for the
+        //        peripheral to test
+        local_sc.PCONP = std::numeric_limits<decltype(local_sc.PCONP)>::max();
+        local_sc.PCONP = ~(1 << peripheral.device_id);
+
+        // Exercise + Verify
+        CHECK(system_controller.IsPeripheralPoweredUp(peripheral) == false);
+      }
     }
 
-    SystemController::system_controller = LPC_SC;
-  }
+    SECTION("PowerUpPeripheral")
+    {
+      // Setup: Set all peripherals power bits to be initially off
+      local_sc.PCONP = 0;
+
+      // Exercise
+      system_controller.PowerUpPeripheral(peripheral);
+
+      // Verify
+      CHECK(local_sc.PCONP == (1 << peripheral.device_id));
+    }
+
+    SECTION("PowerDownPeripheral")
+    {
+      // Setup: Set all peripherals power bits to be initially on
+      local_sc.PCONP = std::numeric_limits<decltype(local_sc.PCONP)>::max();
+
+      // Exercise
+      system_controller.PowerDownPeripheral(peripheral);
+
+      // Verify
+      CHECK(local_sc.PCONP == ~(1 << peripheral.device_id));
+    }
+  }  // Peripheral Power Control
+
+  SystemController::system_controller = LPC_SC;
 }
 }  // namespace sjsu::lpc17xx


### PR DESCRIPTION
Removed setting and getting the peripheral clock divider for the LPC17xx system 
controller. By default, a clock divider of 1 is now used for all peripherals.

Resolves #1140