### PR TITLE
Log: increase performance by logging only once

### DIFF
--- a/library/config.hpp
+++ b/library/config.hpp
@@ -1,6 +1,6 @@
-/// \mainpage SJSU-Dev2 Reference Page
+/// @mainpage SJSU-Dev2 Reference Page
 ///
-/// \section welcome_sec Welcome
+/// @section welcome_sec Welcome
 /// This is the reference API documentation for the SJSU-Dev2 Project. The
 /// reference material should be used as such. This page is not a good place to
 /// learn how to use SJSU-Dev2, but instead should be used to get details about
@@ -9,14 +9,14 @@
 ///
 /// <br />
 ///
-/// \section class_api_sec Finding Class APIs
+/// @section class_api_sec Finding Class APIs
 /// The easiest way to get started with the reference material is to go to the
 /// "classes list" page to see all of the classes and data structures used in
 /// SJSU-Dev2.
 ///
 /// <br />
 ///
-/// \section namespace_sec Finding everything within the SJSU Namespace
+/// @section namespace_sec Finding everything within the SJSU Namespace
 /// See the the "namespace" page and open the sjsu drop down to see everything
 /// contained within the sjsu namespace. This will include data structures,
 /// templated functions, class interfaces (not their descendants), and
@@ -24,7 +24,7 @@
 ///
 /// <br />
 ///
-/// \section support_sec Contact & Support
+/// @section support_sec Contact & Support
 /// If you want to contribute to SJSU-Dev2, check out the documentation
 /// <a
 ///  href="https://sjsu-dev2.readthedocs.io/en/latest/contributing/philosophy/">
@@ -36,7 +36,7 @@
 ///
 /// <br />
 ///
-/// \section license_sec License
+/// @section license_sec License
 ///
 /// <a href="https://github.com/kammce/SJSU-Dev2/blob/master/LICENSE">
 /// Apache License Version 2.0
@@ -66,8 +66,8 @@ namespace config
 /// don't forget to include the config:: scope for the kConstant. Example:
 /// config::kConstant.
 ///
-/// How to create a new global configuration option:
-/// ================================================
+/// How to add a new global configuration option:
+/// ==============================================
 /// 1) Check if the macro is already defined. The macros should only be changed
 ///    in the <project_config.hpp> file
 ///
@@ -215,6 +215,14 @@ SJ2_DECLARE_CONSTANT(STORE_ERROR_MESSAGE, bool, kStoreErrorMessages);
 SJ2_DECLARE_CONSTANT(AUTOMATICALLY_PRINT_ON_ERROR,
                      bool,
                      kAutomaticallyPrintOnError);
+
+/// Enable or disable float support in printf statements. Setting to false will
+/// reduce binary size.
+#if !defined(SJ2_PRINTF_BUFFER_SIZE)
+#define SJ2_PRINTF_BUFFER_SIZE 256
+#endif  // !defined(PRINTF_SUPPORT_FLOAT)
+/// Delcare Constant AUTOMATICALLY_PRINT_ON_ERROR
+SJ2_DECLARE_CONSTANT(PRINTF_BUFFER_SIZE, size_t, kPrintfBufferSize);
 
 /// Enable or disable float support in printf statements. Setting to false will
 /// reduce binary size.

