### PR TITLE
Refactor bit::CreateMaskFromRange()

### DIFF
--- a/demos/sjone/ir_receiver/source/main.cpp
+++ b/demos/sjone/ir_receiver/source/main.cpp
@@ -43,7 +43,7 @@ void HandleDataFrame(const sjsu::infrared::DataFrame_t * data_frame)
   }
   else
   {
-    constexpr auto kCommandMask = sjsu::bit::CreateMaskFromRange(0, 15);
+    constexpr auto kCommandMask = sjsu::bit::MaskFromRange(0, 15);
     const uint16_t kCommand     = static_cast<uint16_t>(
         sjsu::bit::Extract(kDecodedFrame.data, kCommandMask));
     switch (kCommand)

--- a/demos/sjone/system_controller/source/main.cpp
+++ b/demos/sjone/system_controller/source/main.cpp
@@ -49,8 +49,8 @@ int main()
 
   // Clockout Configuration register (CLKOUTCFG) bit masks,
   constexpr uint8_t kClockOutEnableBit = 8;
-  constexpr auto kClockOutSelectMask   = sjsu::bit::CreateMaskFromRange(0, 3);
-  constexpr auto kClockOutDividerMask  = sjsu::bit::CreateMaskFromRange(4, 7);
+  constexpr auto kClockOutSelectMask   = sjsu::bit::MaskFromRange(0, 3);
+  constexpr auto kClockOutDividerMask  = sjsu::bit::MaskFromRange(4, 7);
 
   /// The select code to output CPU clock.
   constexpr uint8_t kClockOutSelect = 0b000;

--- a/demos/sjtwo/clock_configuration/source/main.cpp
+++ b/demos/sjtwo/clock_configuration/source/main.cpp
@@ -27,9 +27,9 @@ int main()
   clock_pin.SetAsOpenDrain(false);
   sjsu::LogInfo("Connect a probe to pin P1[25] to measure the clock rate");
 
-  constexpr sjsu::bit::Mask kClockSelect = sjsu::bit::CreateMaskFromRange(0, 3);
-  constexpr sjsu::bit::Mask kDivide      = sjsu::bit::CreateMaskFromRange(4, 7);
-  constexpr sjsu::bit::Mask kEnable      = sjsu::bit::CreateMaskFromRange(8);
+  constexpr sjsu::bit::Mask kClockSelect = sjsu::bit::MaskFromRange(0, 3);
+  constexpr sjsu::bit::Mask kDivide      = sjsu::bit::MaskFromRange(4, 7);
+  constexpr sjsu::bit::Mask kEnable      = sjsu::bit::MaskFromRange(8);
 
   // The following register configurations do the following:
   //

--- a/demos/stm32f10x/clock_configuration/source/main.cpp
+++ b/demos/stm32f10x/clock_configuration/source/main.cpp
@@ -89,7 +89,7 @@ int main()
 
   // Bitmask of the Clock out bit position in the RCC_CFGR register.
   // See page. 101 of RM0008.
-  static constexpr auto kMCO = sjsu::bit::CreateMaskFromRange(24, 26);
+  static constexpr auto kMCO = sjsu::bit::MaskFromRange(24, 26);
   // Grabbing a pointer to the clock configuration register to reduce the
   // verbosity of the code.
   volatile uint32_t * clock_config = &sjsu::stm32f10x::RCC->CFGR;

--- a/library/L1_Peripheral/lpc17xx/system_controller.hpp
+++ b/library/L1_Peripheral/lpc17xx/system_controller.hpp
@@ -157,7 +157,7 @@ class SystemController final : public sjsu::SystemController
   struct ClockSourceSelectRegister  // NOLINT
   {
     /// Clock source select bit mask.
-    static constexpr auto kSelectMask = bit::CreateMaskFromRange(0, 1);
+    static constexpr auto kSelectMask = bit::MaskFromRange(0, 1);
   };
 
   /// Namespace containing the bit masks for the System Controls and Status
@@ -165,11 +165,11 @@ class SystemController final : public sjsu::SystemController
   struct SystemControlsRegister  // NOLINT
   {
     /// Main oscillator frequency range select bit mask.
-    static constexpr auto kOscillatorRangeMask = bit::CreateMaskFromRange(4);
+    static constexpr auto kOscillatorRangeMask = bit::MaskFromRange(4);
     /// Main oscillator enable bit mask.
-    static constexpr auto kOscillatorEnableMask = bit::CreateMaskFromRange(5);
+    static constexpr auto kOscillatorEnableMask = bit::MaskFromRange(5);
     /// Main oscillator status bit mask.
-    static constexpr auto kOscillatorStatusMask = bit::CreateMaskFromRange(6);
+    static constexpr auto kOscillatorStatusMask = bit::MaskFromRange(6);
   };
 
   /// Namespace containing definitions for PLL0 (Main PLL).
@@ -180,9 +180,9 @@ class SystemController final : public sjsu::SystemController
     struct ConfigurationRegister  // NOLINT
     {
       /// PLL0 multiplier bit mask.
-      static constexpr auto kMultiplierMask = bit::CreateMaskFromRange(0, 14);
+      static constexpr auto kMultiplierMask = bit::MaskFromRange(0, 14);
       /// PLL0 pre-divider bit mask.
-      static constexpr auto kPreDividerMask = bit::CreateMaskFromRange(16, 23);
+      static constexpr auto kPreDividerMask = bit::MaskFromRange(16, 23);
     };
 
     /// Namespace containing the bit masks for the PLL0 Status register
@@ -190,15 +190,15 @@ class SystemController final : public sjsu::SystemController
     struct StatusRegister  // NOLINT
     {
       /// PLL0 multiplier bit mask.
-      static constexpr auto kMultiplierMask = bit::CreateMaskFromRange(0, 14);
+      static constexpr auto kMultiplierMask = bit::MaskFromRange(0, 14);
       /// PLL0 pre-divider bit mask.
-      static constexpr auto kPreDividerMask = bit::CreateMaskFromRange(16, 23);
+      static constexpr auto kPreDividerMask = bit::MaskFromRange(16, 23);
       /// PLL0 enable status bit mask.
-      static constexpr auto kEnableMask = bit::CreateMaskFromRange(24);
+      static constexpr auto kEnableMask = bit::MaskFromRange(24);
       /// PLL0 connection status bit mask.
-      static constexpr auto kConnectMask = bit::CreateMaskFromRange(25);
+      static constexpr auto kConnectMask = bit::MaskFromRange(25);
       /// PLL0 lock status bit mask.
-      static constexpr auto kLockStatusMask = bit::CreateMaskFromRange(26);
+      static constexpr auto kLockStatusMask = bit::MaskFromRange(26);
     };
   };
 
@@ -221,9 +221,9 @@ class SystemController final : public sjsu::SystemController
     struct ConfigurationRegister  // NOLINT
     {
       /// PLL1 multiplier bit mask
-      static constexpr auto kMultiplierMask = bit::CreateMaskFromRange(0, 4);
+      static constexpr auto kMultiplierMask = bit::MaskFromRange(0, 4);
       /// PLL1 pre-divider bit mask
-      static constexpr auto kDividerMask = bit::CreateMaskFromRange(5, 6);
+      static constexpr auto kDividerMask = bit::MaskFromRange(5, 6);
     };
 
     /// Namespace containing the bit masks for the PLL1 Status register
@@ -231,15 +231,15 @@ class SystemController final : public sjsu::SystemController
     struct StatusRegister  // NOLINT
     {
       /// PLL1 multiplier bit mask
-      static constexpr auto kMultiplierMask = bit::CreateMaskFromRange(0, 4);
+      static constexpr auto kMultiplierMask = bit::MaskFromRange(0, 4);
       /// PLL1 pre-divider bit mask
-      static constexpr auto kDividerMask = bit::CreateMaskFromRange(5, 6);
+      static constexpr auto kDividerMask = bit::MaskFromRange(5, 6);
       /// PLL1 enable status bit mask.
-      static constexpr auto kEnableMask = bit::CreateMaskFromRange(8);
+      static constexpr auto kEnableMask = bit::MaskFromRange(8);
       /// PLL1 connection status bit mask.
-      static constexpr auto kConnectMask = bit::CreateMaskFromRange(9);
+      static constexpr auto kConnectMask = bit::MaskFromRange(9);
       /// PLL1 lock status bit
-      static constexpr auto kLockStatusMask = bit::CreateMaskFromRange(10);
+      static constexpr auto kLockStatusMask = bit::MaskFromRange(10);
     };
   };
 
@@ -248,9 +248,9 @@ class SystemController final : public sjsu::SystemController
   struct PllControlRegister  // NOLINT
   {
     /// PLL enable bit mask.
-    static constexpr auto kEnableMask = bit::CreateMaskFromRange(0);
+    static constexpr auto kEnableMask = bit::MaskFromRange(0);
     /// PLL connect/disconnect bit mask.
-    static constexpr auto kConnectMask = bit::CreateMaskFromRange(1);
+    static constexpr auto kConnectMask = bit::MaskFromRange(1);
   };
 
   /// Namespace containing the bit masks for the CPU Clock Configuration
@@ -258,7 +258,7 @@ class SystemController final : public sjsu::SystemController
   struct CpuClockRegister  // NOLINT
   {
     /// The 8-bit CPU clock divider bitmask.
-    static constexpr auto kDividerMask = bit::CreateMaskFromRange(0, 7);
+    static constexpr auto kDividerMask = bit::MaskFromRange(0, 7);
   };
 
   /// Namespace containing the bit masks for the USB Clock Configuration
@@ -266,7 +266,7 @@ class SystemController final : public sjsu::SystemController
   struct UsbClockRegister  // NOLINT
   {
     /// The 4-bit USB clock divider bitmask.
-    static constexpr auto kDividerMask = bit::CreateMaskFromRange(0, 3);
+    static constexpr auto kDividerMask = bit::MaskFromRange(0, 3);
   };
 
   /// @see 4.1 Summary of clocking and power control functions

--- a/library/L1_Peripheral/lpc40xx/adc.hpp
+++ b/library/L1_Peripheral/lpc40xx/adc.hpp
@@ -27,39 +27,48 @@ class Adc final : public sjsu::Adc
     /// It bit position represents 1 channel with this 8 channel ADC.
     /// In software mode, this should hold only a single 1 for the single
     /// channel to be converted.
-    static constexpr bit::Mask kChannelSelect = bit::CreateMaskFromRange(0, 7);
+    static constexpr bit::Mask kChannelSelect = bit::MaskFromRange(0, 7);
+
     /// Sets the channel's clock divider. Potentially saving power if clock is
     /// reduced further.
