### PR TITLE
Printf: Add config for single precision float

### DIFF
--- a/demos/multiplatform/log_level_print/project_config.hpp
+++ b/demos/multiplatform/log_level_print/project_config.hpp
@@ -4,7 +4,6 @@
 #pragma once
 #include "log_levels.hpp"
 
-#define SJ2_DESCRIPTIVE_FUNCTION_NAME true
 // Be sure to enable ANSI color for the terminal. Disable this if your terminal
 // application does not support colored text.
 #define SJ2_ENABLE_ANSI_CODES true

--- a/demos/multiplatform/status/project_config.hpp
+++ b/demos/multiplatform/status/project_config.hpp
@@ -4,7 +4,6 @@
 #pragma once
 #include "log_levels.hpp"
 
-#define SJ2_DESCRIPTIVE_FUNCTION_NAME true
 // Be sure to enable ANSI color for the terminal. Disable this if your terminal
 // application does not support colored text.
 #define SJ2_ENABLE_ANSI_CODES true

--- a/library/config.hpp
+++ b/library/config.hpp
@@ -224,11 +224,21 @@ SJ2_DECLARE_CONSTANT(AUTOMATICALLY_PRINT_ON_ERROR,
 /// Delcare Constant AUTOMATICALLY_PRINT_ON_ERROR
 SJ2_DECLARE_CONSTANT(PRINTF_BUFFER_SIZE, size_t, kPrintfBufferSize);
 
-/// Enable or disable float support in printf statements. Setting to false will
-/// reduce binary size.
+/// Enable or disable single precision float support in printf statements.
+/// Setting to false will disable floating point rendering. This floating point
+/// support is low cost, but can be imprecise. If you want to support
+/// exponential and precision floating point, disable this and set
+/// SJ2_PRINTF_SUPPORT_PRECISION_FLOAT to true.
 #if !defined(SJ2_PRINTF_SUPPORT_FLOAT)
 #define SJ2_PRINTF_SUPPORT_FLOAT true
 #endif  // !defined(PRINTF_SUPPORT_FLOAT)
+
+/// Enable or disable precision float support in printf statements. Setting to
+/// false will reduce binary size. Needed to enable exponential rendering of
+/// floats. Enabling this will override single precision float support.
+#if !defined(SJ2_PRINTF_SUPPORT_PRECISION_FLOAT)
+#define SJ2_PRINTF_SUPPORT_PRECISION_FLOAT false
+#endif  // !defined(PRINTF_SUPPORT_PRECISION_FLOAT)
 
 /// Enable printing of 64 bit numbers. Setting to false will reduce binary size.
 #if !defined(SJ2_PRINTF_SUPPORT_LONG_LONG)
@@ -252,10 +262,16 @@ SJ2_DECLARE_CONSTANT(PRINTF_BUFFER_SIZE, size_t, kPrintfBufferSize);
 #if SJ2_PRINTF_SUPPORT_FLOAT == false
 #define PRINTF_DISABLE_SUPPORT_FLOAT
 #endif
+
+#if SJ2_PRINTF_SUPPORT_PRECISION_FLOAT == false
+#define PRINTF_DISABLE_PRECISION_SUPPORT_FLOAT
+#endif
+
 /// Enables LONG LONG support for the 3rd party printf library.
 #if SJ2_PRINTF_SUPPORT_LONG_LONG == false
 #define PRINTF_DISABLE_SUPPORT_LONG_LONG
 #endif
+
 /// Enables PTRDIFF support for the 3rd party printf library.
 #if SJ2_PRINTF_SUPPORT_PTRDIFF_T == false
 #define PRINTF_DISABLE_SUPPORT_PTRDIFF_T

--- a/library/third_party/printf/printf.cpp
+++ b/library/third_party/printf/printf.cpp
@@ -33,6 +33,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <unistd.h>
+#include <cinttypes>
 
 #include "printf.h"
 #include "config.hpp"
@@ -64,6 +65,12 @@
 // default: activated
 #ifndef PRINTF_DISABLE_SUPPORT_FLOAT
 #define PRINTF_SUPPORT_FLOAT
+#endif
+
+// support for the floating point type (%f)
+// default: activated
+#ifndef PRINTF_DISABLE_PRECISION_SUPPORT_FLOAT
+#define PRINTF_SUPPORT_PRECISION_FLOAT
 #endif
 
 // support for exponential floating point notation (%e/%g)
@@ -113,11 +120,8 @@
 #define FLAGS_PRECISION (1U << 10U)
 #define FLAGS_ADAPT_EXP (1U << 11U)
 
-
 // import float.h for DBL_MAX
-#if defined(PRINTF_SUPPORT_FLOAT)
 #include <float.h>
-#endif
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wall"
@@ -360,16 +364,61 @@ static size_t _ntoa_long_long(out_fct_type out, char* buffer, size_t idx, size_t
 }
 #endif  // PRINTF_SUPPORT_LONG_LONG
 
-
-#if defined(PRINTF_SUPPORT_FLOAT)
-
-#if defined(PRINTF_SUPPORT_EXPONENTIAL)
 // forward declaration so that _ftoa can switch to exp notation for values > PRINTF_MAX_FLOAT
+[[maybe_unused]]
 static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, double value, unsigned int prec, unsigned int width, unsigned int flags);
-#endif
 
