### PR TITLE
Storage: Optimize Returns<> usage in API

### DIFF
--- a/demos/sjtwo/sd_card_experimental/source/main.cpp
+++ b/demos/sjtwo/sd_card_experimental/source/main.cpp
@@ -110,8 +110,8 @@ int main()
   sjsu::LogInfo("Mounting of SD Card was" SJ2_HI_BOLD_GREEN " successful!");
 
   sjsu::LogInfo("Gather SD Card information...");
-  units::data::gigabyte_t capacity = card.GetCapacity().value_or(0_B);
-  units::data::byte_t block_size   = card.GetBlockSize().value_or(0_B);
+  units::data::gigabyte_t capacity = card.GetCapacity();
+  units::data::byte_t block_size   = card.GetBlockSize();
   bool is_read_only                = card.IsReadOnly();
 
   sjsu::LogInfo("SD Card Capacity   = " SJ2_HI_BOLD_GREEN "%f GB",

--- a/demos/stm32f10x/sd_card/source/main.cpp
+++ b/demos/stm32f10x/sd_card/source/main.cpp
@@ -130,8 +130,8 @@ int main()
   sjsu::LogInfo("Mounting of SD Card was" SJ2_HI_BOLD_GREEN " successful!");
 
   sjsu::LogInfo("Gather SD Card information...");
-  units::data::gigabyte_t capacity = card.GetCapacity().value_or(0_B);
-  units::data::byte_t block_size   = card.GetBlockSize().value_or(0_B);
+  units::data::gigabyte_t capacity = card.GetCapacity();
+  units::data::byte_t block_size   = card.GetBlockSize();
   bool is_read_only                = card.IsReadOnly();
 
   sjsu::LogInfo("SD Card Capacity   = " SJ2_HI_BOLD_GREEN "%f GB",

--- a/library/L1_Peripheral/inactive.hpp
+++ b/library/L1_Peripheral/inactive.hpp
@@ -362,19 +362,15 @@ inline sjsu::Storage & GetInactive<sjsu::Storage>()
     {
       return {};
     }
-    Returns<void> Disable() override
-    {
-      return {};
-    }
     bool IsReadOnly() override
     {
       return {};
     }
-    Returns<units::data::byte_t> GetCapacity() override
+    units::data::byte_t GetCapacity() override
     {
       return 0_B;
     }
-    Returns<units::data::byte_t> GetBlockSize() override
+    units::data::byte_t GetBlockSize() override
     {
       return 0_B;
     }
@@ -387,6 +383,10 @@ inline sjsu::Storage & GetInactive<sjsu::Storage>()
       return {};
     }
     Returns<void> Read(uint32_t, void *, size_t) override
+    {
+      return {};
+    }
+    Returns<void> Disable() override
     {
       return {};
     }

--- a/library/L1_Peripheral/lpc40xx/eeprom.hpp
+++ b/library/L1_Peripheral/lpc40xx/eeprom.hpp
@@ -109,12 +109,12 @@ class Eeprom final : public sjsu::Storage
     return false;
   }
 
-  Returns<units::data::byte_t> GetCapacity() override
+  units::data::byte_t GetCapacity() override
   {
     return 4_kB;
   }
 
-  Returns<units::data::byte_t> GetBlockSize() override
+  units::data::byte_t GetBlockSize() override
   {
     return 4_B;
   }

--- a/library/L1_Peripheral/lpc40xx/test/eeprom_test.cpp
+++ b/library/L1_Peripheral/lpc40xx/test/eeprom_test.cpp
@@ -90,9 +90,9 @@ TEST_CASE("Testing EEPROM", "[Eeprom]")
 
   SECTION("Methods that return constants")
   {
-    CHECK(test_eeprom.GetBlockSize().value() == 4_B);
+    CHECK(test_eeprom.GetBlockSize() == 4_B);
     CHECK(test_eeprom.GetMemoryType() == Storage::Type::kEeprom);
-    CHECK(test_eeprom.GetCapacity().value() == 4_kB);
+    CHECK(test_eeprom.GetCapacity() == 4_kB);
     CHECK(test_eeprom.IsReadOnly() == false);
     CHECK(test_eeprom.IsMediaPresent() == true);
   }

--- a/library/L1_Peripheral/storage.hpp
+++ b/library/L1_Peripheral/storage.hpp
@@ -35,40 +35,49 @@ class Storage
   };
 
   /// @return the type of memory this driver controls. Can be called without