-    static constexpr bit::Mask kClockDivider = bit::CreateMaskFromRange(8, 15);
+    static constexpr bit::Mask kClockDivider = bit::MaskFromRange(8, 15);
+
     /// Enable Burst Mode for the ADC. See BurstMode() method of this class to
     /// learn more about what it is and how it works.
-    static constexpr bit::Mask kBurstEnable = bit::CreateMaskFromRange(16);
+    static constexpr bit::Mask kBurstEnable = bit::MaskFromRange(16);
+
     /// Power on the ADC
-    static constexpr bit::Mask kPowerEnable = bit::CreateMaskFromRange(21);
+    static constexpr bit::Mask kPowerEnable = bit::MaskFromRange(21);
+
     /// In order to start a conversion a start code must be inserted into this
     /// bit location.
-    static constexpr bit::Mask kStartCode = bit::CreateMaskFromRange(24, 26);
+    static constexpr bit::Mask kStartCode = bit::MaskFromRange(24, 26);
+
     /// Not used in this driver, but allows the use of an external pins to
     /// trigger a conversion. This flag indicates if rising or falling edges
     /// trigger the conversion.
     /// 1 = falling, 0 = rising.
-    static constexpr bit::Mask kStartEdge = bit::CreateMaskFromRange(27);
+    static constexpr bit::Mask kStartEdge = bit::MaskFromRange(27);
   };
+
   /// Namespace containing the bitmask objects that are used to manipulate the
   /// lpc40xx ADC Global Data register.
   struct DataRegister  // NOLINT
   {
     /// Result mask holds the latest result from the last ADC that was converted
-    static constexpr bit::Mask kResult = bit::CreateMaskFromRange(4, 15);
+    static constexpr bit::Mask kResult = bit::MaskFromRange(4, 15);
+
     /// Converted channel mask indicates which channel was converted in the
     /// latest conversion.
-    static constexpr bit::Mask kConvertedChannel =
-        bit::CreateMaskFromRange(24, 26);
+    static constexpr bit::Mask kConvertedChannel = bit::MaskFromRange(24, 26);
+
     /// Holds whether or not the ADC overran its conversion.
-    static constexpr bit::Mask kOverrun = bit::CreateMaskFromRange(30);
+    static constexpr bit::Mask kOverrun = bit::MaskFromRange(30);
+
     /// Indicates when the ADC conversion is complete.
-    static constexpr bit::Mask kDone = bit::CreateMaskFromRange(31);
+    static constexpr bit::Mask kDone = bit::MaskFromRange(31);
   };
+
   /// Structure that defines a channel's pin, pin's function code and channel
   /// number.
   ///

--- a/library/L1_Peripheral/lpc40xx/can.hpp
+++ b/library/L1_Peripheral/lpc40xx/can.hpp
@@ -31,19 +31,23 @@ class Can final : public sjsu::Can
   struct BusTiming  // NOLINT
   {
     /// The peripheral bus clock is divided by this value
-    static constexpr bit::Mask kPrescalar = bit::CreateMaskFromRange(0, 9);
+    static constexpr bit::Mask kPrescalar = bit::MaskFromRange(0, 9);
+
     /// Used to compensate for positive and negative edge phase errors
     static constexpr bit::Mask kSyncJumpWidth =
-        bit::CreateMaskFromRange(14, 15);
+
+        bit::MaskFromRange(14, 15);
     /// The delay from the nominal Sync point to the sample point is (this value
     /// plus one) CAN clocks.
-    static constexpr bit::Mask kTimeSegment1 = bit::CreateMaskFromRange(16, 19);
+    static constexpr bit::Mask kTimeSegment1 = bit::MaskFromRange(16, 19);
+
     /// The delay from the sample point to the next nominal sync point isCAN
     /// clocks. The nominal CAN bit time is (this value plus the value in
     /// kTimeSegment1 plus 3) CAN clocks.
-    static constexpr bit::Mask kTimeSegment2 = bit::CreateMaskFromRange(20, 22);
+    static constexpr bit::Mask kTimeSegment2 = bit::MaskFromRange(20, 22);
+
     /// How many times the bus is sampled; 0 == once, 1 == 3 times
-    static constexpr bit::Mask kSampling = bit::CreateMaskFromRange(23);
+    static constexpr bit::Mask kSampling = bit::MaskFromRange(23);
   };
 
   /// This struct holds interrupt flags and capture flag status. It is HW mapped
@@ -57,44 +61,59 @@ class Can final : public sjsu::Can
     //       controller as soon as they are read.
 
     /// Assert interrupt when the receive buffer is full
-    static constexpr bit::Mask kRxBufferFull = bit::CreateMaskFromRange(0);
+    static constexpr bit::Mask kRxBufferFull = bit::MaskFromRange(0);
+
     /// Assert interrupt when TX Buffer 1 has finished or aborted its
     /// transmission.
-    static constexpr bit::Mask kTx1Ready = bit::CreateMaskFromRange(1);
+    static constexpr bit::Mask kTx1Ready = bit::MaskFromRange(1);
+
     /// Assert interrupt when bus status or error status is asserted.
-    static constexpr bit::Mask kErrorWarning = bit::CreateMaskFromRange(2);
+    static constexpr bit::Mask kErrorWarning = bit::MaskFromRange(2);
+
     /// Assert interrupt on data overrun occurs
-    static constexpr bit::Mask kDataOverrun = bit::CreateMaskFromRange(3);
+    static constexpr bit::Mask kDataOverrun = bit::MaskFromRange(3);
+
     /// Assert interrupt when CAN controller is sleeping and was woken up from
     /// bus activity.
-    static constexpr bit::Mask kWakeup = bit::CreateMaskFromRange(4);
+    static constexpr bit::Mask kWakeup = bit::MaskFromRange(4);
+
     /// Assert interrupt when the CAN Controller has reached the Error Passive
     /// Status (error counter exceeds 127)
-    static constexpr bit::Mask kErrorPassive = bit::CreateMaskFromRange(5);
+    static constexpr bit::Mask kErrorPassive = bit::MaskFromRange(5);
+
     /// Assert interrupt when arbitration is lost
-    static constexpr bit::Mask kArbitrationLost = bit::CreateMaskFromRange(6);
+    static constexpr bit::Mask kArbitrationLost = bit::MaskFromRange(6);
+
     /// Assert interrupt on bus error
-    static constexpr bit::Mask kBusError = bit::CreateMaskFromRange(7);
+    static constexpr bit::Mask kBusError = bit::MaskFromRange(7);
+
     /// Assert interrupt when any message has been successfully transmitted.
-    static constexpr bit::Mask kIdentifierReady = bit::CreateMaskFromRange(8);
+    static constexpr bit::Mask kIdentifierReady = bit::MaskFromRange(8);
+
     /// Assert interrupt when TX Buffer 2 has finished or aborted its
     /// transmission.
-    static constexpr bit::Mask kTx2Ready = bit::CreateMaskFromRange(9);
+    static constexpr bit::Mask kTx2Ready = bit::MaskFromRange(9);
+
     /// Assert interrupt when TX Buffer 3 has finished or aborted its
     /// transmission.
-    static constexpr bit::Mask kTx3Ready = bit::CreateMaskFromRange(10);
+    static constexpr bit::Mask kTx3Ready = bit::MaskFromRange(10);
+
     /// Error Code Capture status bits to be read during an interrupt
     static constexpr bit::Mask kErrorCodeLocation =
-        bit::CreateMaskFromRange(16, 20);
+
+        bit::MaskFromRange(16, 20);
     /// Indicates if the error occurred during transmission (0) or receiving (1)
     static constexpr bit::Mask kErrorCodeDirection =
-        bit::CreateMaskFromRange(21);
+
+        bit::MaskFromRange(21);
     /// The type of bus error that occurred such as bit error, stuff error, etc
     static constexpr bit::Mask kErrorCodeType =
-        bit::CreateMaskFromRange(22, 23);
+
+        bit::MaskFromRange(22, 23);
     /// Bit location of where arbitration was lost.
     static constexpr bit::Mask kArbitrationLostLocation =
-        bit::CreateMaskFromRange(24, 31);
+
+        bit::MaskFromRange(24, 31);
   };
 
   /// This struct holds CAN controller global status information.
@@ -103,10 +122,11 @@ class Can final : public sjsu::Can
   struct GlobalStatus  // NOLINT
   {
     /// If 1, receive buffer has at least 1 complete message stored
-    static constexpr bit::Mask kReceiveBuffer = bit::CreateMaskFromRange(0);
+    static constexpr bit::Mask kReceiveBuffer = bit::MaskFromRange(0);
+
     /// Bus status bit. If this is '1' then the bus is active, otherwise the bus
     /// is bus off.
-    static constexpr bit::Mask kBusError = bit::CreateMaskFromRange(7);
+    static constexpr bit::Mask kBusError = bit::MaskFromRange(7);
   };
 
   /// This struct holds CAN controller status information. It is HW mapped to a
@@ -115,44 +135,55 @@ class Can final : public sjsu::Can
   struct BufferStatus  // NOLINT
   {
     /// TX1 Buffer has been released
-    static constexpr bit::Mask kTx1Released = bit::CreateMaskFromRange(2);
+    static constexpr bit::Mask kTx1Released = bit::MaskFromRange(2);
+
     /// TX2 Buffer has been released
-    static constexpr bit::Mask kTx2Released = bit::CreateMaskFromRange(10);
+    static constexpr bit::Mask kTx2Released = bit::MaskFromRange(10);
+
     /// TX3 Buffer has been released
-    static constexpr bit::Mask kTx3Released = bit::CreateMaskFromRange(18);
+    static constexpr bit::Mask kTx3Released = bit::MaskFromRange(18);
   };
 
   /// CANBUS modes
   struct Mode  // NOLINT
   {
     /// Reset CAN Controller, allows configuration registers to be modified.
-    static constexpr bit::Mask kReset = bit::CreateMaskFromRange(0);
+    static constexpr bit::Mask kReset = bit::MaskFromRange(0);
+
     /// Put device into Listen Only Mode, device will not acknowledge, messages.
-    static constexpr bit::Mask kListenOnly = bit::CreateMaskFromRange(1);
+    static constexpr bit::Mask kListenOnly = bit::MaskFromRange(1);
+
     /// Put device on self test mode.
-    static constexpr bit::Mask kSelfTest = bit::CreateMaskFromRange(2);
+    static constexpr bit::Mask kSelfTest = bit::MaskFromRange(2);
+
     /// Enable transmit priority control. When enabled, allows a particular
-    static constexpr bit::Mask kTxPriority = bit::CreateMaskFromRange(3);
+    static constexpr bit::Mask kTxPriority = bit::MaskFromRange(3);
+
     /// Put device to Sleep Mode.
-    static constexpr bit::Mask kSleepMode = bit::CreateMaskFromRange(4);
+    static constexpr bit::Mask kSleepMode = bit::MaskFromRange(4);
+
     /// Receive polarity mode. If 1 RD input is active high
-    static constexpr bit::Mask kRxPolarity = bit::CreateMaskFromRange(5);
+    static constexpr bit::Mask kRxPolarity = bit::MaskFromRange(5);
+
     /// Put CAN into test mode, which allows the TD pin to reflect its bits ot
     /// the RD pin.
-    static constexpr bit::Mask kTest = bit::CreateMaskFromRange(7);
+    static constexpr bit::Mask kTest = bit::MaskFromRange(7);
   };
 
   /// CANBus frame bit masks for the TFM and RFM registers
   struct FrameInfo  // NOLINT
   {
     /// The message priority bits (not used in this implementation)
-    static constexpr bit::Mask kPriority = bit::CreateMaskFromRange(0, 7);
+    static constexpr bit::Mask kPriority = bit::MaskFromRange(0, 7);
+
     /// The length of the data
-    static constexpr bit::Mask kLength = bit::CreateMaskFromRange(16, 19);
+    static constexpr bit::Mask kLength = bit::MaskFromRange(16, 19);
+
     /// If set to 1, the message becomes a remote request message
-    static constexpr bit::Mask kRemoteRequest = bit::CreateMaskFromRange(30);
+    static constexpr bit::Mask kRemoteRequest = bit::MaskFromRange(30);
+
     /// If 0, the ID is 11-bits, if 1, the ID is 29-bits.
-    static constexpr bit::Mask kFormat = bit::CreateMaskFromRange(31);
+    static constexpr bit::Mask kFormat = bit::MaskFromRange(31);
   };
 
   /// https://www.nxp.com/docs/en/user-guide/UM10562.pdf (pg. 554)