--- a/library/third_party/printf/printf.cpp
+++ b/library/third_party/printf/printf.cpp
@@ -144,11 +144,9 @@ typedef struct {
 extern "C" int _write(int file, char * ptr, int length);
 // internal chunk output
 
-#define PRINTF_BUFFER_CHUNK_SIZE 512
-
 void _out_chunk(char character, void* buffer, size_t idx, size_t)
 {
-  size_t string_limit = PRINTF_BUFFER_CHUNK_SIZE - 2;
+  size_t string_limit = SJ2_PRINTF_BUFFER_SIZE - 2;
   size_t proper_index = idx % (string_limit);
   ((char*)buffer)[proper_index] = character;
   // if character == '\0', flush the buffer.
@@ -899,7 +897,7 @@ int printf(const char* format, ...)
 {
   va_list va;
   va_start(va, format);
-  char buffer[PRINTF_BUFFER_CHUNK_SIZE];
+  char buffer[SJ2_PRINTF_BUFFER_SIZE];
   const int ret = _vsnprintf(_out_chunk, buffer, (size_t)-1, format, va);
   va_end(va);
   return ret;

--- a/library/utility/log.hpp
+++ b/library/utility/log.hpp
@@ -14,6 +14,8 @@
 #include <experimental/source_location>
 #endif
 
+#include <algorithm>
+#include <array>
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>
@@ -54,21 +56,48 @@ struct Log  // NOLINT
       const std::experimental::source_location & location =
           std::experimental::source_location::current())
   {
-    printf("%s" SJ2_HI_BLUE ":%s:" SJ2_HI_GREEN "%s():" SJ2_HI_YELLOW
-           "%" PRIuLEAST32 "> " SJ2_WHITE,
-           log_type,
-           FileBasename(location.file_name()),
-           location.function_name(),
-           location.line());
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
-    // Without the pragmas disabling the format security warning, this will give
-    // a warning everytime it is used.
-    printf(format, params...);
-#pragma GCC diagnostic pop
 
-    puts(SJ2_COLOR_RESET);
+    // Container for the formated log string
+    std::array<char, config::kPrintfBufferSize> buffer;
+
+    // Write log prefix statement to the buffer.
+    int position =
+        snprintf(buffer.data(), buffer.size(),
+                 "%s" SJ2_HI_BLUE ":%s:" SJ2_HI_GREEN "%s():" SJ2_HI_YELLOW
+                 "%" PRIuLEAST32 "> " SJ2_WHITE,
+                 log_type, FileBasename(location.file_name()),
+                 location.function_name(), location.line());
+
+    int bytes_left = 0;
+
+    // Write the actual log message into the buffer
+    bytes_left = std::max(static_cast<int>(buffer.size()) - position, 0);
+    position += snprintf(&buffer[position], bytes_left, format, params...);
+
+    // Write the ending of the log statement that appends a newline and a color
+    // reset command.
+    bytes_left = std::max(static_cast<int>(buffer.size()) - position, 0);
+    position += snprintf(&buffer[position], bytes_left, "\n" SJ2_COLOR_RESET);
+
+    // If we have exceeded the limits of the log statement, we truncate the
+    // message and add an "..." at the end, to indicate that data was
+    // trimmed/lost.
+    if (static_cast<size_t>(position) >= buffer.size() - 1)
+    {
+      static constexpr std::string_view kEllipsisEnding =
+          "...\n" SJ2_COLOR_RESET;
+      position = buffer.size() - (kEllipsisEnding.size() + 1);
+      std::copy(kEllipsisEnding.begin(), kEllipsisEnding.end(),
+                &buffer[position]);
+    }
+
+    // Finally use fputs to pass buffer to stdout, typically UART port or
+    // semihost.
+    fputs(buffer.data(), stdout);
+
+#pragma GCC diagnostic pop
   }
 };
 
@@ -96,8 +125,8 @@ struct LogDebug  // NOLINT
     _SJ2_USED(format);
     if constexpr (config::kLogLevel <= SJ2_LOG_LEVEL_DEBUG)
     {
-      Log<Params...>(
-          SJ2_BACKGROUND_PURPLE "   DEBUG", format, params..., location);
+      Log<Params...>(SJ2_BACKGROUND_PURPLE "   DEBUG", format, params...,
+                     location);
     }
   }
 };
@@ -126,8 +155,8 @@ struct LogInfo  // NOLINT
     _SJ2_USED(format);
     if constexpr (config::kLogLevel <= SJ2_LOG_LEVEL_INFO)
     {
-      Log<Params...>(
-          SJ2_BACKGROUND_GREEN "    INFO", format, params..., location);
+      Log<Params...>(SJ2_BACKGROUND_GREEN "    INFO", format, params...,
+                     location);
     }
   }
 };
@@ -158,8 +187,8 @@ struct LogWarning  // NOLINT
     _SJ2_USED(format);
     if constexpr (config::kLogLevel <= SJ2_LOG_LEVEL_WARNING)
     {
-      Log<Params...>(
-          SJ2_BACKGROUND_YELLOW " WARNING", format, params..., location);
+      Log<Params...>(SJ2_BACKGROUND_YELLOW " WARNING", format, params...,
+                     location);
     }
   }
 };
@@ -188,8 +217,8 @@ struct LogError  // NOLINT
     _SJ2_USED(format);
     if constexpr (config::kLogLevel <= SJ2_LOG_LEVEL_ERROR)
     {
-      Log<Params...>(
-          SJ2_BACKGROUND_RED "   ERROR", format, params..., location);
+      Log<Params...>(SJ2_BACKGROUND_RED "   ERROR", format, params...,
+                     location);
     }
   }
 };


### PR DESCRIPTION
- printf and log buffer size has been reduced from 512 and 256
- printf and log buffer size can now be adjusted via config.hpp
  usig the SJ2_PRINTF_BUFFER_SIZE flag

Resolves #1154