+static float _PowerOf10(uint32_t exponent)
+{
+  float result = 1;
+  for (uint32_t i = 0; i < exponent; i++)
+  {
+    result *= 10.0f;
+  }
+  return result;
+}
+
+// SJSU-Dev2: Added to minimize the cost of utilizing floating point arithmetic
+[[maybe_unused]] static size_t _imprecise_ftoa(out_fct_type,
+                                               char * buffer,
+                                               size_t idx,
+                                               size_t maxlen,
+                                               float value,
+                                               unsigned int precision,
+                                               unsigned int flags)
+{
+  static constexpr float kRounders[] = {
+    0.5f, 0.05f, 0.005f, 0.0005f, 0.00005f, 0.000005f, 0.0000005f, 0.00000005f,
+  };
+
+  const char * negative = "";
+
+  if (value < 0)
+  {
+    negative = "-";
+    value    = -value;
+  }
+
+  // set default precision, if not set explicitly
+  if (!(flags & FLAGS_PRECISION))
+  {
+    precision = PRINTF_DEFAULT_FLOAT_PRECISION;
+  }
+
+  precision = std::min(precision, PRINTF_DEFAULT_FLOAT_PRECISION);
+  value += kRounders[precision];
+
+  int32_t whole       = static_cast<int32_t>(value);
+  float whole_float   = static_cast<float>(whole);
+  float decimal_float = (value - whole_float) * _PowerOf10(precision);
+  int32_t decimal     = static_cast<int32_t>(decimal_float);
+  int next_position   = snprintf(&buffer[idx], maxlen, "%s%" PRId32 ".%" PRId32,
+                               negative, whole, decimal);
+  return idx + next_position;
+}
 
 // internal ftoa for fixed decimal floating point
+[[maybe_unused]]
 static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, double value, unsigned int prec, unsigned int width, unsigned int flags)
 {
   char buf[PRINTF_FTOA_BUFFER_SIZE];
@@ -495,9 +544,8 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
   return _out_rev(out, buffer, idx, maxlen, buf, len, width, flags);
 }
 
-
-#if defined(PRINTF_SUPPORT_EXPONENTIAL)
 // internal ftoa variant for exponential floating-point type, contributed by Martijn Jasperse <m.jasperse@gmail.com>
+[[maybe_unused]]
 static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, double value, unsigned int prec, unsigned int width, unsigned int flags)
 {
   // check for NaN and special values
@@ -603,13 +651,13 @@ static size_t _etoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
   }
   return idx;
 }
-#endif  // PRINTF_SUPPORT_EXPONENTIAL
-#endif  // PRINTF_SUPPORT_FLOAT
-
 
 // internal vsnprintf
 static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const char* format, va_list va)
 {
+#if defined(SJ2_INCLUDE_VSNPRINTF) && SJ2_INCLUDE_VSNPRINTF == false
+  return 0;
+#endif
   unsigned int flags, width, precision, n;
   size_t idx = 0U;
 
@@ -788,7 +836,8 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
         format++;
         break;
       }
-#if defined(PRINTF_SUPPORT_FLOAT)
+
+#if defined(PRINTF_SUPPORT_PRECISION_FLOAT)
       case 'f' :
       case 'F' :
         if (*format == 'F') flags |= FLAGS_UPPERCASE;
@@ -806,7 +855,15 @@ static int _vsnprintf(out_fct_type out, char* buffer, const size_t maxlen, const
         format++;
         break;
 #endif  // PRINTF_SUPPORT_EXPONENTIAL
+#elif defined(PRINTF_SUPPORT_FLOAT)
+      case 'f':
+      case 'F':
+        idx = _imprecise_ftoa(out, buffer, idx, maxlen,
+                              (float)va_arg(va, double), precision, flags);
+        format++;
+        break;
 #endif  // PRINTF_SUPPORT_FLOAT
+
       case 'c' : {
         unsigned int l = 1U;
         // pre padding

--- a/projects/barebones/project_config.hpp
+++ b/projects/barebones/project_config.hpp
@@ -2,13 +2,12 @@
 #pragma once
 
 #define SJ2_LOG_LEVEL SJ2_LOG_LEVEL_ERROR
-#define SJ2_DESCRIPTIVE_FUNCTION_NAME false
 #define SJ2_PRINTF_SUPPORT_FLOAT false
+#define SJ2_PRINTF_SUPPORT_PRECISION_FLOAT false
 #define SJ2_PRINTF_SUPPORT_LONG_LONG false
 #define SJ2_PRINTF_SUPPORT_PTRDIFF_T false
 #define SJ2_INCLUDE_BACKTRACE false
 #define SJ2_ENABLE_ANSI_CODES false
-#define SJ2_DESCRIPTIVE_FUNCTION_NAME false
 #define SJ2_INCLUDE_VSNPRINTF false
 
 #include "config.hpp"

--- a/projects/hello_world/project.mk
+++ b/projects/hello_world/project.mk
@@ -1,4 +1,1 @@
-# USER_TESTS += $(LIBRARY_DIR)/L1_Peripheral/cortex/test/dwt_counter_test.cpp
 USER_TESTS += $(LIBRARY_DIR)/utility/test/bit_test.cpp
-# USER_TESTS += $(LIBRARY_DIR)/L1_Peripheral/test/uart_test.cpp
-# USER_TESTS += $(LIBRARY_DIR)/L2_HAL/sensors/distance/time_of_flight/test/tfmini_test.cpp

--- a/projects/hello_world/project_config.hpp
+++ b/projects/hello_world/project_config.hpp
@@ -4,6 +4,5 @@
 #pragma once
 
 #define SJ2_LOG_LEVEL SJ2_LOG_LEVEL_INFO
-#define SJ2_AUTOMATICALLY_PRINT_ON_ERROR false
 
 #include "config.hpp"


### PR DESCRIPTION
- Added config for SJ2_PRINTF_SUPPORT_PRECISION_FLOAT which will use
  tiny-printf's ftoa implementation for floating point, which uses
  double precision.
- SJ2_PRINTF_SUPPORT_FLOAT now uses single precision floats and a simple
  and light weight implementation that results in a 4500 byte reduction on
  binary size.

Resolves #1170