--- a/library/L1_Peripheral/lpc40xx/dac.hpp
+++ b/library/L1_Peripheral/lpc40xx/dac.hpp
@@ -28,18 +28,23 @@ class Dac final : public sjsu::Dac
   {
     /// This bit field holds the output value of the DAC. This bit field is also
     /// the exact bit resolution of the DAC output.
-    static constexpr bit::Mask kValue = bit::CreateMaskFromRange(6, 15);
+    static constexpr bit::Mask kValue = bit::MaskFromRange(6, 15);
+
     /// Bias bit position in control register. See Bias enumeration for details
     /// about how this bit works.
-    static constexpr bit::Mask kBias = bit::CreateMaskFromRange(16);
+    static constexpr bit::Mask kBias = bit::MaskFromRange(16);
   };
+
 
   /// The only DAC output pin on the lpc40xx.
   static constexpr sjsu::lpc40xx::Pin kDacPin = Pin::CreatePin<0, 26>();
+
   /// Voltage reference for the lpc40xx voltage.
   static constexpr float kVref = 3.3f;
+
   /// Maximum numeric value of the ADC value register.
   static constexpr uint32_t kMaximumValue = (1 << Control::kValue.width) - 1;
+
   /// Pointer to the LPC DAC peripheral in memory
   inline static LPC_DAC_TypeDef * dac_register = LPC_DAC;
 
@@ -49,6 +54,7 @@ class Dac final : public sjsu::Dac
   ///        use this parameter would be for unit testing. Otherwise, it should
   ///        not be changed from its default.
   explicit constexpr Dac(const sjsu::Pin & pin = kDacPin) : dac_pin_(pin) {}
+
   /// Initialize DAC hardware, enable dac Pin, initial Bias level set to 0.
   Status Initialize() const override
   {
@@ -70,6 +76,7 @@ class Dac final : public sjsu::Dac
 
     return Status::kSuccess;
   }
+
   void Write(uint32_t dac_output) const override
   {
     // The DAC output is a 10 bit input and thus it is necessary to
@@ -88,6 +95,7 @@ class Dac final : public sjsu::Dac
         "DAC output was set above 3.3V. Must be between 0V and 3.3V.");
     Write(conversion);
   }
+
   /// Sets the Bias for the Dac, which determines the settling time, max
   /// current, and the allowed maximum update rate
   void SetBias(Bias bias_level) const
@@ -95,6 +103,7 @@ class Dac final : public sjsu::Dac
     bool bias        = static_cast<bool>(bias_level);
     dac_register->CR = bit::Insert(dac_register->CR, bias, Control::kBias);
   }
+
   uint8_t GetActiveBits() const override
   {
     return Control::kValue.width;

--- a/library/L1_Peripheral/lpc40xx/eeprom.hpp
+++ b/library/L1_Peripheral/lpc40xx/eeprom.hpp
@@ -24,17 +24,16 @@ class Eeprom final : public sjsu::Storage
   /// mode, which means addresses must be multiples of 4 to avoid hard faults.
   /// To enforce this, all addresses used to read/write to the EEPROM have to
   /// be masked.
-  static constexpr bit::Mask kAddressMask = bit::CreateMaskFromRange(0, 1);
+  static constexpr bit::Mask kAddressMask = bit::MaskFromRange(0, 1);
 
   /// Masks for the program status bits and read/write status bits
   struct Status  // NOLINT
   {
     /// Mask to get value of programming status bit
-    static constexpr bit::Mask kProgramStatusMask =
-        bit::CreateMaskFromRange(28);
+    static constexpr bit::Mask kProgramStatusMask = bit::MaskFromRange(28);
+
     /// Mask to get value of read/write status bit
-    static constexpr bit::Mask kReadWriteStatusMask =
-        bit::CreateMaskFromRange(26);
+    static constexpr bit::Mask kReadWriteStatusMask = bit::MaskFromRange(26);
   };
 
   /// EEPROM Command codes for reading from, writing to, and programming the
@@ -126,8 +125,8 @@ class Eeprom final : public sjsu::Storage
 
   Returns<void> Write(uint32_t address, const void * data, size_t size) override
   {
-    constexpr bit::Mask kLower6Bits = bit::CreateMaskFromRange(0, 5);
-    constexpr bit::Mask kUpper6Bits = bit::CreateMaskFromRange(6, 11);
+    constexpr bit::Mask kLower6Bits = bit::MaskFromRange(0, 5);
+    constexpr bit::Mask kUpper6Bits = bit::MaskFromRange(6, 11);
 
     address = bit::Clear(address, kAddressMask);
 

--- a/library/L1_Peripheral/lpc40xx/pin.hpp
+++ b/library/L1_Peripheral/lpc40xx/pin.hpp
@@ -25,33 +25,43 @@ class Pin final : public sjsu::Pin
  public:
   // Source: "UM10562 LPC408x/407x User manual" table 83 page 132
   /// Bitmask for setting pin mux function code.
-  static constexpr bit::Mask kFunction = bit::CreateMaskFromRange(0, 2);
+  static constexpr bit::Mask kFunction = bit::MaskFromRange(0, 2);
+
   /// Bitmask for setting resistor mode of pin.
-  static constexpr bit::Mask kResistor = bit::CreateMaskFromRange(3, 4);
+  static constexpr bit::Mask kResistor = bit::MaskFromRange(3, 4);
+
   /// Bitmask for setting pin hysteresis mode.
-  static constexpr bit::Mask kHysteresis = bit::CreateMaskFromRange(5);
+  static constexpr bit::Mask kHysteresis = bit::MaskFromRange(5);
+
   /// Bitmask for setting inputs as active low or active high. This will behave
   /// badly if the pin is set to a mode that is an output or set to analog. See
   /// usermanual for more details.
-  static constexpr bit::Mask kInputInvert = bit::CreateMaskFromRange(6);
+  static constexpr bit::Mask kInputInvert = bit::MaskFromRange(6);
+
   /// Bitmask for setting a pin to analog mode.
-  static constexpr bit::Mask kAnalogDigitalMode = bit::CreateMaskFromRange(7);
+  static constexpr bit::Mask kAnalogDigitalMode = bit::MaskFromRange(7);
+
   /// Bitmask for enabling/disabling digital filter. This can be used to
   /// ignore/reject noise, reflections, or signal bounce (from something like a
   /// switch).
-  static constexpr bit::Mask kDigitalFilter = bit::CreateMaskFromRange(8);
+  static constexpr bit::Mask kDigitalFilter = bit::MaskFromRange(8);
+
   /// Bitmask to enable/disable high speed I2C mode
-  static constexpr bit::Mask kI2cHighSpeed = bit::CreateMaskFromRange(8);
+  static constexpr bit::Mask kI2cHighSpeed = bit::MaskFromRange(8);
+
   /// Bitmask to change the slew rate of signal transitions for outputs for a
   /// pin.
-  static constexpr bit::Mask kSlew = bit::CreateMaskFromRange(9);
+  static constexpr bit::Mask kSlew = bit::MaskFromRange(9);
+
   /// Bitmask to enable I2C high current drain. This can allow for even faster
   /// I2C communications, as well as allow for more devices on the bus.
-  static constexpr bit::Mask kI2cHighCurrentDrive = bit::CreateMaskFromRange(9);
+  static constexpr bit::Mask kI2cHighCurrentDrive = bit::MaskFromRange(9);
+
   /// Bitmask to enable/disable open drain mode.
-  static constexpr bit::Mask kOpenDrain = bit::CreateMaskFromRange(10);
+  static constexpr bit::Mask kOpenDrain = bit::MaskFromRange(10);
+
   /// Bitmask for enabling/disabling digital to analog pin mode.
-  static constexpr bit::Mask kDacEnable = bit::CreateMaskFromRange(16);
+  static constexpr bit::Mask kDacEnable = bit::MaskFromRange(16);
 
   /// Pin map table for maping pins and ports to registers.
   struct PinMap_t

--- a/library/L1_Peripheral/lpc40xx/pulse_capture.hpp
+++ b/library/L1_Peripheral/lpc40xx/pulse_capture.hpp
@@ -170,9 +170,8 @@ class PulseCapture final : public sjsu::PulseCapture
   /// Handler used to collect capture event status and pass to a user callback
   static void TimerHandler(const CaptureChannelPartial_t & channel)
   {
-    constexpr bit::Mask kCaptureInterruptFlagBit =
-        bit::CreateMaskFromRange(4, 5);
-    constexpr uint8_t kResetCaptureInterrupts = 0b11;
+    constexpr bit::Mask kCaptureInterruptFlagBit = bit::MaskFromRange(4, 5);
+    constexpr uint8_t kResetCaptureInterrupts    = 0b11;
 
     if (*channel.user_callback != nullptr)
     {
@@ -194,6 +193,7 @@ class PulseCapture final : public sjsu::PulseCapture
         bit::Insert(channel.timer_register->IR, kResetCaptureInterrupts,
                     kCaptureInterruptFlagBit);
   }
+
   /// Constructor for LPC40xx timer peripheral
   ///
   /// @param timer - timer to capture from
@@ -226,7 +226,7 @@ class PulseCapture final : public sjsu::PulseCapture
     timer_.channel.timer_register->PR = prescaler;
 
     // Enable timer
-    constexpr bit::Mask kTimerEnableBit = bit::CreateMaskFromRange(0);
+    constexpr bit::Mask kTimerEnableBit = bit::MaskFromRange(0);
     timer_.channel.timer_register->TCR =
         bit::Set(timer_.channel.timer_register->TCR, kTimerEnableBit.position);
 
@@ -257,9 +257,8 @@ class PulseCapture final : public sjsu::PulseCapture
       timer_.channel.capture_pin0.SetPinFunction(3);
     }
 
-    static constexpr bit::Mask kModeBits[2] = {
-      bit::CreateMaskFromRange(0, 1), bit::CreateMaskFromRange(3, 4)
-    };
+    static constexpr bit::Mask kModeBits[2] = { bit::MaskFromRange(0, 1),
+                                                bit::MaskFromRange(3, 4) };
 
     int which = 0;
     if (channel_ == CaptureChannelNumber::kChannel1)
@@ -276,12 +275,11 @@ class PulseCapture final : public sjsu::PulseCapture
   /// @param enabled - enable or disable the interrupt
   void EnableCaptureInterrupt(bool enabled) const override
   {
-    static constexpr bit::Mask kPendingBits[2] = {
-      bit::CreateMaskFromRange(4), bit::CreateMaskFromRange(5)
-    };
+    static constexpr bit::Mask kPendingBits[2] = { bit::MaskFromRange(4),
+                                                   bit::MaskFromRange(5) };
 
-    static constexpr bit::Mask kEnableBits[2] = { bit::CreateMaskFromRange(2),
-                                                  bit::CreateMaskFromRange(5) };
+    static constexpr bit::Mask kEnableBits[2] = { bit::MaskFromRange(2),
+                                                  bit::MaskFromRange(5) };
 
     int which = 0;
     if (channel_ == CaptureChannelNumber::kChannel1)
@@ -300,6 +298,6 @@ class PulseCapture final : public sjsu::PulseCapture
   const CaptureChannel_t & timer_;
   const CaptureChannelNumber channel_;         // NOLINT
   const units::frequency::hertz_t frequency_;  // NOLINT
-};                                             // class Capture
-};                                             // namespace lpc40xx
-};                                             // namespace sjsu
+};
+}  // namespace lpc40xx
+}  // namespace sjsu

