### PR TITLE
Fix .data and .bss initialization functions

### DIFF
--- a/library/L0_Platform/L0.mk
+++ b/library/L0_Platform/L0.mk
@@ -1,5 +1,7 @@
 INCLUDES += $(LIBRARY_DIR)/L0_Platform/freertos
 
+TESTS += $(LIBRARY_DIR)/L0_Platform/test/ram_test.cpp
+
 NO_TEST_NEEDED += $(LIBRARY_DIR)/L0_Platform/%
 
 # FreeRTOS

--- a/library/L0_Platform/ram.hpp
+++ b/library/L0_Platform/ram.hpp
@@ -39,32 +39,26 @@ inline uint8_t * heap_position = &heap;
 
 namespace sjsu
 {
-// Functions to carry out the initialization of RW and BSS data sections.
+/// Copies the defined variabes within the .data section in ROM into RAM
 inline void InitializeDataSection()
 {
-  for (int i = 0; &data_section_table[i] < &data_section_table_end; i++)
+  uint32_t * rom_location = data_section_table[0].rom_location;
+  uint32_t * ram_location = data_section_table[0].ram_location;
+  uint32_t length         = data_section_table[0].length / sizeof(uint32_t);
+  for (size_t j = 0; j < length; j++)
   {
-    uint32_t * rom_location = data_section_table[i].rom_location;
-    uint32_t * ram_location = data_section_table[i].ram_location;
-    uint32_t length         = data_section_table[i].length;
-    for (size_t j = 0; j < length; j++)
-    {
-      ram_location[j] = rom_location[j];
-    }
+    ram_location[j] = rom_location[j];
   }
 }
-// Functions to initialization BSS data sections. This is important because
-// the std c libs assume that BSS is set to zero.
+/// Initializes the .bss section of RAM. The STD C libraries assume that BSS is
+/// set to zero and will fault otherwise.
 inline void InitializeBssSection()
 {
-  for (int i = 0; &bss_section_table[i] < &bss_section_table_end; i++)
+  uint32_t * ram_location = bss_section_table[0].ram_location;
+  uint32_t length         = bss_section_table[0].length / sizeof(uint32_t);
+  for (size_t j = 0; j < length; j++)
   {
-    uint32_t * ram_location = bss_section_table[i].ram_location;
-    uint32_t length         = bss_section_table[i].length;
-    for (size_t j = 0; j < length; j++)
-    {
-      ram_location[j] = 0;
-    }
+    ram_location[j] = 0;
   }
 }
 }  // namespace sjsu

--- a/library/L0_Platform/test/ram_test.cpp
+++ b/library/L0_Platform/test/ram_test.cpp
@@ -1,0 +1,86 @@
+#include <cstdint>
+#include <cstring>
+
+#include "L4_Testing/testing_frameworks.hpp"
+#include "L0_Platform/ram.hpp"
+
+namespace
+{
+struct DataSection_t
+{
+  int32_t a;
+  uint8_t b;
+  double d;
+  uint16_t s;
+};
+
+DataSection_t rom = {
+  .a = 15,
+  .b = 'C',
+  .d = 5.0,
+  .s = 12'346U,
+};
+
+DataSection_t ram;
+
+std::array<uint32_t, 128> bss_section;
+}  // namespace
+
+DataSectionTable_t data_section_table[] = {
+  DataSectionTable_t{
+      .rom_location = reinterpret_cast<uint32_t *>(&rom),
+      .ram_location = reinterpret_cast<uint32_t *>(&ram),
+      .length       = sizeof(rom),
+  },
+};
+
+// NOTE: Not used, but must be defined
+DataSectionTable_t data_section_table_end;
+
+BssSectionTable_t bss_section_table[] = {
+  BssSectionTable_t{
+      .ram_location = bss_section.data(),
+      .length       = bss_section.size(),
+  },
+};
+
+// NOTE: Not used, but must be defined
+BssSectionTable_t bss_section_table_end;
+
+namespace sjsu
+{
+TEST_CASE("Testing Ram Initialization", "[ram-init]")
+{
+  SECTION(".data")
+  {
+    // Setup
+    memset(&ram, 0, sizeof(ram));
+
+    // Exercise
+    sjsu::InitializeDataSection();
+
+    // Verify
+    CHECK(memcmp(&rom, &ram, sizeof(rom)) == 0);
+  }
+
+  SECTION(".bss")
+  {
+    // Setup
+    // Setup: Fill the expected_blank_bss_section with all zeros.
+    std::array<uint32_t, bss_section.size()> expected_blank_bss_section;
+    memset(expected_blank_bss_section.data(), 0,
+           expected_blank_bss_section.size());
+    // Setup: Fill the bss_section to be cleared with an arbitary value. This
+    //        value should be cleared to zero after calling
+    //        `InitializeBssSection()`
+    memset(bss_section.data(), 0xA5A5A5A5, bss_section.size());
+
+    // Exercise
+    sjsu::InitializeBssSection();
+
+    // Verify
+    CHECK(memcmp(expected_blank_bss_section.data(), bss_section.data(),
+                 bss_section.size()) == 0);
+  }
+}
+}  // namespace sjsu

--- a/projects/hello_world/project.mk
+++ b/projects/hello_world/project.mk
@@ -1,1 +1,1 @@
-USER_TESTS += $(LIBRARY_DIR)/utility/test/bit_test.cpp
+USER_TESTS += $(LIBRARY_DIR)/L0_Platform/test/ram_test.cpp


### PR DESCRIPTION
- Adds unit tests for these functions
- Now ram initialization only supports a single data section. If
  initialization of additional data sections are needed, then the ResetISR
  function for your platform will need to be overridden for your
  purposes.

Resolves #1186