### PR TITLE
Add ASCIINEMA to README and Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,49 @@ height="100px" />
 Built for **Ubuntu (18.04 or above)**, **Mac OSX (High Sierra or above)**, and
 **Windows 10 WSL**.
 
+## Quick Start
+
+### Setting up the environment
+If you are using Windows, follow these steps to
+**[install WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10)**
+and make sure to install the Ubuntu as the linux distro. Once you have installed
+WSL, all instructions below for Linux should work for Windows.
+
+To download and setup the environment, simply copy and paste this into a
+terminal:
+
+```
+git clone https://github.com/kammce/SJSU-Dev2.git
+cd SJSU-Dev2
+./setup
+```
+
+[![asciicast](https://asciinema.org/a/314726.svg)](https://asciinema.org/a/314726)
+
+If you find that git is not installed on your machine follow these steps to
+**[install GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)**.
+
+### Building a Project
+The starter `hello_world` project can be found in the `projects/` folder along
+with the the `demos/` folder which is full of examples you can run
+on your board. To build `hello_world` :
+
+    cd project/hello_world
+    make application
+
+### Programming a board
+From within a project, run `make flash`.
+
+[![asciicast](https://asciinema.org/a/314699.svg)](https://asciinema.org/a/314699)
+
+If `make flash` is not available for your platform, then you can try
+`make jtag-flash DEBUG_DEVICE=<jlink|stlink|etc> PLATFORM=<insert platform here>`
+if you have a JTAG or SWD debugger.
+
 ## Full Documentation and Installation Guide
 
-For full guide follow this link:
-**[documentation](http://sjsu-dev2.readthedocs.io/en/latest/?badge=latest)**
-
-## Code Reference and APIs
-
-See **[APIs](https://kammce.github.io/SJSU-Dev2/api/html/)**
+- **[Full Documentation](http://sjsu-dev2.readthedocs.io/en/latest/?badge=latest)**
+- **[Library APIs](https://kammce.github.io/SJSU-Dev2/api/html/)**
 
 ## Using a Prebuilt Virtual Machine
 One of the easiest ways to get started with SJSU-Dev2 is to use a VM with all of
@@ -63,41 +98,6 @@ Steps to install virtual box and the virtual machine are listed below:
 4. At this point you can run commands like `make application` and `make flash`
    from within the SJSU-Dev2 folder which is located `/home/osboxes/SJSU-Dev2`
 
-## Quick Start Install on host machine
-
-### Setting up the environment
-If you are using Windows, follow these steps to
-**[install WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10)**
-and make sure to install the Ubuntu as the linux distro. Once you have installed
-WSL, all instructions below for Linux should work for Windows.
-
-To download and setup the environment, simply copy and paste this into a
-terminal:
-
-```
-git clone https://github.com/kammce/SJSU-Dev2.git
-cd SJSU-Dev2
-./setup
-```
-
-If you find that git is not installed on your machine follow these steps to
-**[install GIT](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)**.
-
-### Building a Project
-The starter `hello_world` project can be found in the `projects/` folder along
-with the the `demos/` folder which is full of examples you can run
-on your board. To build `hello_world` :
-
-    cd project/hello_world
-    make application
-
-### Programming a board
-From within a project, run `make flash`.
-
-If `make flash` is not available for your platform, then you can try
-`make jtag-flash DEBUG_DEVICE=<jlink|stlink|etc> PLATFORM=<insert platform here>`
-if you have a JTAG or SWD debugger.
-
 ### Viewing Serial Output
 The preferred method for communicating with a serial device is via Google
 Chrome, using the online serial terminal tool,
@@ -108,7 +108,7 @@ a project directory.
 
 ## Supported Processors
 | Processor/OS   | InterruptController | SystemTimer | CycleCounter |
-|----------------|---------------------|-------------|--------------|
+| -------------- | ------------------- | ----------- | ------------ |
 | RISCV 32I      | ☒                   | ☒           | ☒            |
 | Arm Cortex M4F | ☑                   | ☑           | ☑            |
 | Arm Cortex M3  | ☑                   | ☑           | ☑            |
@@ -120,39 +120,27 @@ a project directory.
 * ☒ = Not supported but available
 * - = Not available on microcontroller
 
-| Processor/OS   | MCU/SOC   | SystemController | Gpio | Pin | Uart | Adc | Pwm | I2c | Spi | Dac | Timer | Can | Eeprom | Flash | PulseCapture | Watchdog |
-|----------------|-----------|------------------|------|-----|------|-----|-----|-----|-----|-----|-------|-----|--------|-------|--------------|----------|
-| Arm Cortex M4F | lpc40xx   | ☑                | ☑    | ☑   | ☑    | ☑   | ☑   | ☑   | ☑   | ☑   | ☑     | ◯   | ☑      | ☒     | ☑            | ☑        |
-| Arm Cortex M3  | lpc17xx   | ☑                | ☑    | ☑   | ☑    | ☑   | ☑   | ☑   | ☑   | ☑   | ☑     | ◯   | -      | ☒     | ☑            | ☑        |
-| Arm Cortex M3  | stm32f10x | ◯                | ☒    | ☒   | ☒    | ☒   | ☒   | ☒   | ☒   | ☒   | ☒     | ☒   | -      | ☒     | ☒            | ☒        |
-| Arm Cortex M4F | stm32f4xx | ◯                | ☑    | ☑   | ☒    | ☒   | ☒   | ☒   | ☒   | ☒   | ☒     | ☒   | -      | ☒     | ☒            | ☒        |
-| RISCV 32IMAC   | gd32v10x  | ☒                | ☒    | ☒   | ☒    | ☒   | ☒   | ☒   | ☒   | ☒   | ☒     | ☒   | -      | ☒     | ☒            | ☒        |
-| RISCV 32IMAC   | gd32v10x  | ☒                | ☒    | ☒   | ☒    | ☒   | ☒   | ☒   | ☒   | ☒   | ☒     | ☒   | -      | ☒     | ☒            | ☒        |
-| Linux          | any       | ☒                | ☒    | ☒   | ☒    | ☒   | ☒   | ☒   | ☒   | ☒   | ☒     | ☒   | -      | ☒     | ☒            | ☒        |
+| Processor/OS   | MCU/SOC   | SystemController | Gpio | Uart | Adc | Pwm | I2c | Spi | Dac | Timer | Can | Flash | Watchdog |
+| -------------- | --------- | ---------------- | ---- | ---- | --- | --- | --- | --- | --- | ----- | --- | ----- | -------- |
+| Arm Cortex M4F | lpc40xx   | ☑                | ☑    | ☑    | ☑   | ☑   | ☑   | ☑   | ☑   | ☑     | ◯   |  ☒    | ☑        |
+| Arm Cortex M3  | lpc17xx   | ☑                | ☑    | ☑    | ☑   | ☑   | ☑   | ☑   | ☑   | ☑     | ◯   |  ☒    | ☑        |
+| Arm Cortex M3  | stm32f10x | ☑                | ☑    | ☑    | ☒   | ☒   | ☒   | ☒   | ☒   | ☒     | ☒   |  ☒    | ☒        |
+| Arm Cortex M4F | stm32f4xx | ◯                | ☑    | ☒    | ☒   | ☒   | ☒   | ☒   | ☒   | ☒     | ☒   |  ☒    | ☒        |
+| RISCV 32IMAC   | gd32v10x  | ☒                | ☒    | ☒    | ☒   | ☒   | ☒   | ☒   | ☒   | ☒     | ☒   |  ☒    | ☒        |
+| RISCV 32IMAC   | gd32v10x  | ☒                | ☒    | ☒    | ☒   | ☒   | ☒   | ☒   | ☒   | ☒     | ☒   |  ☒    | ☒        |
+| Linux          | any       | ☒                | ☒    | ☒    | ☒   | ☒   | ☒   | ☒   | ☒   | ☒     | ☒   |  ☒    | ☒        |
 
 ## Future Goals of SJSU-Dev2
 - [x] Integrate user-defined literals for SI units
 - [ ] Platform Additions
-  - [ ] Support for Raspberry Pi and other SBCs such as the BeagleBone Black
   - [x] Support for host side application development
   - [x] Support of STM32 series of MCUs
-  - [ ] Support of TI series of MCUs
+  - [x] Support of TI series of MCUs
+  - [ ] Support for Raspberry Pi and other SBCs such as the BeagleBone Black
   - [ ] Support of RISC-V
 - [x] Multi Threading Portability
   - [x] Add FreeRTOS wrapper of POSIX calls
     - [x] Allows Linux platforms to work with code that makes calls to FreeRTOS.
-- [ ] Move from **Return-Error-Codes** to **C++ Exceptions**
-  - [ ] Make a version of C++ exceptions that is more optimal for embedded
-
-## Contributors
-* [Khalil Estell](http://kammce.io): Creator and maintainer of the SJSU-Dev2.
-* David Huang
-* Matthew Boyd
-* Since this repository borrows heavily form
-[SJSU-Dev repo](https://github.com/kammce/SJSU-Dev), the people in that contrib
-list are also contributors to this repository.
-  * SJSU-Dev was based on SJDev by Preet Kang.
-
-## Special Credits
-* **Mikko Bayabo**: Windows surface destructive testing
-* **WSL testing**: Sameer Azer, Aaron Moffit, Ryan Lucus, Onyema Ude
+- [x] Move from **Return-Error-Codes** to **C++ std::expected**
+- [ ] Package manager for adding SJSU-Dev2 libraries
+- [ ] Package manager for adding custom platforms SJSU-Dev2

--- a/documentation/getting_started/getting_started.md
+++ b/documentation/getting_started/getting_started.md
@@ -71,6 +71,8 @@ This will install all of the necessary files and programs that SJSU-Dev2 needs
 in order to build your code. The downloaded files are placed in the `tools/`
 folder.
 
+<script id="asciicast-314687" src="https://asciinema.org/a/314687.js" async></script>
+
 ## Building and Loading the "Hello World" Application
 
 ### Step 0: Move into project
@@ -84,6 +86,8 @@ folder.
 This will take all of the relevant source code files to your project and
 generate a binary file that can be loaded onto your board. These files can be
 found in the `build/application` folder with the project.
+
+<script id="asciicast-314699" src="https://asciinema.org/a/314699.js" async></script>
 
 !!! Tip
     use the `make` by itself to get additional information on the


### PR DESCRIPTION
Asciinema allows you to record and share your terminals. This can make
the documentation more expressive as it can show the user how the output
of a system is supposed to look when operating correctly or in error
conditions.

Issue #1115 (resolves the README.md and Getting Started requirement)