--- a/library/L1_Peripheral/lpc40xx/pwm.hpp
+++ b/library/L1_Peripheral/lpc40xx/pwm.hpp
@@ -36,11 +36,11 @@ class Pwm final : public sjsu::Pwm
   {
     /// Enables/disables double edge PWM for each channel. Each bit in this
     /// field corrissponds to a channel.
-    constexpr static bit::Mask kEnableDoubleEdge =
-        bit::CreateMaskFromRange(2, 6);
+    static constexpr auto kEnableDoubleEdge = bit::MaskFromRange(2, 6);
+
     /// Enables/disables output of PWM channels. Each bit from the start
     /// corrissponds to a PWM channel.
-    constexpr static bit::Mask kEnableOutput = bit::CreateMaskFromRange(8, 14);
+    static constexpr auto kEnableOutput = bit::MaskFromRange(8, 14);
   };
 
   /// Match register control bit masks.
@@ -48,7 +48,7 @@ class Pwm final : public sjsu::Pwm
   {
     /// If set to a 1, tells the PWM hardare to reset the PWM total count
     /// register to be reset to 0 when it is equal to the match register 0.
-    constexpr static bit::Mask kPwm0Reset = bit::CreateMaskFromRange(1);
+    static constexpr auto kPwm0Reset = bit::MaskFromRange(1);
   };
 
   /// Register controls PWM peripheral wide timer control.
@@ -56,15 +56,18 @@ class Pwm final : public sjsu::Pwm
   {
     /// When set to a 1, enables the TC (total count) register and begins
     /// counting.
-    constexpr static bit::Mask kCounterEnable = bit::CreateMaskFromRange(0);
+    static constexpr auto kCounterEnable = bit::MaskFromRange(0);
+
     /// When set to a 1, will reset the total count register.
-    constexpr static bit::Mask kCounterReset = bit::CreateMaskFromRange(1);
+    static constexpr auto kCounterReset = bit::MaskFromRange(1);
+
     /// Enables PWM mode. Without setting the match registers cannot operate
     /// with the timer.
-    constexpr static bit::Mask kPwmEnable = bit::CreateMaskFromRange(3);
+    static constexpr auto kPwmEnable = bit::MaskFromRange(3);
+
     /// Allows PWM0 peripheral to control the PWM1 peripheral. This is generally
     /// set to 0, to allow both of them to work independently.
-    constexpr static bit::Mask kMasterDisable = bit::CreateMaskFromRange(4);
+    static constexpr auto kMasterDisable = bit::MaskFromRange(4);
   };
 
   /// PWM channel count control register
@@ -73,10 +76,11 @@ class Pwm final : public sjsu::Pwm
     /// Controls the counting mode of the PWM peripheral. When set to 0, counts
     /// using the internal prescale counter which is driven by the peripheral
     /// clock. Other modes involve use of an external clock source.
-    constexpr static bit::Mask kMode = bit::CreateMaskFromRange(0, 1);
+    static constexpr auto kMode = bit::MaskFromRange(0, 1);
+
     /// Controls the count input source. For this driver, this should be kept to
     /// zero, since we want to utilize the internal peripheral clock source.
-    constexpr static bit::Mask kCountInput = bit::CreateMaskFromRange(2, 3);
+    static constexpr auto kCountInput = bit::MaskFromRange(2, 3);
   };
 
   /// Defines a LPC PWM peripheral definition that contains all of the
@@ -125,11 +129,13 @@ class Pwm final : public sjsu::Pwm
       .registers = LPC_PWM0,
       .id        = sjsu::lpc40xx::SystemController::Peripherals::kPwm1,
     };
+
     /// Definition of the PWM 1 peripheral.
     inline static const Peripheral_t kPwm1Peripheral = {
       .registers = LPC_PWM1,
       .id        = sjsu::lpc40xx::SystemController::Peripherals::kPwm1,
     };
+
     /// Definition for channel 0 of PWM peripheral 1.
     inline static const Channel_t kPwm0 = {
       .peripheral        = kPwm1Peripheral,
@@ -137,6 +143,7 @@ class Pwm final : public sjsu::Pwm
       .channel           = 1,
       .pin_function_code = 0b001,
     };
+
     /// Definition for channel 1 of PWM peripheral 1.
     inline static const Channel_t kPwm1 = {
       .peripheral        = kPwm1Peripheral,
@@ -144,6 +151,7 @@ class Pwm final : public sjsu::Pwm
       .channel           = 2,
       .pin_function_code = 0b001,
     };
+
     /// Definition for channel 2 of PWM peripheral 1.
     inline static const Channel_t kPwm2 = {
       .peripheral        = kPwm1Peripheral,
@@ -151,6 +159,7 @@ class Pwm final : public sjsu::Pwm
       .channel           = 3,
       .pin_function_code = 0b001,
     };
+
     /// Definition for channel 3 of PWM peripheral 1.
     inline static const Channel_t kPwm3 = {
       .peripheral        = kPwm1Peripheral,
@@ -158,6 +167,7 @@ class Pwm final : public sjsu::Pwm
       .channel           = 4,
       .pin_function_code = 0b001,
     };
+
     /// Definition for channel 4 of PWM peripheral 1.
     inline static const Channel_t kPwm4 = {
       .peripheral        = kPwm1Peripheral,
@@ -165,6 +175,7 @@ class Pwm final : public sjsu::Pwm
       .channel           = 5,
       .pin_function_code = 0b001,
     };
+
     /// Definition for channel 5 of PWM peripheral 1.
     inline static const Channel_t kPwm5 = {
       .peripheral        = kPwm1Peripheral,
@@ -179,6 +190,7 @@ class Pwm final : public sjsu::Pwm
   /// @param channel - Reference to a const channel description for this
   ///        instance of the PWM driver.
   explicit constexpr Pwm(const Channel_t & channel) : channel_(channel) {}
+
   Status Initialize(units::frequency::hertz_t frequency_hz) const override
   {
     SJ2_ASSERT_FATAL(1 <= channel_.channel && channel_.channel <= 6,
@@ -284,7 +296,7 @@ class Pwm final : public sjsu::Pwm
     {
       auto & system      = sjsu::SystemController::GetPlatformController();
       auto pwm_frequency = system.GetClockRate(channel_.peripheral.id);
-      result = pwm_frequency / match_register0;
+      result             = pwm_frequency / match_register0;
     }
     return result;
   }

--- a/library/L1_Peripheral/lpc40xx/spi.hpp
+++ b/library/L1_Peripheral/lpc40xx/spi.hpp
@@ -43,16 +43,19 @@ class Spi final : public sjsu::Spi
   {
     /// Data Size Select. This field controls the number of bits transferred in
     /// each frame. Values 0000-0010 are not supported and should not be used.
-    static constexpr bit::Mask kDataBit = bit::CreateMaskFromRange(0, 3);
+    static constexpr auto kDataBit = bit::MaskFromRange(0, 3);
+
     /// Frame Format bitmask.
     /// 00 = SPI, 01 = TI, 10 = Microwire, 11 = Invalid
-    static constexpr bit::Mask kFrameBit = bit::CreateMaskFromRange(4, 5);
+    static constexpr auto kFrameBit = bit::MaskFromRange(4, 5);
+
     /// If bit is set to 0 SSP controller maintains the bus clock low between
     /// frames.
     ///
     /// If bit is set to 1 SSP controller maintains the bus clock high between
     /// frames.
-    static constexpr bit::Mask kPolarityBit = bit::CreateMaskFromRange(6);
+    static constexpr auto kPolarityBit = bit::MaskFromRange(6);
+
     /// If bit is set to 0 SSP controller captures serial data on the first
     /// clock transition of the frame, that is, the transition away from the
     /// inter-frame state of the clock line.
@@ -60,25 +63,27 @@ class Spi final : public sjsu::Spi
     /// If bit is set to 1 SSP controller captures serial data on the second
     /// clock transition of the frame, that is, the transition back to the
     /// inter-frame state of the clock line.
-    static constexpr bit::Mask kPhaseBit = bit::CreateMaskFromRange(7);
+    static constexpr auto kPhaseBit = bit::MaskFromRange(7);
+
     /// Bitmask for dividing the peripheral clock to set the SPI clock
     /// frequency.
-    static constexpr bit::Mask kDividerBit = bit::CreateMaskFromRange(8, 15);
+    static constexpr auto kDividerBit = bit::MaskFromRange(8, 15);
   };
   /// SSPn Control Register 1
   struct ControlRegister1  // NOLINT
   {
     /// Setting this bit to 1 will enable the peripheral for communication.
-    static constexpr bit::Mask kSpiEnable = bit::CreateMaskFromRange(1);
+    static constexpr auto kSpiEnable = bit::MaskFromRange(1);
+
     /// Setting this bit to 1 will enable spi slave mode.
-    static constexpr bit::Mask kSlaveModeBit = bit::CreateMaskFromRange(2);
+    static constexpr auto kSlaveModeBit = bit::MaskFromRange(2);
   };
   /// SSPn Status Register
   struct StatusRegister  // NOLINT
   {
     /// This bit is 0 if the SSPn controller is idle, or 1 if it is currently
     /// sending/receiving a frame and/or the Tx FIFO is not empty.
-    static constexpr bit::Mask kDataLineBusyBit = bit::CreateMaskFromRange(4);
+    static constexpr auto kDataLineBusyBit = bit::MaskFromRange(4);
   };
 
   /// SSP data size for frame packets
@@ -103,16 +108,21 @@ class Spi final : public sjsu::Spi
   {
     /// Pointer to the LPC SSP peripheral in memory
     LPC_SSP_TypeDef * registers;
+
     /// PeripheralID of the SSP peripheral to power on at initialization
     sjsu::SystemController::PeripheralID power_on_bit;
+
     /// Refernce to the M.ASTER-O.UT-S.LAVE-I.N (output from microcontroller)
     /// spi pin.
     const sjsu::Pin & mosi;
+
     /// Refernce to the M.ASTER-I.N-S.LAVE-O.UT (input to microcontroller) spi
     /// pin.
     const sjsu::Pin & miso;
+
     /// Refernce to serial clock spi pin.
     const sjsu::Pin & sck;
+
     /// Function code to set each pin to the appropriate SSP function.
     uint8_t pin_function;
   };
@@ -153,6 +163,7 @@ class Spi final : public sjsu::Spi
       .sck          = kSck0,
       .pin_function = 0b010,
     };
+
     /// Definition for SPI bus 1 for LPC40xx
     inline static const Bus_t kSpi1 = {
       .registers    = LPC_SSP1,
@@ -172,11 +183,13 @@ class Spi final : public sjsu::Spi
       .pin_function = 0b100,
     };
   };
