### PR TITLE
Define non-allocating variant of fputs

### DIFF
--- a/library/newlib/newlib.cpp
+++ b/library/newlib/newlib.cpp
@@ -87,9 +87,23 @@ extern "C"
   {
     int string_length = static_cast<int>(strlen(str));
     int result        = 0;
+
     result += _write(0, str, string_length);
     result += _write(0, "\n", 1);
-    // + 1 because puts adds an additional newline '\n' character.
+
+    return result;
+  }
+
+  // Overload default libnano puts() with a more optimal version that does
+  // not use dynamic memory
+  int fputs(const char * str, FILE * file)  // NOLINT
+  {
+    int string_length    = static_cast<int>(strlen(str));
+    int result           = 0;
+    intptr_t file_intptr = reinterpret_cast<intptr_t>(file);
+    int file_int         = static_cast<int>(file_intptr);
+
+    result += _write(static_cast<int>(file_int), str, string_length);
     return result;
   }
 


### PR DESCRIPTION
sjsu::Log uses fputs to print to stdout without a newline character,
but the default newlib implementation uses dynamic memory which brings
in about 2kB worth of additional code. This change defines fputs in
order to eliminate malloc from the default binaries.

Resolves #1233