-  /// calling Initialize() first.
+  ///         calling Initialize() first.
   virtual Type GetMemoryType() = 0;
 
   /// Initialize all peripherals required to make communicate with the storage
-  /// media possible.
-  /// MUST be called before calling any method in this interface with the
-  /// exception of `GetMemoryType()`
+  /// media possible. MUST be called before calling any method in this interface
+  /// with the exception of `GetMemoryType()`
   virtual Returns<void> Initialize() = 0;
 
-  /// @return true if the storage is present. For cases where the memory cannot
-  /// be removed or is physically located within a device, this should always
-  /// return true.
-  /// @return false if storage media is not present.
-  virtual bool IsMediaPresent() = 0;
-
-  /// Should prepare and configure the storage media for communication such as
-  /// Write(), Read(), Erase()
+  /// Will prepare and configure storage media for communication.
+  /// This method can only be called after `Initialize()` was called
+  /// successfully without returning an `Error_t`.
+  /// This method MUST be called in order for the following methods to operate:
+  ///
+  ///    bool IsReadOnly()
+  ///    units::data::byte_t GetCapacity()
+  ///    units::data::byte_t GetBlockSize()
+  ///    Returns<void> Erase(uint32_t, size_t)
+  ///    Returns<void> Write(uint32_t, const void *, size_t)
+  ///    Returns<void> Read(uint32_t, void *, size_t)
+  ///    Returns<void> Disable()
+  ///
+  /// Calling any of these methods before `Enable()` has been called
+  /// successfully, will result in undefined behavior.
   virtual Returns<void> Enable() = 0;
 
-  /// Should shutdown the device.
-  virtual Returns<void> Disable() = 0;
+  /// @return true if the storage is present. For cases where the memory cannot
+  ///         be removed or is physically located within a device, this should
+  ///         always return true.
+  /// @return false if storage media is not present.
+  virtual bool IsMediaPresent() = 0;
 
   /// @return true if device is not writable.
   virtual bool IsReadOnly() = 0;
 
   /// @return the maximum capacity of this storage media. This includes areas
-  /// that have already been written to. This does not include sections of the
-  /// memory that are not accessible. For example, if the first 2kB of the
-  /// memory cannot be accessed via this driver, then it should not be
-  /// considered as apart of the capacity.
-  virtual Returns<units::data::byte_t> GetCapacity() = 0;
+  ///         that have already been written to. This does not include sections
+  ///         of the memory that are not accessible. For example, if the first
+  ///         2kB of the memory cannot be accessed via this driver, then it
+  ///         should not be considered as apart of the capacity.
+  virtual units::data::byte_t GetCapacity() = 0;
 
   /// @return the number of bytes per block.
-  virtual Returns<units::data::byte_t> GetBlockSize() = 0;
+  virtual units::data::byte_t GetBlockSize() = 0;
 
   /// Must be called before a `Write()` operation. Erases the contents of the
   /// storage media in the location specified, the number of bytes given. Some
@@ -78,7 +87,7 @@ class Storage
   /// @param block_address - starting block to erase.
   /// @param blocks_count - the number of bytes to erase.
   /// @return Status of if the operation was successful, otherwise, returns an
-  /// appropriate status signal.
+  ///         appropriate status signal.
   virtual Returns<void> Erase(uint32_t block_address, size_t blocks_count) = 0;
 
   /// Write data to the storage media in the location block specified. If the
@@ -93,7 +102,7 @@ class Storage
   /// @param size - the number of bytes to write into memory. Can be less than
   ///               the size of a block.
   /// @return Status of if the operation was successful, otherwise, returns an
-  /// appropriate status signal.
+  ///         appropriate status signal.
   virtual Returns<void> Write(uint32_t block_address,
                               const void * data,
                               size_t size) = 0;
@@ -105,9 +114,12 @@ class Storage
   /// @param size - the number of bytes to read from memory. Can be less than
   ///               the size of a block.
   /// @return Status of if the operation was successful, otherwise, return an
-  /// appropriate status signal.
+  ///         appropriate status signal.
   virtual Returns<void> Read(uint32_t block_address,
                              void * data,
                              size_t size) = 0;
+
+  /// Should shutdown the device.
+  virtual Returns<void> Disable() = 0;
 };
 }  // namespace sjsu

--- a/library/L2_HAL/memory/sd_experimental.hpp
+++ b/library/L2_HAL/memory/sd_experimental.hpp
@@ -11,6 +11,7 @@
 #include "L1_Peripheral/inactive.hpp"
 #include "utility/log.hpp"
 #include "utility/crc.hpp"