+
   /// Constructor for LPC40xx Spi peripheral
   ///
   /// @param bus - pass a reference to a constant lpc40xx::Spi::Bus_t
   ///        definition.
   explicit constexpr Spi(const Bus_t & bus) : bus_(bus) {}
+
   /// This METHOD MUST BE EXECUTED before any other method can be called.
   /// Powers on the peripheral, activates the SSP pins and enables the SSP
   /// peripheral.

--- a/library/L1_Peripheral/lpc40xx/system_controller.hpp
+++ b/library/L1_Peripheral/lpc40xx/system_controller.hpp
@@ -159,40 +159,46 @@ class SystemController final : public sjsu::SystemController
     /// In PLLCON register: When 1, and after a valid PLL feed, this bit
     /// will activate the related PLL and allow it to lock to the requested
     /// frequency.
-    static constexpr bit::Mask kEnable = bit::CreateMaskFromRange(0);
+    static constexpr bit::Mask kEnable = bit::MaskFromRange(0);
+
     /// In PLLCFG register: PLL multiplier value, the amount to multiply the
     /// input frequency by.
-    static constexpr bit::Mask kMultiplier = bit::CreateMaskFromRange(0, 4);
+    static constexpr bit::Mask kMultiplier = bit::MaskFromRange(0, 4);
+
     /// In PLLCFG register: PLL divider value, the amount to divide the output
     /// of the multiplier stage to bring the frequency down to a
     /// reasonable/usable level.
-    static constexpr bit::Mask kDivider = bit::CreateMaskFromRange(5, 6);
+    static constexpr bit::Mask kDivider = bit::MaskFromRange(5, 6);
+
     /// In PLLSTAT register: if set to 1 by hardware, the PLL has accepted
     /// the configuration and is locked.
-    static constexpr bit::Mask kPllLockStatus = bit::CreateMaskFromRange(10);
+    static constexpr bit::Mask kPllLockStatus = bit::MaskFromRange(10);
   };
 
   /// Namespace of Oscillator register bitmasks
   struct OscillatorRegister  // NOLINT
   {
     /// IRC or Main oscillator select bit
-    static constexpr bit::Mask kSelect = bit::CreateMaskFromRange(0);
+    static constexpr bit::Mask kSelect = bit::MaskFromRange(0);
 
     /// SCS: Main oscillator range select
-    static constexpr bit::Mask kRangeSelect = bit::CreateMaskFromRange(4);
+    static constexpr bit::Mask kRangeSelect = bit::MaskFromRange(4);
+
     /// SCS: Main oscillator enable
-    static constexpr bit::Mask kExternalEnable = bit::CreateMaskFromRange(5);
+    static constexpr bit::Mask kExternalEnable = bit::MaskFromRange(5);
+
     /// SCS: Main oscillator ready status
-    static constexpr bit::Mask kExternalReady = bit::CreateMaskFromRange(6);
+    static constexpr bit::Mask kExternalReady = bit::MaskFromRange(6);
   };
 
   /// Namespace of Clock register bitmasks
   struct CpuClockRegister  // NOLINT
   {
     /// CPU clock divider amount
-    static constexpr bit::Mask kDivider = bit::CreateMaskFromRange(0, 4);
+    static constexpr bit::Mask kDivider = bit::MaskFromRange(0, 4);
+
     /// CPU clock source select bit
-    static constexpr bit::Mask kSelect = bit::CreateMaskFromRange(8);
+    static constexpr bit::Mask kSelect = bit::MaskFromRange(8);
   };
 
   /// Namespace of Peripheral register bitmasks
@@ -200,32 +206,34 @@ class SystemController final : public sjsu::SystemController
   {
     /// Main single peripheral clock divider shared across all peripherals,
     /// except for USB and SPIFI.
-    static constexpr bit::Mask kDivider = bit::CreateMaskFromRange(0, 4);
+    static constexpr bit::Mask kDivider = bit::MaskFromRange(0, 4);
   };
 
   /// Namespace of EMC register bitmasks
   struct EmcClockRegister  // NOLINT
   {
     /// EMC Clock Register divider bit
-    static constexpr bit::Mask kDivider = bit::CreateMaskFromRange(0);
+    static constexpr bit::Mask kDivider = bit::MaskFromRange(0);
   };
 
   /// Namespace of USB register bitmasks
   struct UsbClockRegister  // NOLINT
   {
     /// USB clock divider constant
-    static constexpr bit::Mask kDivider = bit::CreateMaskFromRange(0, 4);
+    static constexpr bit::Mask kDivider = bit::MaskFromRange(0, 4);
+
     /// USB clock source select bit
-    static constexpr bit::Mask kSelect = bit::CreateMaskFromRange(8, 9);
+    static constexpr bit::Mask kSelect = bit::MaskFromRange(8, 9);
   };
 
   /// Namespace of SPIFI register bitmasks
   struct SpiFiClockRegister  // NOLINT
   {
     /// SPIFI clock divider constant
-    static constexpr bit::Mask kDivider = bit::CreateMaskFromRange(0, 4);
+    static constexpr bit::Mask kDivider = bit::MaskFromRange(0, 4);
+
     /// SPIFI clock source select bit
-    static constexpr bit::Mask kSelect = bit::CreateMaskFromRange(8, 9);
+    static constexpr bit::Mask kSelect = bit::MaskFromRange(8, 9);
   };
 
   /// Clock configuration structure for use the lpc40xx microcontrollers
@@ -481,7 +489,7 @@ class SystemController final : public sjsu::SystemController
     // =========================================================================
     // Step 6. Configure flash cycles per load
     // =========================================================================
-    sys->PBOOST   = 0b00;
+    sys->PBOOST = 0b00;
 
     if (cpu_clock_rate_ < 20_MHz)
     {

--- a/library/L1_Peripheral/lpc40xx/timer.hpp
+++ b/library/L1_Peripheral/lpc40xx/timer.hpp
@@ -71,9 +71,10 @@ class Timer final : public sjsu::Timer
   {
    public:
     /// Enable bit
-    inline static constexpr bit::Mask kEnableBit = bit::CreateMaskFromRange(0);
+    inline static constexpr bit::Mask kEnableBit = bit::MaskFromRange(0);
+
     /// Reset bit
-    inline static constexpr bit::Mask kResetBit = bit::CreateMaskFromRange(1);
+    inline static constexpr bit::Mask kResetBit = bit::MaskFromRange(1);
   };
 
   /// Constructor of the LPC40xx Timer implementation

--- a/library/L1_Peripheral/msp432p401r/gpio.hpp
+++ b/library/L1_Peripheral/msp432p401r/gpio.hpp
@@ -20,8 +20,8 @@ class Gpio final : public sjsu::Gpio
 
   void SetDirection(Direction direction) const override
   {
-    constexpr auto kDirectionBit = bit::CreateMaskFromRange(2);
-    uint32_t function_code        = 0b00;
+    constexpr auto kDirectionBit = bit::MaskFromRange(2);
+    uint32_t function_code       = 0b00;
     function_code = bit::Insert(function_code, Value(direction), kDirectionBit);
     pin_.SetPinFunction(static_cast<uint8_t>(function_code));
   }

--- a/library/L1_Peripheral/msp432p401r/pin.hpp
+++ b/library/L1_Peripheral/msp432p401r/pin.hpp
@@ -76,9 +76,9 @@ class Pin final : public sjsu::Pin
           "The function code must be a 3-bit value between 0b000 and 0b111.");
     }
 
-    constexpr auto kDirectionBit = bit::CreateMaskFromRange(2);
-    constexpr auto kSel1Bit      = bit::CreateMaskFromRange(1);
-    constexpr auto kSel0Bit      = bit::CreateMaskFromRange(0);
+    constexpr auto kDirectionBit = bit::MaskFromRange(2);
+    constexpr auto kSel1Bit      = bit::MaskFromRange(1);
+    constexpr auto kSel0Bit      = bit::MaskFromRange(0);
 
     volatile uint8_t * select1_register = RegisterAddress(&Port()->SEL1);
     volatile uint8_t * select0_register = RegisterAddress(&Port()->SEL0);

