### PR TITLE
Error_t now obeys config::kIncludeBacktrace

### DIFF
--- a/library/utility/status.hpp
+++ b/library/utility/status.hpp
@@ -227,10 +227,13 @@ struct Error_t
     if constexpr (config::kAutomaticallyPrintOnError)
     {
       Print();
-      printf(SJ2_HI_BOLD_WHITE "\nBacktrace:" SJ2_COLOR_RESET);
-      int depth = 0;
-      _Unwind_Backtrace(&debug::PrintAddressInRow, &depth);
-      puts("");
+      if constexpr (config::kIncludeBacktrace)
+      {
+        printf(SJ2_HI_BOLD_WHITE "\nBacktrace:" SJ2_COLOR_RESET);
+        int depth = 0;
+        _Unwind_Backtrace(&debug::PrintAddressInRow, &depth);
+        puts("");
+      }
     }
   }
 


### PR DESCRIPTION
Resolves #1182