+#include "utility/units.hpp"
 
 namespace sjsu::experimental
 {
@@ -254,12 +255,12 @@ class Sd : public Storage
     return false;
   }
 
-  Returns<units::data::byte_t> GetBlockSize() override
+  units::data::byte_t GetBlockSize() override
   {
     return units::data::byte_t{ kBlockSize };
   }
 
-  Returns<units::data::byte_t> GetCapacity() override
+  units::data::byte_t GetCapacity() override
   {
     // The c_size register's contents can be found in bits [48:69]
     constexpr bit::Mask kCSizeMask = bit::CreateMaskFromRange(48, 69);

--- a/library/L2_HAL/memory/test/sd_experimental_test.cpp
+++ b/library/L2_HAL/memory/test/sd_experimental_test.cpp
@@ -111,7 +111,7 @@ TEST_CASE("Testing [experimental] SD Card Driver Class", "[sd-experimental]")
 
   SECTION("GetBlockSize()")
   {
-    CHECK(512_B == sd.GetBlockSize().value());
+    CHECK(512_B == sd.GetBlockSize());
   }
 
   SECTION("IsReadOnly()")
@@ -134,7 +134,7 @@ TEST_CASE("Testing [experimental] SD Card Driver Class", "[sd-experimental]")
     const units::data::byte_t kExpectedSize = (kCSize + 1) * 512_KiB;
 
     // Exercise
-    auto actual_size = sd.GetCapacity().value();
+    auto actual_size = sd.GetCapacity();
 
     // Verify
     INFO("Expected = " << kExpectedSize.to<float>()

--- a/library/L3_Application/file_io/diskio.cpp
+++ b/library/L3_Application/file_io/diskio.cpp
@@ -144,8 +144,7 @@ extern "C" DRESULT disk_read(BYTE drive_number,
   auto & storage = drive[drive_number];
 
   // Get the number of bytes per block for this media.
-  units::data::byte_t block_size =
-      SJ2_RETURN_VALUE_ON_ERROR(storage.media->GetBlockSize(), RES_ERROR);
+  units::data::byte_t block_size = storage.media->GetBlockSize();
 
   auto location = CorrectedLocation(block_size.to<uint32_t>(), sector, count);
   uint32_t location_block = std::get<0>(location);
@@ -173,8 +172,7 @@ extern "C" DRESULT disk_write(BYTE drive_number,
   auto & storage = drive[drive_number];
 
   // Get the number of bytes per block for this media.
-  units::data::byte_t block_size =
-      SJ2_RETURN_VALUE_ON_ERROR(storage.media->GetBlockSize(), RES_ERROR);
+  units::data::byte_t block_size = storage.media->GetBlockSize();
 
   auto location = CorrectedLocation(block_size.to<uint32_t>(), sector, count);
   uint32_t location_block = std::get<0>(location);

--- a/library/L3_Application/file_io/test/fatfs_test.cpp
+++ b/library/L3_Application/file_io/test/fatfs_test.cpp
@@ -217,8 +217,7 @@ TEST_CASE("Testing FAT FS", "[fatfs]")
                                        << ", block size: " << block_size);
             const uint32_t kExpectedSector = (sector * FF_MIN_SS) / block_size;
             const uint32_t kLength         = (count * FF_MIN_SS);
-            Returns<units::data::byte_t> result =
-                units::data::byte_t{ static_cast<float>(block_size) };
+            auto result = units::data::byte_t{ static_cast<float>(block_size) };
 
             When(Method(mock_storage, GetBlockSize)).AlwaysReturn(result);
 
@@ -322,8 +321,7 @@ TEST_CASE("Testing FAT FS", "[fatfs]")
                                        << ", block size: " << block_size);
             const uint32_t kExpectedSector = (sector * FF_MIN_SS) / block_size;
             const uint32_t kLength         = (count * FF_MIN_SS);
-            Returns<units::data::byte_t> result =
-                units::data::byte_t{ static_cast<float>(block_size) };
+            auto result = units::data::byte_t{ static_cast<float>(block_size) };
 
             When(Method(mock_storage, GetBlockSize)).AlwaysReturn(result);
 


### PR DESCRIPTION
- Removes the Returns<T> for capacity method
- Removes the Returns<T> for block size method
- Adds language for the Enable and Initialize methods that describes
  that running the other methods without successfully calling Enable()
  and Initialize() will result in undefined behavior.

Resolves #1207