--- a/library/L1_Peripheral/msp432p401r/system_controller.hpp
+++ b/library/L1_Peripheral/msp432p401r/system_controller.hpp
@@ -115,10 +115,13 @@ class SystemController final : public sjsu::SystemController
   {
     /// Clock rate for the very low power oscillator.
     static constexpr units::frequency::hertz_t kVeryLowFrequency = 9'400_Hz;
+
     /// Clock rate for the low power oscillator.
     static constexpr units::frequency::hertz_t kModule = 25_MHz;
+
     /// Internal system oscillator.
     static constexpr units::frequency::hertz_t kSystem = 5_MHz;
+
     /// Clock rates for the reference oscillator The reference oscillator is
     /// configuration to be either 32.768 kHz or 128 kHz.
     static constexpr std::array<units::frequency::hertz_t, 2> kReference = {
@@ -134,6 +137,7 @@ class SystemController final : public sjsu::SystemController
   {
     /// Clock rate for the on-board external low frequency oscillator.
     static constexpr units::frequency::hertz_t kLowFrequency = 32'768_Hz;
+
     /// Clock rate for the on-board external high frequency oscillator.
     static constexpr units::frequency::hertz_t kHighFrequency = 48_MHz;
   };
@@ -150,7 +154,7 @@ class SystemController final : public sjsu::SystemController
 
     /// The CSKEY bit mask used for locking or unlocking the clock system
     /// registers.
-    static constexpr bit::Mask kCsKey = bit::CreateMaskFromRange(0, 15);
+    static constexpr auto kCsKey = bit::MaskFromRange(0, 15);
   };
 
   /// Namespace containing the bit masks for the Control 0 Register (CTL0)
@@ -164,12 +168,13 @@ class SystemController final : public sjsu::SystemController
     }
 
     /// DCO tuning value bit mask.
-    static constexpr bit::Mask kTuningSelect = bit::CreateMaskFromRange(0, 9);
+    static constexpr auto kTuningSelect = bit::MaskFromRange(0, 9);
+
     /// DCO frequency seelect bit mask.
-    static constexpr bit::Mask kFrequencySelect =
-        bit::CreateMaskFromRange(16, 18);
+    static constexpr auto kFrequencySelect = bit::MaskFromRange(16, 18);
+
     /// DCO enable bit mask.
-    static constexpr bit::Mask kEnable = bit::CreateMaskFromRange(23);
+    static constexpr auto kEnable = bit::MaskFromRange(23);
   };
 
   /// Namespace containing the bit masks for the Control 1 Register (CTL1)
@@ -184,29 +189,34 @@ class SystemController final : public sjsu::SystemController
     }
 
     /// Master clock source select bit mask.
-    static constexpr bit::Mask kMasterClockSourceSelect =
-        bit::CreateMaskFromRange(0, 2);
+    static constexpr auto kMasterClockSourceSelect = bit::MaskFromRange(0, 2);
+
     /// Subsystem master clock source select bit mask.
-    static constexpr bit::Mask kSubsystemClockSourceSelect =
-        bit::CreateMaskFromRange(4, 6);
+    static constexpr auto kSubsystemClockSourceSelect =
+        bit::MaskFromRange(4, 6);
+
     /// Auxiliary clock source select bit mask.
-    static constexpr bit::Mask kAuxiliaryClockSourceSelect =
-        bit::CreateMaskFromRange(8, 10);
+    static constexpr auto kAuxiliaryClockSourceSelect =
+        bit::MaskFromRange(8, 10);
+
     /// Backup clock source select bit mask.
-    static constexpr bit::Mask kBackupClockSourceSelect =
-        bit::CreateMaskFromRange(12);
+    static constexpr auto kBackupClockSourceSelect = bit::MaskFromRange(12);
+
     /// Master clock divider select bit mask.
-    static constexpr bit::Mask kMasterClockDividerSelect =
-        bit::CreateMaskFromRange(16, 18);
+    static constexpr auto kMasterClockDividerSelect =
+        bit::MaskFromRange(16, 18);
+
     /// Subsystem master clock divider select bit mask.
-    static constexpr bit::Mask kSubsystemClockDividerSelect =
-        bit::CreateMaskFromRange(20, 22);
+    static constexpr auto kSubsystemClockDividerSelect =
+        bit::MaskFromRange(20, 22);
+
     /// Auxiliary clock divider select bit mask.
-    static constexpr bit::Mask kAuxiliaryClockDividerSelect =
-        bit::CreateMaskFromRange(24, 26);
+    static constexpr auto kAuxiliaryClockDividerSelect =
+        bit::MaskFromRange(24, 26);
+
     /// Low speed subsystem master clock divider select bit mask.
-    static constexpr bit::Mask kLowSpeedSubsystemClockDividerSelect =
-        bit::CreateMaskFromRange(28, 30);
+    static constexpr auto kLowSpeedSubsystemClockDividerSelect =
+        bit::MaskFromRange(28, 30);
   };
 
   /// Namespace containing the bit masks for the Clock Enable Register (CLKEN).
@@ -219,8 +229,7 @@ class SystemController final : public sjsu::SystemController
     }
 
     /// Reference clock frequency select bit mask.
-    static constexpr bit::Mask kReferenceFrequencySelect =
-        bit::CreateMaskFromRange(15);
+    static constexpr auto kReferenceFrequencySelect = bit::MaskFromRange(15);
   };
 
   /// @see Figure 6-1. Clock System Block Diagram
@@ -515,8 +524,8 @@ class SystemController final : public sjsu::SystemController
 
     constexpr uint8_t kClockReadyBit = 24;
     const uint8_t kOffset            = Value(clock);
-    const bit::Mask kReadyBitMask    = bit::CreateMaskFromRange(
-        static_cast<uint8_t>(kClockReadyBit + kOffset));
+    const bit::Mask kReadyBitMask =
+        bit::MaskFromRange(static_cast<uint8_t>(kClockReadyBit + kOffset));
 
     while (!bit::Read(clock_system->STAT, kReadyBitMask))
     {

--- a/library/L1_Peripheral/msp432p401r/test/pin_test.cpp
+++ b/library/L1_Peripheral/msp432p401r/test/pin_test.cpp
@@ -124,9 +124,9 @@ TEST_CASE("Testing Msp432p401r Pin", "[msp432p401r-pin_configure]")
   {
     SECTION("Valid function codes")
     {
-      constexpr auto kDirectionBit = bit::CreateMaskFromRange(2);
-      constexpr auto kSel1Bit      = bit::CreateMaskFromRange(1);
-      constexpr auto kSel0Bit      = bit::CreateMaskFromRange(0);
+      constexpr auto kDirectionBit = bit::MaskFromRange(2);
+      constexpr auto kSel1Bit      = bit::MaskFromRange(1);
+      constexpr auto kSel0Bit      = bit::MaskFromRange(0);
 
       for (size_t i = 0; i < test_pins.size(); i++)
       {

--- a/library/L1_Peripheral/stm32f10x/pin.hpp
+++ b/library/L1_Peripheral/stm32f10x/pin.hpp
@@ -39,8 +39,8 @@ class Pin final : public sjsu::Pin
     system.PowerUpPeripheral(stm32f10x::SystemController::Peripherals::kAFIO);
 
     // Set the JTAG Release
-    afio->MAPR = sjsu::bit::Insert(afio->MAPR, 0b010,
-                                   sjsu::bit::CreateMaskFromRange(24, 26));
+    afio->MAPR =
+        sjsu::bit::Insert(afio->MAPR, 0b010, sjsu::bit::MaskFromRange(24, 26));
   }
 
   /// @param port - must be a capitol letter from 'A' to 'I'
@@ -104,8 +104,8 @@ class Pin final : public sjsu::Pin
   ///        alternative mode.
   Returns<void> SetPinFunction(uint8_t alternative_function) const override
   {
-    static constexpr auto kMode = bit::CreateMaskFromRange(0, 1);
-    static constexpr auto kCFN1 = bit::CreateMaskFromRange(3);
+    static constexpr auto kMode = bit::MaskFromRange(0, 1);
+    static constexpr auto kCFN1 = bit::MaskFromRange(3);
 
     SJ2_RETURN_ON_ERROR(Initialize());
 
@@ -148,7 +148,7 @@ class Pin final : public sjsu::Pin
   /// This function MUST NOT be called for pins set as inputs.
   Returns<void> SetAsOpenDrain(bool set_as_open_drain = true) const override
   {
-    static constexpr auto kCFN0 = bit::CreateMaskFromRange(2);
+    static constexpr auto kCFN0 = bit::MaskFromRange(2);
 
     uint32_t config = GetConfig();
 

--- a/library/L1_Peripheral/stm32f10x/system_controller.hpp
+++ b/library/L1_Peripheral/stm32f10x/system_controller.hpp
@@ -160,41 +160,51 @@ class SystemController : public sjsu::SystemController
   struct ClockConfigurationRegisters  // NOLINT
   {
     /// Controls which clock signal is sent to the MCO pin
-    static constexpr auto kMco = bit::CreateMaskFromRange(24, 26);
+    static constexpr auto kMco = bit::MaskFromRange(24, 26);
+
     /// Sets the USB clock divider
-    static constexpr auto kUsbPrescalar = bit::CreateMaskFromRange(22);
+    static constexpr auto kUsbPrescalar = bit::MaskFromRange(22);
+
     /// Sets the PLL multiplier
-    static constexpr auto kPllMul = bit::CreateMaskFromRange(18, 21);
+    static constexpr auto kPllMul = bit::MaskFromRange(18, 21);
+
     /// If set to 1, will divide the HSE signal by 2 before sending to PLL
-    static constexpr auto kHsePreDivider = bit::CreateMaskFromRange(17);
+    static constexpr auto kHsePreDivider = bit::MaskFromRange(17);
+
     /// Sets which source the PLL will take as input
-    static constexpr auto kPllSource = bit::CreateMaskFromRange(16);
+    static constexpr auto kPllSource = bit::MaskFromRange(16);
+
     /// Sets the clock divider for the ADC peripherals
-    static constexpr auto kAdcDivider = bit::CreateMaskFromRange(14, 15);
+    static constexpr auto kAdcDivider = bit::MaskFromRange(14, 15);
+
     /// Sets the divider for peripherals on the APB2 bus
-    static constexpr auto kAPB2Divider = bit::CreateMaskFromRange(11, 13);
+    static constexpr auto kAPB2Divider = bit::MaskFromRange(11, 13);
+
     /// Sets the divider for peripherals on the APB1 bus
-    static constexpr auto kAPB1Divider = bit::CreateMaskFromRange(8, 10);
+    static constexpr auto kAPB1Divider = bit::MaskFromRange(8, 10);
+
     /// Sets the divider for peripherals on the AHB bus
-    static constexpr auto kAHBDivider = bit::CreateMaskFromRange(4, 7);
+    static constexpr auto kAHBDivider = bit::MaskFromRange(4, 7);
+
     /// Used to check if the system clock has taken the new system clock
     /// settings.
-    static constexpr auto kSystemClockStatus = bit::CreateMaskFromRange(2, 3);
-    /// Set which clock will be used for the system clock .
-    static constexpr auto kSystemClockSelect = bit::CreateMaskFromRange(0, 1);
+    static constexpr auto kSystemClockStatus = bit::MaskFromRange(2, 3);
+
+    /// Set which clock will be used for the system clock.
+    static constexpr auto kSystemClockSelect = bit::MaskFromRange(0, 1);
   };
 
   /// Bit masks for the CR register
   struct ClockControlRegisters  // NOLINT
   {
     /// Indicates if the PLL is enabled and ready
-    static constexpr auto kPllReady = bit::CreateMaskFromRange(25);
+    static constexpr auto kPllReady = bit::MaskFromRange(25);
     /// Used to enable the PLL
-    static constexpr auto kPllEnable = bit::CreateMaskFromRange(24);
+    static constexpr auto kPllEnable = bit::MaskFromRange(24);
     /// Indicates if the external oscillator is ready for use
-    static constexpr auto kExternalOscReady = bit::CreateMaskFromRange(17);
+    static constexpr auto kExternalOscReady = bit::MaskFromRange(17);
     /// Used to enable the external oscillator
-    static constexpr auto kExternalOscEnable = bit::CreateMaskFromRange(16);
+    static constexpr auto kExternalOscEnable = bit::MaskFromRange(16);
   };
 
   /// PLL frequency multiplication options.
@@ -221,15 +231,15 @@ class SystemController : public sjsu::SystemController
   struct RtcRegisters  // NOLINT
   {
     /// Will reset all clock states for the RTC
-    static constexpr auto kBackupDomainReset = bit::CreateMaskFromRange(16);
+    static constexpr auto kBackupDomainReset = bit::MaskFromRange(16);
     /// Enables the RTC clock
-    static constexpr auto kRtcEnable = bit::CreateMaskFromRange(15);
+    static constexpr auto kRtcEnable = bit::MaskFromRange(15);
     /// Selects the clock source for the RTC
-    static constexpr auto kRtcSourceSelect = bit::CreateMaskFromRange(8, 9);
+    static constexpr auto kRtcSourceSelect = bit::MaskFromRange(8, 9);
     /// Indicates if the LSE is ready for use
-    static constexpr auto kLowSpeedOscReady = bit::CreateMaskFromRange(1);
+    static constexpr auto kLowSpeedOscReady = bit::MaskFromRange(1);
     /// Used to enable the LSE
-    static constexpr auto kLowSpeedOscEnable = bit::CreateMaskFromRange(0);
+    static constexpr auto kLowSpeedOscEnable = bit::MaskFromRange(0);
   };
 
   /// Available clock sources for the RTC
@@ -490,19 +500,19 @@ class SystemController : public sjsu::SystemController
       {
         // 0 Wait states
         flash->ACR = sjsu::bit::Insert(flash->ACR, 0b000,
-                                       sjsu::bit::CreateMaskFromRange(0, 2));
+                                       sjsu::bit::MaskFromRange(0, 2));
       }
       else if (24_MHz <= pll_clock_rate_ && pll_clock_rate_ <= 48_MHz)
       {
         // 1 Wait state
         flash->ACR = sjsu::bit::Insert(flash->ACR, 0b001,
-                                       sjsu::bit::CreateMaskFromRange(0, 2));
+                                       sjsu::bit::MaskFromRange(0, 2));
       }
       else
       {
         // 2 Wait states
         flash->ACR = sjsu::bit::Insert(flash->ACR, 0b010,
-                                       sjsu::bit::CreateMaskFromRange(0, 2));
+                                       sjsu::bit::MaskFromRange(0, 2));
       }
     }
 

--- a/library/L1_Peripheral/stm32f10x/test/pin_test.cpp
+++ b/library/L1_Peripheral/stm32f10x/test/pin_test.cpp
@@ -406,7 +406,7 @@ TEST_CASE("Testing stm32f10x Pin", "[stm32f10x-pin]")
 
     // Set the JTAG Release
     CHECK(0b010 == sjsu::bit::Extract(local_afio.MAPR,
-                                      sjsu::bit::CreateMaskFromRange(24, 26)));
+                                      sjsu::bit::MaskFromRange(24, 26)));
   }
 
   Pin::gpio[0] = GPIOA;

--- a/library/L1_Peripheral/stm32f10x/test/system_controller_test.cpp
+++ b/library/L1_Peripheral/stm32f10x/test/system_controller_test.cpp
@@ -317,7 +317,7 @@ TEST_CASE("Testing stm32f10x SystemController", "[stm32f10x-systemcontroller]")
 
       // Verify
       CHECK(flash_code == bit::Extract(local_flash.ACR,
-                                       sjsu::bit::CreateMaskFromRange(0, 2)));
+                                       sjsu::bit::MaskFromRange(0, 2)));
     }
 
     SECTION("Changing dividers")

--- a/library/L1_Peripheral/stm32f10x/uart.hpp
+++ b/library/L1_Peripheral/stm32f10x/uart.hpp
@@ -96,7 +96,7 @@ class UartBase : public sjsu::Uart
   {
     /// Indicates if the transmit data register is empty and can be loaded with
     /// another byte.
-    static constexpr auto kTransitEmpty = bit::CreateMaskFromRange(7);
+    static constexpr auto kTransitEmpty = bit::MaskFromRange(7);
   };
 
   /// Namespace for the control registers (CR1, CR3) bit masks and predefined
@@ -106,16 +106,16 @@ class UartBase : public sjsu::Uart
     /// When this bit is cleared the USART prescalers and outputs are stopped
     /// and the end of the current byte transfer in order to reduce power
     /// consumption. (CR1)
-    static constexpr auto kUsartEnable = bit::CreateMaskFromRange(13);
+    static constexpr auto kUsartEnable = bit::MaskFromRange(13);
 
     /// Enables DMA receiver (CR3)
-    static constexpr auto kDmaReceiverEnable = bit::CreateMaskFromRange(6);
+    static constexpr auto kDmaReceiverEnable = bit::MaskFromRange(6);
 
     /// This bit enables the transmitter. (CR1)
-    static constexpr auto kTransmitterEnable = bit::CreateMaskFromRange(3);
+    static constexpr auto kTransmitterEnable = bit::MaskFromRange(3);
 
     /// This bit enables the receiver. (CR1)
-    static constexpr auto kReceiveEnable = bit::CreateMaskFromRange(2);
+    static constexpr auto kReceiveEnable = bit::MaskFromRange(2);
 
     /// Enable USART + Enable Receive + Enable Transmitter
     static constexpr uint16_t kControlSettings1 =
@@ -133,10 +133,10 @@ class UartBase : public sjsu::Uart
   struct BaudRateReg  // NOLINT
   {
     /// Mantissa of USART DIV
-    static constexpr auto kMantissa = bit::CreateMaskFromRange(4, 15);
+    static constexpr auto kMantissa = bit::MaskFromRange(4, 15);
 
     /// Fraction of USART DIV
-    static constexpr auto kFraction = bit::CreateMaskFromRange(0, 3);
+    static constexpr auto kFraction = bit::MaskFromRange(0, 3);
   };
 
   /// Namespace for the control registers (DMA->CCR) bit masks and predefined
@@ -144,78 +144,74 @@ class UartBase : public sjsu::Uart
   struct DmaReg  // NOLINT
   {
     /// Declare this channel for Memory to memory mode
-    static constexpr auto kMemoryToMemory = bit::CreateMaskFromRange(14);
+    static constexpr auto kMemoryToMemory = bit::MaskFromRange(14);
 
     /// Configure the channel priority for this channel.
     /// 0b00: Low
     /// 0b01: Medium
     /// 0b10: High
     /// 0b11: Very high
-    static constexpr auto kChannelPriority = bit::CreateMaskFromRange(12, 13);
+    static constexpr auto kChannelPriority = bit::MaskFromRange(12, 13);
 
     /// The size of each element of the memory.
     /// 0b00: 8-bits
     /// 0b01: 16-bits
     /// 0b10: 32-bits
     /// 0b11: Reserved
-    static constexpr auto kMemorySize = bit::CreateMaskFromRange(10, 11);
+    static constexpr auto kMemorySize = bit::MaskFromRange(10, 11);
 
     /// The peripheral register size.
     /// 0b00: 8-bits
     /// 0b01: 16-bits
     /// 0b10: 32-bits
     /// 0b11: Reserved
-    static constexpr auto kPeripheralSize = bit::CreateMaskFromRange(8, 9);
+    static constexpr auto kPeripheralSize = bit::MaskFromRange(8, 9);
 
     /// Activate memory increment mode, which will increment the memory address
     /// with each transfer
-    static constexpr auto kMemoryIncrementEnable = bit::CreateMaskFromRange(7);
+    static constexpr auto kMemoryIncrementEnable = bit::MaskFromRange(7);
 
     /// Activate memory increment mode, which will increment the peripheral
     /// address with each transfer
-    static constexpr auto kPeripheralIncrementEnable =
-        bit::CreateMaskFromRange(6);
+    static constexpr auto kPeripheralIncrementEnable = bit::MaskFromRange(6);
 
     /// DMA will continuous load bytes into the buffer supplied in a circular
     /// buffer manner.
-    static constexpr auto kCircularMode = bit::CreateMaskFromRange(5);
+    static constexpr auto kCircularMode = bit::MaskFromRange(5);
 
     /// Data transfer direction
     /// 0: Read from peripheral
     /// 1: Read from memory
-    static constexpr auto kDataTransferDirection = bit::CreateMaskFromRange(4);
+    static constexpr auto kDataTransferDirection = bit::MaskFromRange(4);
 
     /// Enable interrupt on transfer error
-    static constexpr auto kTransferErrorInterruptEnable =
-        bit::CreateMaskFromRange(3);
+    static constexpr auto kTransferErrorInterruptEnable = bit::MaskFromRange(3);
 
     /// Enable interrupt on half of data transferred
-    static constexpr auto kHalfTransferInterruptEnable =
-        bit::CreateMaskFromRange(2);
+    static constexpr auto kHalfTransferInterruptEnable = bit::MaskFromRange(2);
 
     /// Enable interrupt on complete transfer
     static constexpr auto kTransferCompleteInterruptEnable =
-        bit::CreateMaskFromRange(1);
+        bit::MaskFromRange(1);
 
     /// Enable this DMA channel
-    static constexpr auto kEnable = bit::CreateMaskFromRange(0);
+    static constexpr auto kEnable = bit::MaskFromRange(0);
 
     /// Setup the DMA channel with all of the options specific to handling UART
     static constexpr uint32_t kDmaSettings =
         bit::Value{}
-            .Clear(DmaReg::kTransferCompleteInterruptEnable)
-            .Clear(DmaReg::kHalfTransferInterruptEnable)
-            .Clear(DmaReg::kTransferErrorInterruptEnable)
-            .Clear(DmaReg::kDataTransferDirection)  // Read from peripheral
-            .Set(DmaReg::kCircularMode)
-            .Clear(DmaReg::kPeripheralIncrementEnable)
-            .Set(DmaReg::kMemoryIncrementEnable)
-            .Insert(0b00, DmaReg::kPeripheralSize)  // size = 8 bits
-            .Insert(0b00, DmaReg::kMemorySize)      // size = 8 bits
-            .Insert(0b10,
-                    DmaReg::kChannelPriority)  // Low Medium [High] Very_High
-            .Clear(DmaReg::kMemoryToMemory)
-            .Set(DmaReg::kEnable);
+            .Clear(kTransferCompleteInterruptEnable)
+            .Clear(kHalfTransferInterruptEnable)
+            .Clear(kTransferErrorInterruptEnable)
+            .Clear(kDataTransferDirection)  // Read from peripheral
+            .Set(kCircularMode)
+            .Clear(kPeripheralIncrementEnable)
+            .Set(kMemoryIncrementEnable)
+            .Insert(0b00, kPeripheralSize)   // size = 8 bits
+            .Insert(0b00, kMemorySize)       // size = 8 bits
+            .Insert(0b10, kChannelPriority)  // Low Medium [High] Very_High
+            .Clear(kMemoryToMemory)
+            .Set(kEnable);
   };
 
   /// @tparam size - size of the array

--- a/library/L2_HAL/memory/sd.hpp
+++ b/library/L2_HAL/memory/sd.hpp
@@ -174,9 +174,9 @@ class Sd : public Storage
   };
 
   /// R1 Response error flag "Illegal Command" bit position
-  static constexpr bit::Mask kIllegalCommand = bit::CreateMaskFromRange(2);
+  static constexpr bit::Mask kIllegalCommand = bit::MaskFromRange(2);
   /// R1 Response error flag "In Idle Mode" bit position
-  static constexpr bit::Mask kIdle = bit::CreateMaskFromRange(0);
+  static constexpr bit::Mask kIdle = bit::MaskFromRange(0);
 
   /// @param spi         - spi peripheral connected to an SD card.
   /// @param chip_select - gpio connected to the chip select pin of the SD card.
@@ -263,7 +263,7 @@ class Sd : public Storage
   units::data::byte_t GetCapacity() override
   {
     // The c_size register's contents can be found in bits [48:69]
-    constexpr bit::Mask kCSizeMask = bit::CreateMaskFromRange(48, 69);
+    constexpr bit::Mask kCSizeMask = bit::MaskFromRange(48, 69);
     uint32_t c_size =
         bit::StreamExtract<uint32_t>(sd_.csd.byte, kCSizeMask, Endian::kLittle);
     LogDebug("c_size = 0x%08X", c_size);
@@ -632,7 +632,7 @@ class Sd : public Storage
     // Bit 1 -->  If set, CC error occurred
     // Bit 0 -->  If set, a generic error occurred
 
-    constexpr bit::Mask kErrorIndicator = bit::CreateMaskFromRange(4, 7);
+    constexpr bit::Mask kErrorIndicator = bit::MaskFromRange(4, 7);
 
     for (uint32_t i = 0; i < kRetryLimit * 100; i++)
     {
@@ -773,7 +773,7 @@ class Sd : public Storage
 
     // If the most significant bit of the response byte is a zero, then this
     // indicates that the start of a response sequence.
-    constexpr bit::Mask kResponseFlag = bit::CreateMaskFromRange(7);
+    constexpr bit::Mask kResponseFlag = bit::MaskFromRange(7);
 
     for (uint32_t tries = 0; tries < kRetryLimit; tries++)
     {
@@ -902,7 +902,7 @@ class Sd : public Storage
   Returns<void> CheckSupportedVoltages()
   {
     LogDebug("Checking Current SD Card Voltage Level...");
-    constexpr bit::Mask kVoltageCodeMask = bit::CreateMaskFromRange(8, 11) >> 8;
+    constexpr bit::Mask kVoltageCodeMask = bit::MaskFromRange(8, 11) >> 8;
     constexpr uint8_t kCheckPattern      = 0xAB;
     uint8_t voltage_code                 = 0x01;
     uint32_t voltage_pattern             = (voltage_code << 8) | kCheckPattern;

--- a/library/utility/bit.hpp
+++ b/library/utility/bit.hpp
@@ -67,7 +67,7 @@ struct Mask  // NOLINT
 /// @return constexpr Mask from the low bit position to the high bit position.
 ///         If the low_bit_position > high_bit_position, the result is
 ///         undefined.
-constexpr Mask CreateMaskFromRange(uint32_t low_bit_position,
+constexpr Mask MaskFromRange(uint32_t low_bit_position,
                                    uint32_t high_bit_position)
 {
   return Mask({
@@ -78,7 +78,7 @@ constexpr Mask CreateMaskFromRange(uint32_t low_bit_position,
 
 /// @param bit_position - bit field composed of a single bit with bit width 1.
 /// @return a bit mask with of width 1 and position = bit_position.
-constexpr Mask CreateMaskFromRange(uint32_t bit_position)
+constexpr Mask MaskFromRange(uint32_t bit_position)
 {
   return Mask({
       .position = bit_position,

--- a/library/utility/test/bit_test.cpp
+++ b/library/utility/test/bit_test.cpp
@@ -7,51 +7,51 @@ namespace sjsu
 {
 TEST_CASE("Testing Bit Manipulations", "[bit manipulation]")
 {
-  SECTION("CreateMaskFromRange()")
+  SECTION("MaskFromRange()")
   {
     SECTION("(start, end)")
     {
       CHECK(bit::Mask{ .position = 5, .width = 16 - 4 } ==
-            bit::CreateMaskFromRange(5, 16));
+            bit::MaskFromRange(5, 16));
       static_assert(bit::Mask{ .position = 5, .width = 16 - 4 } ==
-                    bit::CreateMaskFromRange(5, 16));
+                    bit::MaskFromRange(5, 16));
 
       CHECK(bit::Mask{ .position = 16, .width = 47 - 15 } ==
-            bit::CreateMaskFromRange(16, 47));
+            bit::MaskFromRange(16, 47));
       static_assert(bit::Mask{ .position = 16, .width = 47 - 15 } ==
-                    bit::CreateMaskFromRange(16, 47));
+                    bit::MaskFromRange(16, 47));
 
       CHECK(bit::Mask{ .position = 1, .width = 61 } ==
-            bit::CreateMaskFromRange(1, 61));
+            bit::MaskFromRange(1, 61));
       static_assert(bit::Mask{ .position = 1, .width = 61 } ==
-                    bit::CreateMaskFromRange(1, 61));
+                    bit::MaskFromRange(1, 61));
 
       CHECK(bit::Mask{ .position = 55, .width = 89 - 54 } ==
-            bit::CreateMaskFromRange(55, 89));
+            bit::MaskFromRange(55, 89));
       static_assert(bit::Mask{ .position = 55, .width = 89 - 54 } ==
-                    bit::CreateMaskFromRange(55, 89));
+                    bit::MaskFromRange(55, 89));
     }
     SECTION("Single Bit")
     {
       CHECK(bit::Mask{ .position = 5, .width = 1 } ==
-            bit::CreateMaskFromRange(5));
+            bit::MaskFromRange(5));
       static_assert(bit::Mask{ .position = 5, .width = 1 } ==
-                    bit::CreateMaskFromRange(5));
+                    bit::MaskFromRange(5));
 
       CHECK(bit::Mask{ .position = 47, .width = 1 } ==
-            bit::CreateMaskFromRange(47));
+            bit::MaskFromRange(47));
       static_assert(bit::Mask{ .position = 47, .width = 1 } ==
-                    bit::CreateMaskFromRange(47));
+                    bit::MaskFromRange(47));
 
       CHECK(bit::Mask{ .position = 61, .width = 1 } ==
-            bit::CreateMaskFromRange(61));
+            bit::MaskFromRange(61));
       static_assert(bit::Mask{ .position = 61, .width = 1 } ==
-                    bit::CreateMaskFromRange(61));
+                    bit::MaskFromRange(61));
 
       CHECK(bit::Mask{ .position = 7, .width = 1 } ==
-            bit::CreateMaskFromRange(7));
+            bit::MaskFromRange(7));
       static_assert(bit::Mask{ .position = 7, .width = 1 } ==
-                    bit::CreateMaskFromRange(7));
+                    bit::MaskFromRange(7));
     }
   }
 
@@ -376,7 +376,7 @@ TEST_CASE("Testing Bit Manipulations", "[bit manipulation]")
       SECTION("8 bit value in a single byte stream")
       {
         std::array<uint8_t, 1> test = { 0b0011'1100 };
-        bit::Mask mask              = bit::CreateMaskFromRange(2, 5);
+        bit::Mask mask              = bit::MaskFromRange(2, 5);
         CHECK(0b1111 == bit::StreamExtract<uint8_t>(test, mask));
       }
 
@@ -401,7 +401,7 @@ TEST_CASE("Testing Bit Manipulations", "[bit manipulation]")
         };
 
         // Bits in SD card driver are [48:69]
-        constexpr bit::Mask kCSizeMask = bit::CreateMaskFromRange(48, 69);
+        constexpr bit::Mask kCSizeMask = bit::MaskFromRange(48, 69);
         // C_SIZE should equal 15159 & 0x3b37
         constexpr uint32_t kCSizeBytes = kCSD[7] << 16 | kCSD[8] << 8 | kCSD[9];
         constexpr uint32_t kExpected =
@@ -455,7 +455,7 @@ TEST_CASE("Testing Bit Manipulations", "[bit manipulation]")
       SECTION("8 bit value in a single byte stream")
       {
         std::array<uint8_t, 1> test = { 0b0011'1100 };
-        bit::Mask mask              = bit::CreateMaskFromRange(2, 5);
+        bit::Mask mask              = bit::MaskFromRange(2, 5);
         CHECK(0b1111 == bit::StreamExtract<uint8_t>(test, mask, Endian::kBig));
       }
 


### PR DESCRIPTION
Rename function from bit::CreateMaskFromRange() to
bit::MaskFromRange() to reduce verbosity.